### PR TITLE
Use 'exit 0' for neutral status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm test
 
       - name: Publish to the npm registry
-        uses: "primer/publish@v1.0.0"
+        uses: "primer/publish@c047b7c2646dd34b9f26a3e6a52c6393c07d7d52"
         with:
           args: "-- --unsafe-perm --allow-same-version"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm test
 
       - name: Publish to the npm registry
-        uses: "primer/publish@c047b7c2646dd34b9f26a3e6a52c6393c07d7d52"
+        uses: "primer/publish@2.0.0"
         with:
           args: "-- --unsafe-perm --allow-same-version"
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
         run: npm test
 
       - name: Publish to the npm registry
-        uses: "primer/publish@2.0.0"
+        uses: "primer/publish@v2.0.0"
         with:
           args: "-- --unsafe-perm --allow-same-version"
         env:


### PR DESCRIPTION
When a package with the current version has already been published, don’t mark master builds as failed. See [primer/publish’s README.md#L7](https://github.com/primer/publish/blame/no-neutral-exit/README.md#L7) for details.