### PR TITLE
Release 12.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -49,15 +49,15 @@ export const FLEX_CONTAINER_LIST = [
   'alignContent',
   'alignItems',
   'justifyContent',
-  'justifyItems',
-  'order'
+  'justifyItems'
 ]
 
 export const FLEX_ITEM_LIST = [
   // flex container child props
   'flex',
   'justifySelf',
-  'alignSelf'
+  'alignSelf',
+  'order'
 ]
 
 export const COMMON = composeList(COMMON_LIST)


### PR DESCRIPTION
Moving the `order` prop to Flex.Item - this was supposed to have been done in https://github.com/primer/components/pull/406 but it looks like it got overridden or something?

Releasing as a patch because `order` on Flex wouldn't have done anything before, so we're just adding functionality here.
