### PR TITLE
Fix default font weight & size in Heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@
 </p>
 
 
-## Status
-
-**⚠️ This project is a work in progress and is not ready for production use yet!**
-
 ## Documentation
 
 Our documentation site lives at [primer.style/components](https://primer.style/components). You'll be able to find the information listed in this README as well as detailed docs for each component, our theme, and system props.

--- a/src/Heading.js
+++ b/src/Heading.js
@@ -1,16 +1,17 @@
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
-import {TYPOGRAPHY, COMMON, Base} from './constants'
+import {TYPOGRAPHY, COMMON, Base, get} from './constants'
 import theme from './theme'
 
 const Heading = styled(Base)`
+  font-weight: ${get('fontWeights.bold')};
+  font-size: ${get('fontSizes.5')};
   ${TYPOGRAPHY} ${COMMON};
 `
 
 Heading.defaultProps = {
   theme,
   m: 0,
-  fontSize: 5,
   is: 'h1'
 }
 


### PR DESCRIPTION
Sets the default font weight for the `Heading` component to `600` and moves the default text size into the styled-component declaration

Closes #402 

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
