### PR TITLE
Allow usage with compatible versions of octicons

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@primer/octicons-react": "9.0.0",
+    "@primer/octicons-react": "^9.0.0",
     "@reach/dialog": "0.2.9",
     "@styled-system/prop-types": "5.0.5",
     "@styled-system/theme-get": "5.0.5",


### PR DESCRIPTION
I'm trying to use the Skip icon from Octicons 9.1.0, but when adding that dependency to my project I get a duplication off Octicons and this library is still pulling in the old version.

This PR changes the range on the dependency to allow all 9.x.x versions of Octicons to be installed together with this package.

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge