### PR TITLE
Combine Themes in Docs

### DIFF
--- a/pages/_app.js
+++ b/pages/_app.js
@@ -9,9 +9,10 @@ import * as primerComponents from '..'
 import {repository} from '../package.json'
 
 const {pageMap} = getConfig().publicRuntimeConfig
-const {BaseStyles, Box, Flex, Link, Text} = primerComponents
+const {BaseStyles, Box, Flex, Link, Text, theme} = primerComponents
 const {SideNav, Header, IndexHero, customTheme} = docComponents
 
+const docsTheme = Object.assign({}, customTheme, theme)
 const iconComponents = Object.keys(iconsByName).reduce((map, key) => {
   map[iconsByName[key].name] = iconsByName[key]
   return map

--- a/pages/doc-components/theme.js
+++ b/pages/doc-components/theme.js
@@ -1,7 +1,6 @@
 import {theme} from '../..'
 
 export default {
-  font: theme.fonts.normal,
   LiveEditor: {
     whiteSpace: 'pre-wrap',
     backgroundColor: theme.colors.gray[1],


### PR DESCRIPTION
This PR combines the custom theme created to tweak some mdx-docs styles, and our regular theme. This is necessary because the `Layout` component was overriding the `theme` prop passed to every child component, so our attempts to set `defaultProps = {theme}` in `withSystemComponent` were failing, because `theme` was already set in the props. Because of that, instances of `themeGet` were always hitting the fallback.

In the future, I'd be open to removing `mdx-docs` entirely. We aren't using a ton of it's features and I'd like our docs to be a clean example of how to set up an application using primer/components - right now that seems a bit messy because of the extra work we need to do in `_app.js` to get our set up playing nicely with `mdx-docs`. Removing `mdx-docs` would mean we'd need to put something custom in place for our LiveEditors & we'd need to rename all of our `.md` files to `.mdx` (.mdx support is already working in our docs so no need to set anything up beyond changing the file types 🙌 )


#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
