### PR TITLE
Move styled-components to deps instead of dev-deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "primer-typography": "1.0.1",
     "react": "16.4.2",
     "react-dom": "16.4.2",
+    "styled-components": "4.1.2",
     "styled-system": "3.1.3",
     "system-components": "3.0.1"
   },
@@ -87,6 +88,5 @@
     "rollup-plugin-babel": "4.0.0-beta.8",
     "rollup-plugin-commonjs": "9.1.3",
     "sass.macro": "0.1.0",
-    "styled-components": "4.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "8.0.1-beta",
+  "version": "8.2.0-beta",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "8.0.0-beta",
+  "version": "8.0.1-beta",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
@@ -87,6 +87,6 @@
     "rollup": "0.62.0",
     "rollup-plugin-babel": "4.0.0-beta.8",
     "rollup-plugin-commonjs": "9.1.3",
-    "sass.macro": "0.1.0",
+    "sass.macro": "0.1.0"
   }
 }

--- a/src/Box.js
+++ b/src/Box.js
@@ -1,9 +1,9 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import {LAYOUT, COMMON} from './constants'
+import {LAYOUT, COMMON, Base} from './constants'
 import theme from './theme'
 
-const Box = styled.div`
+const Box = styled(Base)`
   ${LAYOUT} ${COMMON};
 `
 

--- a/src/CircleOcticon.js
+++ b/src/CircleOcticon.js
@@ -6,10 +6,10 @@ import theme from './theme'
 import BorderBox from './BorderBox'
 
 function CircleOcticon(props) {
-  const {size} = props
+  const {size, is} = props
   const {icon, bg, ...rest} = props
   return (
-    <BorderBox bg={bg} overflow="hidden" border="none" size={size} borderRadius="50%">
+    <BorderBox is={is} bg={bg} overflow="hidden" border="none" size={size} borderRadius="50%">
       <Flex {...rest} alignItems="center" justifyContent="center">
         <Octicon icon={icon} size={size} />
       </Flex>

--- a/src/Flash.js
+++ b/src/Flash.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import {COMMON, get} from './constants'
+import {COMMON, get, Base} from './constants'
 import theme from './theme'
 
 const schemeMap = {
@@ -10,7 +10,7 @@ const schemeMap = {
   base: {color: 'colors.blue.8', bg: 'colors.blue.1'}
 }
 
-const Flash = styled.div`
+const Flash = styled(Base)`
   position: relative;
   padding: ${get('space.3')}px;
   color: ${props => get(schemeMap[props.scheme] ? schemeMap[props.scheme].color : '')};

--- a/src/PointerBox.js
+++ b/src/PointerBox.js
@@ -7,11 +7,11 @@ import {Relative} from './Position'
 
 function PointerBox(props) {
   // don't destructure these, just grab them
-  const {bg, border, borderColor} = props
+  const {bg, border, borderColor, is} = props
   const {caret, children, ...boxProps} = props
   const caretProps = {bg, borderColor, borderWidth: border, location: caret}
   return (
-    <Relative>
+    <Relative is={is}>
       <BorderBox {...boxProps}>
         {children}
         <Caret {...caretProps} />

--- a/src/__tests__/BorderBox.js
+++ b/src/__tests__/BorderBox.js
@@ -14,6 +14,11 @@ describe('BorderBox', () => {
     expect(BorderBox).toSetDefaultTheme()
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<BorderBox is="span" />).type).toEqual('span')
+  })
+
+
   it('renders borders', () => {
     expect(render(<BorderBox borderColor="green.5" />)).toHaveStyleRule('border-color', colors.green[5])
     expect(render(<BorderBox borderBottom={0} />)).toHaveStyleRule('border-bottom', '0')

--- a/src/__tests__/BorderBox.js
+++ b/src/__tests__/BorderBox.js
@@ -18,7 +18,6 @@ describe('BorderBox', () => {
     expect(render(<BorderBox is="span" />).type).toEqual('span')
   })
 
-
   it('renders borders', () => {
     expect(render(<BorderBox borderColor="green.5" />)).toHaveStyleRule('border-color', colors.green[5])
     expect(render(<BorderBox borderBottom={0} />)).toHaveStyleRule('border-bottom', '0')

--- a/src/__tests__/Box.js
+++ b/src/__tests__/Box.js
@@ -10,6 +10,10 @@ describe('Box', () => {
     expect(Box).toImplementSystemProps(COMMON)
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<Box is="span" />).type).toEqual('span')
+  })
+
   it('renders without any props', () => {
     expect(render(<Box />)).toMatchSnapshot()
   })

--- a/src/__tests__/CircleOcticon.js
+++ b/src/__tests__/CircleOcticon.js
@@ -32,5 +32,4 @@ describe('CircleOcticon', () => {
   it('respects the "is" prop', () => {
     expect(render(<CircleOcticon icon={Check} is="span" />).type).toEqual('span')
   })
-
 })

--- a/src/__tests__/CircleOcticon.js
+++ b/src/__tests__/CircleOcticon.js
@@ -28,4 +28,9 @@ describe('CircleOcticon', () => {
     expect(result).toHaveStyleRule('width', '32px')
     expect(result).toHaveStyleRule('height', '32px')
   })
+
+  it('respects the "is" prop', () => {
+    expect(render(<CircleOcticon icon={Check} is="span" />).type).toEqual('span')
+  })
+
 })

--- a/src/__tests__/CounterLabel.js
+++ b/src/__tests__/CounterLabel.js
@@ -29,4 +29,9 @@ describe('CounterLabel', () => {
   it('implements system props', () => {
     expect(CounterLabel).toImplementSystemProps(COMMON)
   })
+
+  it('respects the "is" prop', () => {
+    expect(render(<CounterLabel is="span" />).type).toEqual('span')
+  })
+
 })

--- a/src/__tests__/CounterLabel.js
+++ b/src/__tests__/CounterLabel.js
@@ -33,5 +33,4 @@ describe('CounterLabel', () => {
   it('respects the "is" prop', () => {
     expect(render(<CounterLabel is="span" />).type).toEqual('span')
   })
-
 })

--- a/src/__tests__/Flash.js
+++ b/src/__tests__/Flash.js
@@ -23,7 +23,6 @@ describe('Flash', () => {
     expect(render(<Flash is="span" />).type).toEqual('span')
   })
 
-
   it('respects the "scheme" prop', () => {
     expect(render(<Flash scheme="yellow" theme={theme} />)).toHaveStyleRule('color', colors.yellow[9])
     expect(render(<Flash scheme="red" theme={theme} />)).toHaveStyleRule('color', colors.red[9])

--- a/src/__tests__/Flash.js
+++ b/src/__tests__/Flash.js
@@ -19,6 +19,11 @@ describe('Flash', () => {
     expect(render(<Flash full />)).toHaveStyleRule('border-width', '1px 0px')
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<Flash is="span" />).type).toEqual('span')
+  })
+
+
   it('respects the "scheme" prop', () => {
     expect(render(<Flash scheme="yellow" theme={theme} />)).toHaveStyleRule('color', colors.yellow[9])
     expect(render(<Flash scheme="red" theme={theme} />)).toHaveStyleRule('color', colors.red[9])

--- a/src/__tests__/Label.js
+++ b/src/__tests__/Label.js
@@ -13,6 +13,10 @@ describe('Label', () => {
     expect(render(<Label outline />)).toMatchSnapshot()
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<Label is="span" />).type).toEqual('span')
+  })
+
   it('has default theme', () => {
     expect(Label).toSetDefaultTheme()
   })

--- a/src/__tests__/Link.js
+++ b/src/__tests__/Link.js
@@ -26,7 +26,6 @@ describe('Link', () => {
     expect(render(<Link is="button" />).type).toEqual('button')
   })
 
-
   it('respects hoverColor prop', () => {
     expect(render(<Link hoverColor="blue.4" />)).toMatchSnapshot()
   })

--- a/src/__tests__/Link.js
+++ b/src/__tests__/Link.js
@@ -22,6 +22,11 @@ describe('Link', () => {
     expect(render(<Link />)).toMatchSnapshot()
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<Link is="button" />).type).toEqual('button')
+  })
+
+
   it('respects hoverColor prop', () => {
     expect(render(<Link hoverColor="blue.4" />)).toMatchSnapshot()
   })

--- a/src/__tests__/PointerBox.js
+++ b/src/__tests__/PointerBox.js
@@ -22,5 +22,4 @@ describe('PointerBox', () => {
   it('respects the "is" prop', () => {
     expect(render(<PointerBox is="span" />).type).toEqual('span')
   })
-
 })

--- a/src/__tests__/PointerBox.js
+++ b/src/__tests__/PointerBox.js
@@ -18,4 +18,9 @@ describe('PointerBox', () => {
   it('has default theme', () => {
     expect(PointerBox).toSetDefaultTheme()
   })
+
+  it('respects the "is" prop', () => {
+    expect(render(<PointerBox is="span" />).type).toEqual('span')
+  })
+
 })

--- a/src/__tests__/Position.js
+++ b/src/__tests__/Position.js
@@ -26,12 +26,20 @@ describe('position components', () => {
       expect(result).toHaveStyleRule('position', 'absolute')
       expect(result).toHaveStyleRule('border', '1px solid')
     })
+
+    it('respects the "is" prop', () => {
+      expect(render(<Absolute is="span" />).type).toEqual('span')
+    })
+
   })
 
   describe('Fixed', () => {
     it('implements system props', () => {
       expect(Fixed).toImplementSystemProps(LAYOUT)
       expect(Fixed).toImplementSystemProps(POSITION)
+    })
+    it('respects the "is" prop', () => {
+      expect(render(<Fixed is="span" />).type).toEqual('span')
     })
     it('has default theme', () => {
       expect(Fixed).toSetDefaultTheme()
@@ -54,6 +62,10 @@ describe('position components', () => {
       expect(Relative).toImplementSystemProps(LAYOUT)
       expect(Relative).toImplementSystemProps(POSITION)
     })
+    it('respects the "is" prop', () => {
+      expect(render(<Relative is="span" />).type).toEqual('span')
+    })
+
     it('has default theme', () => {
       expect(Relative).toSetDefaultTheme()
     })
@@ -74,6 +86,9 @@ describe('position components', () => {
     it('implements system props', () => {
       expect(Sticky).toImplementSystemProps(LAYOUT)
       expect(Sticky).toImplementSystemProps(POSITION)
+    })
+    it('respects the "is" prop', () => {
+      expect(render(<Sticky is="span" />).type).toEqual('span')
     })
     it('sets position: sticky', () => {
       expect(render(<Sticky />)).toHaveStyleRule('position', 'sticky')

--- a/src/__tests__/Position.js
+++ b/src/__tests__/Position.js
@@ -30,7 +30,6 @@ describe('position components', () => {
     it('respects the "is" prop', () => {
       expect(render(<Absolute is="span" />).type).toEqual('span')
     })
-
   })
 
   describe('Fixed', () => {

--- a/src/__tests__/StateLabel.js
+++ b/src/__tests__/StateLabel.js
@@ -27,6 +27,11 @@ describe('StateLabel', () => {
     expect(render(<StateLabel>hi</StateLabel>)).toMatchSnapshot()
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<StateLabel is="span" />).type).toEqual('span')
+  })
+
+
   it('does not pass on arbitrary attributes', () => {
     const defaultOutput = render(<StateLabel />)
     expect(render(<StateLabel data-foo="bar" />)).toEqual(defaultOutput)

--- a/src/__tests__/StateLabel.js
+++ b/src/__tests__/StateLabel.js
@@ -31,7 +31,6 @@ describe('StateLabel', () => {
     expect(render(<StateLabel is="span" />).type).toEqual('span')
   })
 
-
   it('does not pass on arbitrary attributes', () => {
     const defaultOutput = render(<StateLabel />)
     expect(render(<StateLabel data-foo="bar" />)).toEqual(defaultOutput)

--- a/src/__tests__/Tooltip.js
+++ b/src/__tests__/Tooltip.js
@@ -16,7 +16,6 @@ describe('Tooltip', () => {
     expect(render(<Tooltip is="span" />).type).toEqual('span')
   })
 
-
   it('renders a <span> with the "tooltipped" class', () => {
     expect(render(<Tooltip />).type).toEqual('span')
     expect(renderClasses(<Tooltip />)).toContain('tooltipped-n')

--- a/src/__tests__/Tooltip.js
+++ b/src/__tests__/Tooltip.js
@@ -12,6 +12,11 @@ describe('Tooltip', () => {
     expect(Tooltip).toSetDefaultTheme()
   })
 
+  it('respects the "is" prop', () => {
+    expect(render(<Tooltip is="span" />).type).toEqual('span')
+  })
+
+
   it('renders a <span> with the "tooltipped" class', () => {
     expect(render(<Tooltip />).type).toEqual('span')
     expect(renderClasses(<Tooltip />)).toContain('tooltipped-n')

--- a/src/__tests__/__snapshots__/Box.js.snap
+++ b/src/__tests__/__snapshots__/Box.js.snap
@@ -7,6 +7,7 @@ exports[`Box renders margin 1`] = `
 
 <div
   className="c0"
