### PR TITLE
Button link styles

### DIFF
--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -23,6 +23,7 @@ const getButtonStyles = theme => {
       border: 1px solid ${get('colors.button.border')(theme)};
       border-radius: 0.25em;
       appearance: none;
+      text-decoration: none;
 
       &:hover {
         background-color: ${get('colors.button.hoverBg')(theme)};

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -26,6 +26,8 @@ exports[`Dropdown matches the snapshots 1`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   font-size: 14px;
 }
 
@@ -160,6 +162,8 @@ exports[`Dropdown matches the snapshots 2`] = `
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
   font-size: 14px;
 }
 


### PR DESCRIPTION
This PR removes text decoration on buttons, so that when `as='a'` is passed, the text does not get underlined. Thanks for the heads up @LinusU!

Closes: #502 