### PR TITLE
Move title tag to App

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import App, {Container} from 'next/app'
+import Head from 'next/head'
 import getConfig from 'next/config'
 import {Layout} from 'mdx-docs'
 import Octicon, {iconsByName, Pencil} from '@githubprimer/octicons-react'
@@ -53,6 +54,9 @@ export default class MyApp extends App {
     return (
       <BaseStyles>
         <Container>
+          <Head>
+            <title>Primer Components</title>
+          </Head>
           <Layout components={components} routes={[]} theme={customTheme}>
             <Header />
             <Flex display={['block', 'block', 'flex', 'flex']} flexDirection="row-reverse">

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -32,7 +32,6 @@ export default class MyDocument extends Document {
         <Head>
           <script async src="https://www.googletagmanager.com/gtag/js?id=UA-126681523-1" />
           <script async href={getAssetPath('analytics.js')} />
-          <title>Primer Components</title>
           <meta charSet="utf8" />
           <link rel="icon" href={getAssetPath('favicon.png')} />
           <link rel="apple-touch-icon" href={getAssetPath('apple-touch-icon.png')} />


### PR DESCRIPTION
closes https://github.com/primer/components/issues/351

- [x] Moved the title from `pages/_document.js` to `pages/_app.js`