+  m={1}
 />
 `;
 
@@ -35,6 +36,14 @@ exports[`Box renders margin 2`] = `
 
 <div
   className="c0"
+  m={
+    Array [
+      0,
+      1,
+      2,
+      3,
+    ]
+  }
 />
 `;
 
@@ -63,6 +72,14 @@ exports[`Box renders margin 3`] = `
 
 <div
   className="c0"
+  m={
+    Array [
+      1,
+      1,
+      1,
+      3,
+    ]
+  }
 />
 `;
 
@@ -73,6 +90,7 @@ exports[`Box renders padding 1`] = `
 
 <div
   className="c0"
+  p={1}
 />
 `;
 
@@ -101,6 +119,14 @@ exports[`Box renders padding 2`] = `
 
 <div
   className="c0"
+  p={
+    Array [
+      0,
+      1,
+      2,
+      3,
+    ]
+  }
 />
 `;
 
@@ -129,6 +155,14 @@ exports[`Box renders padding 3`] = `
 
 <div
   className="c0"
+  p={
+    Array [
+      1,
+      1,
+      1,
+      3,
+    ]
+  }
 />
 `;
 

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -137,7 +137,21 @@ exports[`Dropdown matches the snapshots 1`] = `
       </svg>
     </summary>
     <div
+      bg="white"
+      border={1}
+      borderColor="gray.2"
+      borderRadius={1}
+      boxShadow="small"
       className="c4"
