### PR TITLE
Export themeGet

### DIFF
--- a/src/__tests__/themeGet.js
+++ b/src/__tests__/themeGet.js
@@ -1,0 +1,16 @@
+import {themeGet} from '..'
+
+describe('themeGet', () => {
+  it('acccepts theme prop', () => {
+    expect(themeGet('example')({theme: {example: 'test'}})).toBe('test')
+  })
+
+  it('allows theme prop to override primer theme', () => {
+    expect(themeGet('colors.gray.0')({theme: {colors: {gray: ['#f00']}}})).toBe('#f00')
+  })
+
+  it('uses primer theme as fallback', () => {
+    expect(themeGet('colors.gray.1')({})).toBe('#f6f8fa')
+    expect(themeGet('colors.gray.1')({theme: {colors: {foo: 'bar'}}})).toBe('#f6f8fa')
+  })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export {default as theme} from './theme'
+export {get as themeGet} from './constants'
 export {default as BaseStyles} from './BaseStyles'
 
 // Layout


### PR DESCRIPTION
Exports the [`get`](https://github.com/primer/components/blob/master/src/constants.js#L8) function as `themeGet`. Exporting `themeGet` will make it easier for people to use the Primer theme with styled-components. 

## Usage

```jsx
import {themeGet} from '@primer/components'
import styled from 'styled-components'

const Example = styled.div`
  color: ${themeGet('colors.gray.7')};
`
```

Creating components in this way allows users to override theme values with `ThemeProvider` if necessary.

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
