### PR TITLE
Fix borderColor property for BorderBox

### DIFF
--- a/src/BorderBox.js
+++ b/src/BorderBox.js
@@ -8,7 +8,8 @@ const BorderBox = styled(Box)(BORDER)
 
 BorderBox.defaultProps = {
   theme,
-  border: '1px solid',
+  borderWidth: 1,
+  borderStyle: 'solid',
   borderColor: 'gray.2',
   borderRadius: 1
 }


### PR DESCRIPTION
First of all, thank you folks for Primer components.
I noticed `borderColor` can't be changed independently and figured out quick fix.
Though, I'm marking this PR as draft since you're planning more changes for `BorderBox`.
Thank you.

#### If development process was changed
Description of changes

- [ ] Updated README

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
