### PR TITLE
Update theming docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,47 @@ export default () => (
 
 This will set the `color`, `font-family`, and `line-height` CSS properties to the same ones used in [primer-base](https://github.com/primer/primer/blob/master/modules/primer-base/lib/base.scss#L15).
 
+#### Theming
+
+Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+
+```
+import {ThemeProvider} from `styled-components`
+
+const theme = { ... }
+
+const App = (props) => {
+  return (
+    <div>
+      <ThemeProvider theme={theme}>
+        <div>your app here</div>
+      </ThemeProvider>
+    </div>
+  )
+}
+
+```
+
+If you'd like to merge the Primer theme with your theme, you can do so importing the Primer theme and merging using Object.assign:
+
+```
+import {ThemeProvider} from `styled-components`
+import {theme} from '@primer/components'
+
+const customTheme = { ... }
+
+
+const App = (props) => {
+  return (
+    <div>
+      <ThemeProvider theme={Object.assign({}, theme, customTheme)}> // matching keys in customTheme will override keys in the Primer theme
+        <div>your app here</div>
+      </ThemeProvider>
+    </div>
+  )
+}
+```
+
 #### Static CSS rendering
 
 If you're rendering React components both server-side _and_ client-side, we suggest following [styled-component's server-side rendering instructions](https://www.styled-components.com/docs/advanced#server-side-rendering) to avoid the flash of unstyled content for server-rendered components. This repo's [documentation template component](https://github.com/primer/components/blob/master/pages/_document.js) demonstrates how to do this in [Next.js].

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This will set the `color`, `font-family`, and `line-height` CSS properties to th
 Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
 ```jsx
-import {ThemeProvider} from `styled-components`
+import {ThemeProvider} from 'styled-components'
 
 const theme = { ... }
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ const App = (props) => {
 
 If you'd like to merge the Primer theme with your theme, you can do so importing the Primer theme and merging using Object.assign:
 
-```
+```jsx
 import {ThemeProvider} from 'styled-components'
 import {theme} from '@primer/components'
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will set the `color`, `font-family`, and `line-height` CSS properties to th
 
 #### Theming
 
-Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme.js) by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
 ```jsx
 import {ThemeProvider} from 'styled-components'
@@ -116,6 +116,8 @@ const App = (props) => {
   )
 }
 ```
+
+*Note that using `Object.assign` will only create a shallow merge. This means that if both themes have a `color` object, the _entire_ `color` object will be replaced with the new `color` object, instead of only replacing duplicate values from the original theme's color object.
 
 #### Static CSS rendering
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will set the `color`, `font-family`, and `line-height` CSS properties to th
 
 #### Theming
 
-Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
 ```
 import {ThemeProvider} from `styled-components`

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ This will set the `color`, `font-family`, and `line-height` CSS properties to th
 
 Components are styled using Primer's theme by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer theme with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
-```
+```jsx
 import {ThemeProvider} from `styled-components`
 
 const theme = { ... }

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ const App = (props) => {
 If you'd like to merge the Primer theme with your theme, you can do so importing the Primer theme and merging using Object.assign:
 
 ```
-import {ThemeProvider} from `styled-components`
+import {ThemeProvider} from 'styled-components'
 import {theme} from '@primer/components'
 
 const customTheme = { ... }

--- a/contributing.md
+++ b/contributing.md
@@ -63,7 +63,7 @@ Default values for system props can be set in `Component.defaultProps`.
 
 Prop Types from system props such as `COMMON` or `TYPOGRAPHY` as well as styled-system functions can be spread in the component's prop types declaration (see example below).
 
- ⚠️ **Make sure to always set the default `theme` prop to our theme! This allows consumers of our components to access our theme values without a ThemeProvider.**
+ ⚠️ **Make sure to always set the default `theme` prop to our [theme](https://github.com/primer/components/blob/master/src/theme.js)! This allows consumers of our components to access our theme values without a ThemeProvider.**
 
 
 ```jsx

--- a/pages/components/docs/primer-theme.md
+++ b/pages/components/docs/primer-theme.md
@@ -48,7 +48,7 @@ There are two ways to change the theme of Primer components:
     **⚠️ Note: [styled-components]'s `<ThemeProvider>` only allows exactly one child.**
 2. You can merge the Primer theme with your custom theme using Object.assign:
 
-```
+```jsx
 import {ThemeProvider} from `styled-components`
 import {theme} from '@primer/components'
 

--- a/pages/components/docs/primer-theme.md
+++ b/pages/components/docs/primer-theme.md
@@ -20,7 +20,7 @@ Custom theming is an optional way to override the Primer values that control col
 
 There are two ways to change the theme of Primer components:
 
-1. You can override the theme for an entire tree of components using the `<ThemeProvider>` from [styled-components]:
+1. You can override the entire theme for an entire tree of components using the `<ThemeProvider>` from [styled-components]:
 
     ```jsx
     import {Block, Button, Text, theme as primer} from '@primer/components'
@@ -46,8 +46,27 @@ There are two ways to change the theme of Primer components:
     ```
 
     **⚠️ Note: [styled-components]'s `<ThemeProvider>` only allows exactly one child.**
+2. You can merge the Primer theme with your custom theme using Object.assign:
 
-1. You can theme individual components by passing the `theme` prop directly:
+```
+import {ThemeProvider} from `styled-components`
+import {theme} from '@primer/components'
+
+const customTheme = { ... }
+
+
+const App = (props) => {
+  return (
+    <div>
+      <ThemeProvider theme={Object.assign({}, theme, customTheme)}> // matching keys in customTheme will override keys in the Primer theme
+        <div>your app here</div>
+      </ThemeProvider>
+    </div>
+  )
+}
+```
+
+3. You can theme individual components by passing the `theme` prop directly:
 
     ```jsx
     import {Text} from '@primer/components'
@@ -64,6 +83,7 @@ There are two ways to change the theme of Primer components:
     ```
 
     **☝️ This is an intentionally convoluted example, since you can use `<Text color='#f0f'>` out of the box.**
+
 
 Read the [styled-system docs](http://jxnblk.com/styled-system/getting-started#theming) for more information on theming in styled-system.
 


### PR DESCRIPTION
This branch was originally created to make a custom `<ThemeProvider>` to export, but after chatting with @mxstbr about the pros and cons of namespacing and automatically merging themes, I've decided to not go forward with a custom ThemeProvider component, and instead update our docs with additional instructions on how to merge a theme on the user's end 🙌 

Just for context, some of the issues that came up were:

- Namespacing the theme made it pretty much impossible to work with styled-system without making our own patch of styled-system. Styled-system is expecting all theme values to be in the root level of the object.

- Automatically merging custom themes with the Primer Component's theme could lead to confusion if the consumer of the library wasn't expecting a merge to happen. I considered adding a `merge` prop to the `ThemeProvider` but landed on leaving merging up to the end consumer. That way what is being merged/not merged is super explicit. 

- After deciding against auto-merging + namespacing, there wasn't really any reason to export a custom ThemeProvider 😂 I instead opt'd to update the README and docs site with additional instruction on how merge themes using `Object.assign()`