+      css={
+        Object {
+          "position": "absolute",
+          "zIndex": 99999,
+        }
+      }
+      mt={1}
+      px={3}
+      py={2}
     >
       hi
       <svg
@@ -312,7 +326,21 @@ exports[`Dropdown matches the snapshots 2`] = `
       </svg>
     </summary>
     <div
+      bg="white"
+      border={1}
+      borderColor="gray.2"
+      borderRadius={1}
+      boxShadow="small"
       className="c4"
+      css={
+        Object {
+          "position": "absolute",
+          "zIndex": 99999,
+        }
+      }
+      mt={1}
+      px={3}
+      py={2}
     >
       hello!
       <svg

--- a/src/__tests__/__snapshots__/PointerBox.js.snap
+++ b/src/__tests__/__snapshots__/PointerBox.js.snap
@@ -17,6 +17,10 @@ exports[`PointerBox passes the "bg" prop to both <BorderBox> and <Caret> 1`] = `
   position="relative"
 >
   <div
+    bg="red.5"
+    border="1px solid"
+    borderColor="gray.2"
+    borderRadius={1}
     className="c1"
   >
     <svg
@@ -68,6 +72,9 @@ exports[`PointerBox passes the "borderColor" prop to both <BorderBox> and <Caret
   position="relative"
 >
   <div
+    border="1px solid"
+    borderColor="red.5"
+    borderRadius={1}
     className="c1"
   >
     <svg
@@ -119,6 +126,9 @@ exports[`PointerBox renders a <Caret> in <BorderBox> with relative positioning 1
   position="relative"
 >
   <div
+    border="1px solid"
+    borderColor="gray.2"
+    borderRadius={1}
     className="c1"
   >
     <svg


### PR DESCRIPTION
This PR moves `styled-components` out of `devDependencies` and into `dependencies` 😬 Thanks to @JasonEtco for the catch! I also needed to fix a few things to make sure that the `is` prop is still working everywhere that it should have been. I've added a bunch of tests to make sure any changes to the `is` prop functionality get caught in the future.

Updates version to 8.2.0-beta 🚀 Planning on merging this into master and releasing ASAP