### PR TITLE
Fixing test warnings

### DIFF
--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -26,7 +26,7 @@ export function mount(component) {
  * ```
  */
 export function render(component) {
-  return renderer.create(mount(component)).toJSON()
+  return renderer.create(component).toJSON()
 }
 
 /**


### PR DESCRIPTION
Each time that a test used render() it would generate this warning:
```
Warning: Each child in a list should have a unique "key" prop. See https://fb.me/react-warning-keys for more information.
```

Example:  https://github.com/primer/components/pull/549/checks?check_run_id=230299317#step:6:11

By not using enzyme.mount in this call (since we're serializing to JSON anyway), this issue goes away. All of the tests still pass after this change, so I think it's safe, but feel free to let me know if there is a different reason why this needs to be there :)