### PR TITLE
Add readOnly property to TextInput

### DIFF
--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -25,6 +25,7 @@ TextInput components get `COMMON` system props. Read our [System Props](/system-
 | name | String | | Sets the `name` attribute on the element |
 | onChange | Function | | Function to be called when content in Input changes |
 | placeholder | String | | Sets the placeholder text |
+| readOnly | Boolean | | Sets the `readonly` attribute on the element |
 | required | Boolean | | Sets the `required` attribute on the element |
 | size | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
 | value | String | | Current value of the Input. |

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -76,6 +76,7 @@ TextInput.propTypes = {
   name: PropTypes.string,
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
+  readOnly: PropTypes.bool,
   required: PropTypes.bool,
   size: PropTypes.oneOf(['small', 'large']),
   theme: PropTypes.object,


### PR DESCRIPTION
This adds prop type and documentation for the `readOnly` property (which sets the `readonly` attribute on the `<input />`).

Note that the property is already there and working, just not documented which is what this PR addresses.

You might note that the property is called `readOnly`, whereas the HTML/DOM attribute is called `readonly`. This comes from React and is the same thing as `onClick` vs `onclick`...

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
