### PR TITLE
Allow usage together with React >= 16.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
   "peerDependencies": {
     "styled-components": "4.x",
     "@githubprimer/octicons-react": "8.x",
-    "react": "16.8.x"
+    "react": "^16.8.0"
   }
 }


### PR DESCRIPTION
Thre previous constraint (`16.8.x`) don't allow the upcoming `16.9` release of React to satisfy the peer dependency. This new constraint will allow any React 16.x release that's newer or equal to `16.8.0`.

ping @emplums, it seems like you touched this line last, was the intention to restrict it to only 16.8.x? I don't see anything that makes it not work with the 16.9.0-alpha 🤔 

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge