### PR TITLE
Make styled-components a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "styled-components": "4.1.2"
   },
   "peerDependencies": {
-    "styled-components": "4.1.2"
+    "styled-components": "4.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react": "16.8.0",
     "react-bodymovin": "2.0.0",
     "react-dom": "16.8.0",
-    "styled-components": "4.1.2",
     "styled-system": "3.1.3",
     "system-components": "3.0.1"
   },
@@ -88,6 +87,10 @@
     "rollup": "0.62.0",
     "rollup-plugin-babel": "4.0.0-beta.8",
     "rollup-plugin-commonjs": "9.1.3",
-    "sass.macro": "0.1.0"
+    "sass.macro": "0.1.0",
+    "styled-components": "4.1.2"
+  },
+  "peerDependencies": {
+    "styled-components": "4.1.2"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,6 +8,9 @@ export default [
   {
     input: 'src/index.js',
     plugins,
+    external: [
+      "styled-components"
+    ],
     output: formats.map(format => ({
       file: `dist/index.${format}.js`,
       format,


### PR DESCRIPTION
As per [styled-component's documentation](https://www.styled-components.com/docs/faqs#i-am-a-library-author-should-i-bundle-styledcomponents-with-my-library), they recommend not bundling `styled-components` with our library. I've moved styled-components to a dev & peer dependency and removing it from our bundle.

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
