### PR TITLE
Fix Details component open property

### DIFF
--- a/src/Details.js
+++ b/src/Details.js
@@ -23,8 +23,8 @@ function getRenderer(children) {
   return typeof children === 'function' ? children : () => children
 }
 
-function DetailsBase({children, overlay, render = getRenderer(children), defaultOpen = false, ...rest}) {
-  const [open, setOpen] = useState(defaultOpen)
+function DetailsBase({children, overlay, render = getRenderer(children), open: defaultOpen, ...rest}) {
+  const [open, setOpen] = useState(!!defaultOpen)
   const ref = useRef(null)
 
   const closeMenu = useCallback(
@@ -68,7 +68,7 @@ Details.defaultProps = {
 Details.propTypes = {
   children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]),
   className: PropTypes.string,
-  defaultOpen: PropTypes.bool,
+  open: PropTypes.bool,
   overlay: PropTypes.bool,
   render: PropTypes.func,
   theme: PropTypes.object,

--- a/src/__tests__/Details.js
+++ b/src/__tests__/Details.js
@@ -57,7 +57,7 @@ describe('Details', () => {
     wrapper.unmount()
   })
 
-  xit('Does not toggle or prevent click events when you click inside', () => {
+  it('Does not toggle or prevent click events when you click inside', () => {
     const wrapper = mount(
       <Details open>
         {({open}) => (


### PR DESCRIPTION
#499 introduced what appears to be either a bug or an unnoticed/undocumented breaking change:

With #499, the `Details` component instead of using an `open` property to open/show the contents on initial mount, it now uses a `defaultOpen` property.

I've assumed that this is a bug instead of a breaking change, since there's no mention of this [on the breaking changes list](https://github.com/primer/components/releases/tag/v14.0.0). Also [the docs](https://github.com/primer/components/blob/b5835716e1cf65e7ddcd6082d257a7c4769ac5b7/docs/content/Details.md#component-props), the [Typescript definitions](https://github.com/primer/components/blob/2888c48dcff0fc5afd9fc55c38a193d4b9c49f6c/index.d.ts#L107) and the [tests](https://github.com/primer/components/blob/2888c48dcff0fc5afd9fc55c38a193d4b9c49f6c/src/__tests__/Details.js#L62) are referring to `open` instead of `defaultOpen` (in fact I could reenable that last test thanks to this change).

Alternatively, if we want to stick to `defaultOpen` (which to be honest I think it's a better property name), I can change this PR to update docs/tests/TS types. Let me know your preference 😃

#### Merge checklist
- [x] Changed base branch to release branch
- [x] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
