### PR TITLE
Docs: Update styled-system and styled-components url

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,7 @@ A code coverage report is included in the `npm test` output, and test coverage d
 ## Tools we use
 
 1. We use [styled-components](https://www.styled-components.com/) to style our components.
+2. We use style functions from [styled-system](https://styled-system.com/) whenever possible, and styled-systems' `style()` function to create new ones.
 
 
 ## Component patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,7 @@ A code coverage report is included in the `npm test` output, and test coverage d
 
 ## Tools we use
 
-1. We use [styled-components] to style our components.
-2. We use style functions from [styled-system] whenever possible, and styled-systems' `style()` function to create new ones.
+1. We use [styled-components](https://www.styled-components.com/) to style our components.
 
 
 ## Component patterns


### PR DESCRIPTION
A quick update to some urls within the CONTRIBUTING doc. styled-components link was missing and styled-systems link 404'd in previous version
