### PR TITLE
Add TypeScript definitions for Dialog component

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -274,6 +274,14 @@ declare module '@primer/components' {
   export const UnderlineNav: React.FunctionComponent<UnderlineNavProps>
 
   export const theme: Object
+
+  export interface DialogProps extends CommonProps {
+    title: string
+    isOpen: boolean
+    onDismiss: () => unknown
+  }
+
+  export const Dialog: React.FunctionComponent<DialogProps>
 }
 
 declare module '@primer/components/src/Box' {
@@ -418,4 +426,8 @@ declare module '@primer/components/src/UnderlineNav' {
 declare module '@primer/components/src/theme' {
   import {theme} from '@primer/components'
   export default theme
+}
+declare module '@primer/components/src/Dialog' {
+  import {Dialog} from '@primer/components'
+  export default Dialog
 }


### PR DESCRIPTION
This PR adds the TypeScript definitions for the `Dialog` component, which were missing.

#### Merge checklist
- [ ] Changed base branch to release branch
- [x] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
