### PR TITLE
DRY up constants.js

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -4,68 +4,6 @@ import theme from './theme'
 
 export const get = key => themeGet(key, getKey(theme, key))
 
-export const COMMON = compose(
-  styles.color,
-  styles.space
-)
-
-export const BORDER = compose(
-  styles.borders,
-  styles.borderColor,
-  styles.boxShadow,
-  styles.borderRadius
-)
-
-export const TYPOGRAPHY = compose(
-  styles.fontFamily,
-  styles.fontSize,
-  styles.fontStyle,
-  styles.fontWeight,
-  styles.lineHeight,
-  styles.textAlign
-)
-
-export const LAYOUT = compose(
-  styles.display,
-  styles.size,
-  styles.width,
-  styles.height,
-  styles.minWidth,
-  styles.minHeight,
-  styles.maxWidth,
-  styles.maxHeight,
-  styles.overflow,
-  styles.verticalAlign
-)
-
-export const POSITION = compose(
-  styles.position,
-  styles.zIndex,
-  styles.top,
-  styles.right,
-  styles.bottom,
-  styles.left
-)
-
-export const FLEX_CONTAINER = compose(
-  styles.flexBasis,
-  styles.flexDirection,
-  styles.flexWrap,
-  styles.alignContent,
-  styles.alignItems,
-  styles.justifyContent,
-  styles.justifyItems,
-  styles.order
-)
-
-export const FLEX_ITEM = compose(
-  styles.flex,
-  styles.justifySelf,
-  styles.alignSelf
-)
-
-// These lists are just used to generate docs
-
 export const COMMON_LIST = ['color', 'space']
 
 export const BORDER_LIST = ['borders', 'borderColor', 'boxShadow', 'borderRadius']
@@ -122,5 +60,17 @@ export const FLEX_ITEM_LIST = [
   'justifySelf',
   'alignSelf'
 ]
+
+export const COMMON = composeList(COMMON_LIST)
+export const BORDER = composeList(BORDER_LIST)
+export const TYPOGRAPHY = composeList(TYPOGRAPHY_LIST)
+export const LAYOUT = composeList(LAYOUT_LIST)
+export const POSITION = composeList(POSITION_LIST)
+export const FLEX_CONTAINER = composeList(FLEX_CONTAINER_LIST)
+export const FLEX_ITEM = composeList(FLEX_ITEM_LIST)
+
+function composeList(list) {
+  return compose(...list.map(name => styles[name]))
+}
 
 export const Base = ({is: Tag = 'div', theme, ...rest}) => <Tag {...rest} />


### PR DESCRIPTION
Currently,  each "system prop" is listed in twice in `constants.js` because: once for use with `styled-components` and once for the docs. It seems like it would be easy for the docs to get out-of-sync if we forget to update _both_ lists every time we make a change to a constant. I wrote a little helper function to avoid having to repeat lists of system props. 

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
