### PR TITLE
Button: Remove default value of "div" from `is` prop

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -12,7 +12,7 @@ function fontSize({size = '14px', ...props}) {
   }
 }
 
-const ButtonBase = ({is: Tag = 'div', onClick, disabled, theme, ...rest}) => {
+const ButtonBase = ({is: Tag, onClick, disabled, theme, ...rest}) => {
   return <Tag disabled={disabled} onClick={disabled ? undefined : onClick} {...rest} />
 }
 


### PR DESCRIPTION
The `is` prop of the `Button` component was getting a default value of `"div"` when the function was declared, but that value was just getting overridden later by `defaultProps`. This pull removes the unnecessary default value assignment.

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
