### PR TITLE
Upgrade styled-system to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13738,11 +13738,42 @@
       }
     },
     "styled-system": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.1.3.tgz",
-      "integrity": "sha512-ohDTJPC/MXJMUgfT0qE9syoTOmFculOkW30+AZDn+hbMGRg07V49MNMl5sA0Vi8gFEz6Xluoomvn5xZpaqRDyQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-4.2.2.tgz",
+      "integrity": "sha512-qaIIFbjHZxjIOQQ3AWIswriHP91L42UmNHt5GFut+IKkLIqMEWmd+OYo7N3myt5kFrJKGGKJBVDcjCpwglsY0A==",
       "requires": {
-        "prop-types": "^15.6.2"
+        "@babel/runtime": "^7.4.2",
+        "prop-types": "^15.7.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.8.6",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
+          "integrity": "sha512-aUk3bHfZ2bRSVFFbbeVS4i+lNPZr3/WM5jT2J5omUVV1zzcs1nAaf3l51ctA5FFvCRbhrH0bdAsRRQddFJZPtA=="
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        }
       }
     },
     "stylis": {
@@ -13842,6 +13873,30 @@
       "integrity": "sha512-9awqnq7esNnqgmOOqU4i0w/9/YsJFm+1IS9lAyuk6a52IrcdToFqH7vFJmnr56FNLsXjOFohonmeHs0QOmvWeQ==",
       "requires": {
         "styled-system": "^3.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.4.5",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+          "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+          "requires": {
+            "regenerator-runtime": "^0.13.2"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.13.2",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+          "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
+        },
+        "styled-system": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/styled-system/-/styled-system-3.2.1.tgz",
+          "integrity": "sha512-ag0Yp7UeVHHc3t+1uM3jvlljaZYzwqpbJ8hMrFvpaKfUd8xsB9JeQXLwMpEsz8iLx8Lz/+9j0coWFZjmw8MogQ==",
+          "requires": {
+            "@babel/runtime": "^7.1.2",
+            "prop-types": "^15.6.2"
+          }
+        }
       }
     },
     "table": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react": "^16.8.0",
     "react-bodymovin": "2.0.0",
     "react-dom": "^16.8.1",
-    "styled-system": "3.1.3",
+    "styled-system": "4.2.2",
     "system-components": "3.0.1"
   },
   "devDependencies": {

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -36,9 +36,9 @@ const TextInput = styled(TextInputBase)`
   box-shadow: ${get('shadows.formControl')};
 
   &:focus {
-    border-color: ${get('blue.4')};
+    border-color: ${get('colors.blue.4')};
     outline: none;
-    box-shadow: ${get('shadows.formControl')}, ${get('shadows.formControl.focus')};
+    box-shadow: ${get('shadows.formControl')}, ${get('shadows.formControlFocus')};
   }
 
   &.input-sm {

--- a/src/__tests__/__snapshots__/Box.js.snap
+++ b/src/__tests__/__snapshots__/Box.js.snap
@@ -12,7 +12,7 @@ exports[`Box renders margin 1`] = `
 
 exports[`Box renders margin 2`] = `
 .c0 {
-  margin: 0px;
+  margin: 0;
 }
 
 @media screen and (min-width:544px) {
@@ -78,7 +78,7 @@ exports[`Box renders padding 1`] = `
 
 exports[`Box renders padding 2`] = `
 .c0 {
-  padding: 0px;
+  padding: 0;
 }
 
 @media screen and (min-width:544px) {

--- a/src/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/__tests__/__snapshots__/TextInput.js.snap
@@ -18,8 +18,9 @@ exports[`TextInput renders 1`] = `
 }
 
 .c0:focus {
+  border-color: #2188ff;
   outline: none;
-  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
 }
 
 .c0.input-sm {
@@ -71,8 +72,9 @@ exports[`TextInput renders block 1`] = `
 }
 
 .c0:focus {
+  border-color: #2188ff;
   outline: none;
-  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
 }
 
 .c0.input-sm {
@@ -124,8 +126,9 @@ exports[`TextInput renders large 1`] = `
 }
 
 .c0:focus {
+  border-color: #2188ff;
   outline: none;
-  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
 }
 
 .c0.input-sm {
@@ -177,8 +180,9 @@ exports[`TextInput renders small 1`] = `
 }
 
 .c0:focus {
+  border-color: #2188ff;
   outline: none;
-  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
 }
 
 .c0.input-sm {

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,7 @@
-import {styles, compose, get as getKey, themeGet} from 'styled-system'
+import * as styledSystem from 'styled-system'
 import theme from './theme'
+
+const {compose, get: getKey, themeGet} = styledSystem
 
 export const get = key => themeGet(key, getKey(theme, key))
 
@@ -69,5 +71,5 @@ export const FLEX_CONTAINER = composeList(FLEX_CONTAINER_LIST)
 export const FLEX_ITEM = composeList(FLEX_ITEM_LIST)
 
 function composeList(list) {
-  return compose(...list.map(name => styles[name]))
+  return compose(...list.map(name => styledSystem[name]))
 }


### PR DESCRIPTION
This PR upgrades styled-system to v4 which should save us 7kB in our bundle size 😎 

The biggest change is that the `styles` export was removed, so I had to do a little refactoring of our constants file.

The `get` helper also got refactored to return the last argument as a fallback, which I _thought_ it did before, but I need to do some testing to make sure that doesn't bork our expected behavior with pulling theme values