### PR TITLE
TypeScript types

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,6 +9,7 @@ Description of changes
 
 #### Merge checklist
 - [ ] Changed base branch to release branch
+- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
 - [ ] Tested in Chrome
 - [ ] Tested in Firefox
 - [ ] Tested in Safari

--- a/index.d.ts
+++ b/index.d.ts
@@ -199,6 +199,3 @@ declare module '@primer/components/src/BaseStyles' {
   export default BaseStyles
 }
 
-declare module '@primer/components/src/theme' {
-  export default Object
-}

--- a/index.d.ts
+++ b/index.d.ts
@@ -194,6 +194,84 @@ declare module '@primer/components' {
   }
 
   export const Flash: React.FunctionComponent<FlashProps>
+
+  export interface CounterLabelProps extends CommonProps {
+    scheme?: string
+  }
+
+  export const CounterLabel: React.FunctionComponent<CounterLabelProps>
+
+  export interface LabelProps extends CommonProps {
+    outline?: boolean
+    size?: 'small' | 'medium' | 'large' | 'xl'
+    dropshadow?: boolean
+  }
+
+  export const Label: React.FunctionComponent<LabelProps>
+
+  export interface LinkProps extends CommonProps, TypographyProps {
+    href: string
+    underline?: boolean
+  }
+
+  export const Link: React.FunctionComponent<LinkProps>
+
+  export interface PointerBoxProps extends CommonProps, LayoutProps {
+    caret?: string
+  }
+
+  export const PointerBox: React.FunctionComponent<PointerBoxProps>
+
+  export interface PositionComponentProps extends PositionProps, CommonProps, LayoutProps {}
+
+  export const Relative: React.FunctionComponent<PositionComponentProps>
+  export const Absolute: React.FunctionComponent<PositionComponentProps>
+  export const Sticky: React.FunctionComponent<PositionComponentProps>
+  export const Fixed: React.FunctionComponent<PositionComponentProps>
+
+  export interface StateLabelProps extends CommonProps {
+    small?: boolean
+    status: 'issueOpened' | 'issueClosed' | 'pullOpened' | 'pullClosed' | 'pullMerged'
+  }
+
+  export const StateLabel: React.FunctionComponent<StateLabelProps>
+
+  export interface TextInputProps extends CommonProps {
+    autocomplete?: string
+    'aria-label'?: string
+    block?: boolean
+    disabled?: boolean
+    id?: string
+    name?: string
+    onChange?: (evt: React.ChangeEvent<HTMLInputElement>) => void
+    placeholder?: string
+    required?: boolean
+    size?: 'small' | 'large'
+    value?: string
+  }
+
+  export const TextInput: React.FunctionComponent<TextInputProps>
+
+  export interface TooltipProps extends CommonProps {
+    align?: 'left' | 'right'
+    direction?: 'n' | 'ne' | 'e' | 'se' | 's' | 'sw' | 'w' | 'nw'
+    noDelay?: boolean
+    text?: string
+    wrap?: boolean
+  }
+
+  export const Tooltip: React.FunctionComponent<TooltipProps>
+
+  export interface UnderlineNavProps extends CommonProps {
+    actions?: React.ReactNode
+    align?: 'right'
+    full?: boolean
+    label?: string
+  }
+
+  export const UnderlineNav: React.FunctionComponent<UnderlineNavProps>
+
+  export const theme: Object
 }
 
 declare module '@primer/components/src/Box' {
@@ -283,4 +361,59 @@ declare module '@primer/components/src/FilterList' {
 declare module '@primer/components/src/Flash' {
   import {Flash} from '@primer/components'
   export default Flash
+}
+
+declare module '@primer/components/src/CounterLabel' {
+  import {CounterLabel} from '@primer/components'
+  export default CounterLabel
+}
+
+declare module '@primer/components/src/Label' {
+  import {Label} from '@primer/components'
+  export default Label
+}
+
+declare module '@primer/components/src/Link' {
+  import {Link} from '@primer/components'
+  export default Link
+}
+declare module '@primer/components/src/PointerBox' {
+  import {PointerBox} from '@primer/components'
+  export default PointerBox
+}
+declare module '@primer/components/src/Relative' {
+  import {Relative} from '@primer/components'
+  export default Relative
+}
+declare module '@primer/components/src/Absolute' {
+  import {Absolute} from '@primer/components'
+  export default Absolute
+}
+declare module '@primer/components/src/Sticky' {
+  import {Sticky} from '@primer/components'
+  export default Sticky
+}
+declare module '@primer/components/src/Fixed' {
+  import {Fixed} from '@primer/components'
+  export default Fixed
+}
+declare module '@primer/components/src/StateLabel' {
+  import {StateLabel} from '@primer/components'
+  export default StateLabel
+}
+declare module '@primer/components/src/TextInput' {
+  import {TextInput} from '@primer/components'
+  export default TextInput
+}
+declare module '@primer/components/src/Tooltip' {
+  import {Tooltip} from '@primer/components'
+  export default Tooltip
+}
+declare module '@primer/components/src/UnderlineNav' {
+  import {UnderlineNav} from '@primer/components'
+  export default UnderlineNav
+}
+declare module '@primer/components/src/theme' {
+  import {theme} from '@primer/components'
+  export default theme
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -127,6 +127,73 @@ declare module '@primer/components' {
   export interface BaseStylesProps extends TypographyProps, CommonProps {}
 
   export const BaseStyles: React.FunctionComponent<BaseStylesProps>
+
+  export interface BorderBoxProps extends CommonProps, LayoutProps {
+    border?: string
+    borderColor?: string
+    borderRadius?: string | number
+    boxShadow?: string
+  }
+
+  export const BorderBox: React.FunctionComponent<BorderBoxProps>
+
+  export interface BranchNameProps extends CommonProps {
+    href?: string
+  }
+
+  export const BranchName: React.FunctionComponent<BranchNameProps>
+
+  export interface CircleBadgeProps extends CommonProps {
+    size?: string | number
+  }
+
+  export const CircleBadge: React.FunctionComponent<CircleBadgeProps>
+
+  export interface CircleOcticonProps extends CommonProps {
+    size?: number
+    icon: React.ReactNode
+  }
+
+  export const CircleOcticon: React.FunctionComponent<CircleOcticonProps>
+
+  export interface StyledOcticonProps extends CommonProps {
+    size?: number
+    icon: React.ReactNode
+  }
+
+  export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
+
+  export interface DropdownProps extends CommonProps {}
+
+  export interface DropdownMenuProps extends CommonProps {
+    direction?: string
+    title: string
+  }
+
+  export const Dropdown: React.FunctionComponent<DropdownProps> & {
+    Menu: React.FunctionComponent<DropdownMenuProps>
+    Item: React.FunctionComponent<DropdownProps>
+  }
+
+  export interface FilterListProps extends CommonProps {
+    small?: boolean
+  }
+
+  export interface FilterListItemProps extends CommonProps {
+    count?: number
+    selected?: boolean
+  }
+
+  export const FilterList: React.FunctionComponent<FilterListProps> & {
+    Item: React.FunctionComponent<FilterListItemProps>
+  }
+
+  export interface FlashProps extends CommonProps {
+    full?: boolean
+    scheme?: string
+  }
+
+  export const Flash: React.FunctionComponent<FlashProps>
 }
 
 declare module '@primer/components/src/Box' {
@@ -184,3 +251,36 @@ declare module '@primer/components/src/BaseStyles' {
   export default BaseStyles
 }
 
+declare module '@primer/components/src/BorderBox' {
+  import {BorderBox} from '@primer/components'
+  export default BorderBox
+}
+
+declare module '@primer/components/src/BranchName' {
+  import {BranchName} from '@primer/components'
+  export default BranchName
+}
+declare module '@primer/components/src/CircleBadge' {
+  import {CircleBadge} from '@primer/components'
+  export default CircleBadge
+}
+declare module '@primer/components/src/CircleOcticon' {
+  import {CircleOcticon} from '@primer/components'
+  export default CircleOcticon
+}
+declare module '@primer/components/src/StyledOcticon' {
+  import {StyledOcticon} from '@primer/components'
+  export default StyledOcticon
+}
+declare module '@primer/components/src/Dropdown' {
+  import {Dropdown} from '@primer/components'
+  export default Dropdown
+}
+declare module '@primer/components/src/FilterList' {
+  import {FilterList} from '@primer/components'
+  export default FilterList
+}
+declare module '@primer/components/src/Flash' {
+  import {Flash} from '@primer/components'
+  export default Flash
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -76,10 +76,21 @@ declare module '@primer/components' {
     extends FlexContainerProps,
       Omit<React.HTMLProps<HTMLDivElement>, keyof FlexContainerProps> {}
 
+  export const Flex: React.FunctionComponent<FlexProps> & {
+    Item: React.FunctionComponent<FlexItemProps>
+  }
+
   export interface BoxProps extends BaseProps, CommonProps, LayoutProps {}
 
+  export const Box: React.FunctionComponent<BoxProps>
+
   export interface TextProps extends BaseProps, CommonProps, TypographyProps {}
+
+  export const Text: React.FunctionComponent<TextProps>
+
   export interface HeadingProps extends BaseProps, CommonProps, TypographyProps {}
+
+  export const Heading: React.FunctionComponent<HeadingProps>
 
   type DetailsRenderFunction = (args: {open: boolean; toggle: () => void}) => React.ReactElement
 
@@ -90,112 +101,86 @@ declare module '@primer/components' {
     overlay?: boolean
   }
 
+  export const Details: React.FunctionComponent<DetailsProps>
+
   export interface ButtonProps extends BaseProps, CommonProps {
     disabled?: boolean
     grouped?: boolean
     onClick?: Function
     size?: 'sm' | 'large'
   }
+
+  export const ButtonPrimary: React.FunctionComponent<ButtonProps>
+  export const ButtonOutline: React.FunctionComponent<ButtonProps>
+  export const ButtonDanger: React.FunctionComponent<ButtonProps>
+  export const Button: React.FunctionComponent<ButtonProps>
+
+  export interface AvatarProps extends CommonProps {
+    alt: string
+    src: string
+    isChild?: boolean
+    size?: number
+  }
+
+  export const Avatar: React.FunctionComponent<AvatarProps>
+
+  export interface BaseStylesProps extends TypographyProps, CommonProps {}
+
+  export const BaseStyles: React.FunctionComponent<BaseStylesProps>
 }
 
 declare module '@primer/components/src/Box' {
-  import {BoxProps} from '@primer/components'
-
-  export {BoxProps}
-
-  const Box: React.FunctionComponent<BoxProps>
-
+  import {Box} from '@primer/components'
   export default Box
 }
 
 declare module '@primer/components/src/Text' {
-  import {TextProps} from '@primer/components'
-
-  const Text: React.FunctionComponent<TextProps>
-
+  import {Text} from '@primer/components'
   export default Text
 }
 
 declare module '@primer/components/src/Heading' {
-  import {HeadingProps} from '@primer/components'
-
-  const Heading: React.FunctionComponent<HeadingProps>
-
+  import {Heading} from '@primer/components'
   export default Heading
 }
 
 declare module '@primer/components/src/ButtonDanger' {
-  import {ButtonProps} from '@primer/components'
-
-  const ButtonDanger: React.FunctionComponent<ButtonProps>
-
+  import {ButtonDanger} from '@primer/components'
   export default ButtonDanger
 }
 
 declare module '@primer/components/src/ButtonPrimary' {
-  import {ButtonProps} from '@primer/components'
-
-  const ButtonPrimary: React.FunctionComponent<ButtonProps>
-
+  import {ButtonPrimary} from '@primer/components'
   export default ButtonPrimary
 }
 
 declare module '@primer/components/src/ButtonOutline' {
-  import {ButtonProps} from '@primer/components'
-
-  const ButtonOutline: React.FunctionComponent<ButtonProps>
-
+  import {ButtonOutline} from '@primer/components'
   export default ButtonOutline
 }
 
 declare module '@primer/components/src/Button' {
-  import {ButtonProps} from '@primer/components'
-
-  const Button: React.FunctionComponent<ButtonProps>
-
+  import {Button} from '@primer/components'
   export default Button
 }
 
 declare module '@primer/components/src/Flex' {
-  import {FlexProps, FlexItemProps} from '@primer/components'
-
-  const Flex: React.FunctionComponent<FlexProps> & {
-    Item: React.FunctionComponent<FlexItemProps>
-  }
-
-  export {FlexProps, FlexItemProps}
-
+  import {Flex} from '@primer/components'
   export default Flex
 }
 
 declare module '@primer/components/src/Avatar' {
-  import {CommonProps} from '@primer/components'
-
-  const Avatar: React.FunctionComponent<
-    CommonProps & {
-      alt: string
-      src: string
-      isChild?: boolean
-      size?: number
-    }
-  >
-
+  import {Avatar} from '@primer/components'
   export default Avatar
 }
 
 declare module '@primer/components/src/Details' {
-  import {DetailsProps} from '@primer/components'
-
-  const Details: React.FunctionComponent<DetailsProps>
-
+  import {Details} from '@primer/components'
   export default Details
 }
 
 declare module '@primer/components/src/BaseStyles' {
-  import {TypographyProps, CommonProps} from '@primer/components'
-
-  const BaseStyles: React.FunctionComponent<TypographyProps & CommonProps>
-
+  import {BaseStyles} from '@primer/components'
   export default BaseStyles
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,204 @@
+declare module '@primer/components' {
+  type Omit<T, K> = Pick<T, Exclude<keyof T, K>>
+  import * as StyledSystem from 'styled-system'
+  import * as StyledComponents from 'styled-components'
+  import * as History from 'history'
+
+  export interface BaseProps extends React.Props<any> {
+    as?: React.ReactType
+    title?: string
+    // NOTE(@mxstbr): Necessary workaround to make <Component as={Link} to="/bla" /> work
+    to?: History.LocationDescriptor
+  }
+
+  interface CommonProps extends BaseProps, StyledSystem.ColorProps, StyledSystem.SpaceProps {}
+
+  interface LayoutProps
+    extends BaseProps,
+      StyledSystem.DisplayProps,
+      StyledSystem.SizeProps,
+      StyledSystem.WidthProps,
+      StyledSystem.HeightProps,
+      StyledSystem.MinWidthProps,
+      StyledSystem.MinHeightProps,
+      StyledSystem.MaxWidthProps,
+      StyledSystem.MaxHeightProps,
+      StyledSystem.OverflowProps,
+      StyledSystem.VerticalAlignProps {}
+
+  interface TypographyProps
+    extends BaseProps,
+      StyledSystem.FontFamilyProps,
+      StyledSystem.FontSizeProps,
+      StyledSystem.FontStyleProps,
+      StyledSystem.FontWeightProps,
+      StyledSystem.LineHeightProps,
+      StyledSystem.TextAlignProps {}
+
+  interface BorderProps
+    extends BaseProps,
+      StyledSystem.BordersProps,
+      StyledSystem.BorderColorProps,
+      StyledSystem.BoxShadowProps,
+      StyledSystem.BorderRadiusProps {}
+
+  interface PositionProps
+    extends BaseProps,
+      StyledSystem.PositionProps,
+      StyledSystem.ZIndexProps,
+      StyledSystem.TopProps,
+      StyledSystem.RightProps,
+      StyledSystem.BottomProps,
+      StyledSystem.LeftProps {}
+
+  interface FlexContainerProps
+    extends BaseProps,
+      CommonProps,
+      LayoutProps,
+      StyledSystem.FlexBasisProps,
+      StyledSystem.FlexDirectionProps,
+      StyledSystem.FlexWrapProps,
+      StyledSystem.AlignContentProps,
+      StyledSystem.AlignItemsProps,
+      StyledSystem.JustifyContentProps,
+      StyledSystem.JustifyItemsProps {}
+
+  interface FlexItemProps
+    extends BaseProps,
+      CommonProps,
+      LayoutProps,
+      StyledSystem.FlexProps,
+      StyledSystem.JustifySelfProps,
+      StyledSystem.AlignSelfProps,
+      StyledSystem.OrderProps {}
+
+  export interface FlexProps
+    extends FlexContainerProps,
+      Omit<React.HTMLProps<HTMLDivElement>, keyof FlexContainerProps> {}
+
+  export interface BoxProps extends BaseProps, CommonProps, LayoutProps {}
+
+  export interface TextProps extends BaseProps, CommonProps, TypographyProps {}
+  export interface HeadingProps extends BaseProps, CommonProps, TypographyProps {}
+
+  type DetailsRenderFunction = (args: {open: boolean; toggle: () => void}) => React.ReactElement
+
+  export interface DetailsProps extends CommonProps {
+    open?: boolean
+    render?: DetailsRenderFunction
+    children?: DetailsRenderFunction | React.ReactNode
+    overlay?: boolean
+  }
+
+  export interface ButtonProps extends BaseProps, CommonProps {
+    disabled?: boolean
+    grouped?: boolean
+    onClick?: Function
+    size?: 'sm' | 'large'
+  }
+}
+
+declare module '@primer/components/src/Box' {
+  import {BoxProps} from '@primer/components'
+
+  export {BoxProps}
+
+  const Box: React.FunctionComponent<BoxProps>
+
+  export default Box
+}
+
+declare module '@primer/components/src/Text' {
+  import {TextProps} from '@primer/components'
+
+  const Text: React.FunctionComponent<TextProps>
+
+  export default Text
+}
+
+declare module '@primer/components/src/Heading' {
+  import {HeadingProps} from '@primer/components'
+
+  const Heading: React.FunctionComponent<HeadingProps>
+
+  export default Heading
+}
+
+declare module '@primer/components/src/ButtonDanger' {
+  import {ButtonProps} from '@primer/components'
+
+  const ButtonDanger: React.FunctionComponent<ButtonProps>
+
+  export default ButtonDanger
+}
+
+declare module '@primer/components/src/ButtonPrimary' {
+  import {ButtonProps} from '@primer/components'
+
+  const ButtonPrimary: React.FunctionComponent<ButtonProps>
+
+  export default ButtonPrimary
+}
+
+declare module '@primer/components/src/ButtonOutline' {
+  import {ButtonProps} from '@primer/components'
+
+  const ButtonOutline: React.FunctionComponent<ButtonProps>
+
+  export default ButtonOutline
+}
+
+declare module '@primer/components/src/Button' {
+  import {ButtonProps} from '@primer/components'
+
+  const Button: React.FunctionComponent<ButtonProps>
+
+  export default Button
+}
+
+declare module '@primer/components/src/Flex' {
+  import {FlexProps, FlexItemProps} from '@primer/components'
+
+  const Flex: React.FunctionComponent<FlexProps> & {
+    Item: React.FunctionComponent<FlexItemProps>
+  }
+
+  export {FlexProps, FlexItemProps}
+
+  export default Flex
+}
+
+declare module '@primer/components/src/Avatar' {
+  import {CommonProps} from '@primer/components'
+
+  const Avatar: React.FunctionComponent<
+    CommonProps & {
+      alt: string
+      src: string
+      isChild?: boolean
+      size?: number
+    }
+  >
+
+  export default Avatar
+}
+
+declare module '@primer/components/src/Details' {
+  import {DetailsProps} from '@primer/components'
+
+  const Details: React.FunctionComponent<DetailsProps>
+
+  export default Details
+}
+
+declare module '@primer/components/src/BaseStyles' {
+  import {TypographyProps, CommonProps} from '@primer/components'
+
+  const BaseStyles: React.FunctionComponent<TypographyProps & CommonProps>
+
+  export default BaseStyles
+}
+
+declare module '@primer/components/src/theme' {
+  export default Object
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",
+  "typings": "index.d.ts",
   "scripts": {
     "dev": "next dev",
     "prebuild": "npm run dist",
@@ -31,6 +32,7 @@
     "codemods",
     "dist",
     "src",
+    "index.d.ts",
     "!src/__tests__",
     "!src/utils"
   ],


### PR DESCRIPTION
Adds TypeScript types to the components, so that any consumer only has to install the package and will automatically get the types. These were extracted from our internal project where I typed all the components we are currently using.

**TODO**

- [x] Currently only file-based imports are typed (`import Flex from '@primer/components/src/Flex'`), we will need to update the types to also type the exports
- [x] Avatar
- [x] BaseStyles
- [x] BorderBox
- [x] Box
- [x] BranchName
- [x] Button
- [x] CircleBadge
- [x] CircleOcticon
- [x] CounterLabel
- [x] Details
- [x] Dropdown
- [x] FilterList
- [x] Flash
- [x] Flex
- [x] Heading
- [x] Label
- [x] Link
- [x] PointerBox
- [x] Position
- [x] StateLabel
- [x] StyledOcticon
- [x] Text
- [x] TextInput
- [x] Tooltip
- [x] UnderlineNav
- [x] theme

Closes #389 

I think it might be worth having a discussion on whether the package itself should be written in TypeScript, but that would be a much bigger change and this gets us 100% of the way there for all consumers.

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
