### PR TITLE
Rename start script

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ To run `@primer/components` locally when adding or updating components:
 
 1. Clone this repo: `git clone https://github.com/primer/components`
 1. Install dependencies: `npm install`
-1. Run the dev app: `npm run dev`
+1. Run the dev app: `npm start`
 
 > 👉 See [the contributing docs](contributing.md) for more info on code style, testing, and coverage.
 

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   "scripts": {
     "dev": "next dev",
     "prebuild": "npm run dist",
-    "build": "next build",
-    "start": "next start",
+    "next-build": "next build",
+    "start": "next dev",
+    "next-start": "next start",
     "predist": "rm -rf dist",
     "dist": "NODE_ENV=production rollup -c",
     "postdist": "du -ha dist",


### PR DESCRIPTION
This PR sets the `npm start` script to run `next dev` and renames the current `start` to `next-start`, in order to match the pattern we've got on other repositories ❤️ 

#### If development process was changed
Description of changes

- [ ] Updated README

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
