### PR TITLE
Increase specificity for ButtonGroup children

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "14.0.0",
+  "version": "14.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "14.2.2",
+  "version": "14.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "14.3.0",
+  "version": "14.3.1",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "14.2.1",
+  "version": "14.2.2",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -4,7 +4,7 @@ import Box from './Box'
 const ButtonGroup = styled(Box)`
   vertical-align: middle;
 
-  & > * {
+  && > * {
     position: relative;
     border-right-width: 0;
     border-radius: 0;


### PR DESCRIPTION
This PR increases the specificity of the `ButtonGroup` child styles so that components styled from `Button` all render with the correct border styles.

**Before**

![image](https://user-images.githubusercontent.com/189606/66068723-fb47e900-e502-11e9-9bdb-e86074cd214b.png)

**After**

![image](https://user-images.githubusercontent.com/189606/66068631-c76cc380-e502-11e9-8024-ddea82ec40f7.png)

Fixes #570

#### Merge checklist
- [x] Changed ~base branch to release branch~ `package.json` version
- [x] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari (ButtonGroup is already broken in Safari; see #528)
- [x] Tested in Edge
