### PR TITLE
Details polyfill + useEffect linting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3584,6 +3584,11 @@
         "repeat-string": "^1.5.4"
       }
     },
+    "details-element-polyfill": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz",
+      "integrity": "sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g=="
+    },
     "detect-newline": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "14.0.0",
+  "version": "14.1.0",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/styled-system": "5.1.1",
     "babel-plugin-macros": "2.4.2",
     "classnames": "^2.2.5",
+    "details-element-polyfill": "2.4.0",
     "nanoid": "2.0.0",
     "primer-colors": "1.0.1",
     "primer-markdown": "3.7.9",

--- a/src/Details.js
+++ b/src/Details.js
@@ -4,6 +4,13 @@ import styled from 'styled-components'
 import {COMMON} from './constants'
 import theme from './theme'
 
+// The <details> element is not yet supported in Edge so we have to use a polyfill.
+// We have to check if window is defined before importing the polyfill
+// so the code doesn’t run while pages build
+if (typeof window !== 'undefined') {
+  import('details-element-polyfill')
+}
+
 const DetailsReset = styled('details')`
   & > summary {
     list-style: none;

--- a/src/Details.js
+++ b/src/Details.js
@@ -28,7 +28,7 @@ function DetailsBase({children, overlay, render = getRenderer(children), default
   const ref = useRef(null)
 
   const closeMenu = useCallback(
-    (event) => {
+    event => {
       // only close the menu if we're clicking outside
       if (event && event.target.closest('details') !== ref.current) {
         setOpen(false)

--- a/src/Details.js
+++ b/src/Details.js
@@ -1,4 +1,4 @@
-import React, {useState, useEffect, useRef} from 'react'
+import React, {useState, useEffect, useCallback, useRef} from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {COMMON} from './constants'
@@ -27,6 +27,17 @@ function DetailsBase({children, overlay, render = getRenderer(children), default
   const [open, setOpen] = useState(defaultOpen)
   const ref = useRef(null)
 
+  const closeMenu = useCallback(
+    (event) => {
+      // only close the menu if we're clicking outside
+      if (event && event.target.closest('details') !== ref.current) {
+        setOpen(false)
+        document.removeEventListener('click', closeMenu)
+      }
+    },
+    [ref]
+  )
+
   useEffect(() => {
     if (overlay && open) {
       document.addEventListener('click', closeMenu)
@@ -34,18 +45,10 @@ function DetailsBase({children, overlay, render = getRenderer(children), default
         document.removeEventListener('click', closeMenu)
       }
     }
-  }, [open, overlay])
+  }, [open, overlay, closeMenu])
 
   function toggle(event) {
     setOpen(event.target.open)
-  }
-
-  function closeMenu(event) {
-    // only close the menu if we're clicking outside
-    if (event && event.target.closest('details') !== ref.current) {
-      setOpen(false)
-      document.removeEventListener('click', closeMenu)
-    }
   }
 
   return (


### PR DESCRIPTION
This PR adds the Details polyfill, and fixes up a few linting errors on the `useEffect` call - `closeMenu` has to be set as a dependency even though it's a static function call, but adding it as a dep gives me this error: `The 'closeMenu' function makes the dependencies of useEffect Hook (at line 37) change on every render. To fix this, wrap the 'closeMenu' definition into its own useCallback() Hook` so I've wrapped it in a `useCallback`

This PR also bumps the version to 14.1.0