### PR TITLE
Details refactor (non-breaking)

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,7 +26,7 @@ action "npm test" {
 }
 
 action "deploy" {
-  uses = "primer/deploy@v3.0.0"
+  uses = "primer/deploy@bc4097b"
   needs = ["npm install"]
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -9,30 +9,30 @@ workflow "Primer Components Workflow" {
 }
 
 action "npm install" {
-  uses = "actions/npm@94e6933"
+  uses = "actions/npm@v2.0.0"
   args = "ci"
 }
 
 action "npm lint" {
-  uses = "actions/npm@3c8332795d5443adc712d30fa147db61fd520b5a"
+  uses = "actions/npm@v2.0.0"
   needs = ["npm install"]
   args = "run lint"
 }
 
 action "npm test" {
-  uses = "actions/npm@3c8332795d5443adc712d30fa147db61fd520b5a"
+  uses = "actions/npm@v2.0.0"
   needs = ["npm install"]
   args = "test"
 }
 
 action "deploy" {
-  uses = "primer/deploy@66d83b7"
+  uses = "primer/deploy@v3.0.0"
   needs = ["npm install"]
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
 }
 
 action "publish" {
-  uses = "primer/publish@master"
+  uses = "primer/publish@v1.0.0"
   needs = ["npm install"]
   secrets = [
     "GITHUB_TOKEN",

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,7 +26,7 @@ action "npm test" {
 }
 
 action "deploy" {
-  uses = "primer/deploy@bc4097b"
+  uses = "primer/deploy@v3.0.0"
   needs = ["npm install"]
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -26,7 +26,7 @@ action "npm test" {
 }
 
 action "deploy" {
-  uses = "primer/deploy@v2.0.0"
+  uses = "primer/deploy@66d83b7"
   needs = ["npm install"]
   secrets = ["GITHUB_TOKEN", "NOW_TOKEN"]
 }

--- a/pages/components/docs/Details.md
+++ b/pages/components/docs/Details.md
@@ -62,4 +62,4 @@ Details components get `COMMON` system props. Read our [System Props](/component
 | render | Function | | Optional render function, to allow you to handle toggling and open/closed state from a container component.
 | overlay | Boolean | false | Sets whether or not element will close when user clicks outside of it
 
-export const meta = {displayName: 'Details'} 
+export const meta = {displayName: 'Details'}

--- a/pages/components/docs/Details.md
+++ b/pages/components/docs/Details.md
@@ -62,4 +62,4 @@ Details components get `COMMON` system props. Read our [System Props](/component
 | render | Function | | Optional render function, to allow you to handle toggling and open/closed state from a container component.
 | overlay | Boolean | false | Sets whether or not element will close when user clicks outside of it
 
-export const meta = {displayName: 'Details'}
+export const meta = {displayName: 'Details'} 

--- a/src/Details.js
+++ b/src/Details.js
@@ -21,7 +21,7 @@ function DetailsBase({children, overlay, render = getRenderer(children), ...rest
 
   function toggle(event) {
     if (event) event.preventDefault()
-    if (overlay) {
+    if (overlay && !open) {
       setOpen(true)
       document.addEventListener('click', closeMenu);
     } else {

--- a/src/Details.js
+++ b/src/Details.js
@@ -17,7 +17,6 @@ const overlayStyles = `
     content: " ";
     background: transparent;
   }
-  background: 'red';
 `
 
 const DetailsReset = styled('details')`

--- a/src/Details.js
+++ b/src/Details.js
@@ -31,14 +31,14 @@ function DetailsBase({children, overlay, render = getRenderer(children), ...rest
   function openMenu() {
     if (!open) {
       setOpen(true)
-      document.addEventListener('click', closeMenu);
+      document.addEventListener('click', closeMenu)
     }
   }
 
   function closeMenu(event) {
     if (event) event.preventDefault()
     setOpen(false)
-    document.removeEventListener('click', closeMenu);
+    document.removeEventListener('click', closeMenu)
   }
   return (
     <DetailsReset {...rest} open={open} overlay={overlay}>

--- a/src/Details.js
+++ b/src/Details.js
@@ -4,32 +4,13 @@ import styled from 'styled-components'
 import {COMMON} from './constants'
 import theme from './theme'
 
-const overlayStyles = `
-  & > summary::before {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 80;
-    display: block;
-    cursor: default;
-    content: " ";
-    background: transparent;
-  }
-`
-
 const DetailsReset = styled('details')`
   & > summary {
     list-style: none;
   }
-  & > summary::before {
-    display: none;
-  }
   & > summary::-webkit-details-marker {
     display: none;
   }
-  ${props => (props.overlay && props.open ? overlayStyles : '')};
 `
 function getRenderer(children) {
   return typeof children === 'function' ? children : () => children
@@ -40,7 +21,17 @@ function DetailsBase({children, overlay, render = getRenderer(children), ...rest
 
   function toggle(event) {
     if (event) event.preventDefault()
-    setOpen(!open)
+    if (overlay) {
+      setOpen(true)
+      document.addEventListener('click', closeMenu);
+    } else {
+      setOpen(!true)
+    }
+  }
+
+  function closeMenu(event) {
+    setOpen(false)
+    document.removeEventListener('click', closeMenu);
   }
   return (
     <DetailsReset {...rest} open={open} overlay={overlay}>

--- a/src/Details.js
+++ b/src/Details.js
@@ -25,7 +25,7 @@ function DetailsBase({children, overlay, render = getRenderer(children), ...rest
       setOpen(true)
       document.addEventListener('click', closeMenu);
     } else {
-      setOpen(!true)
+      setOpen(!open)
     }
   }
 

--- a/src/Details.js
+++ b/src/Details.js
@@ -21,15 +21,22 @@ function DetailsBase({children, overlay, render = getRenderer(children), ...rest
 
   function toggle(event) {
     if (event) event.preventDefault()
-    if (overlay && !open) {
-      setOpen(true)
-      document.addEventListener('click', closeMenu);
+    if (overlay) {
+      openMenu()
     } else {
       setOpen(!open)
     }
   }
 
+  function openMenu() {
+    if (!open) {
+      setOpen(true)
+      document.addEventListener('click', closeMenu);
+    }
+  }
+
   function closeMenu(event) {
+    if (event) event.preventDefault()
     setOpen(false)
     document.removeEventListener('click', closeMenu);
   }

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -69,10 +69,6 @@ exports[`Dropdown matches the snapshots 1`] = `
   list-style: none;
 }
 
-.c1 > summary::before {
-  display: none;
-}
-
 .c1 > summary::-webkit-details-marker {
   display: none;
 }
@@ -176,10 +172,6 @@ exports[`Dropdown matches the snapshots 2`] = `
 
 .c1 > summary {
   list-style: none;
-}
-
-.c1 > summary::before {
-  display: none;
 }
 
 .c1 > summary::-webkit-details-marker {


### PR DESCRIPTION
This PR refactors the Details element to use a document event listener to show/hide the Details element when a click is made, instead of an overlay element. The overlay element works fine if you've only got one Details element on the page, but if you're using several (in the case of the new docs header), clicking on another Details element doesn't open the new element, because the overlay is blocking the DOM element.

I wrote this to prioritize not breaking the current API of the Details element, which is why there's a conditional in the `toggle` function now. I felt this was a fair compromise to keep the API the same :) 
