### PR TITLE
Change 'size' props to 'variant'

### DIFF
--- a/docs/content/Buttons.md
+++ b/docs/content/Buttons.md
@@ -30,13 +30,14 @@ To create a button group, wrap `Button` elements in the `ButtonGroup` element. `
 
 ## Component props
 
+Props other than the ones listed here are forwarded to the underlying React `button` component.
+
 ### Button
 | Prop name | Type | Default | Description |
 | :- | :- | :-: | :- |
 | as | String | `button` | sets the HTML tag for the component |
-| disabled | Boolean |  | sets the `disabled` attribute on the Button |
-| onClick | Function | | function to be called when Button is clicked |
-| size | String | | use `sm` for a small Button, or `large` for a large Button
+| fontSize | Number or String | | explicitly sets the font size for the Button text; overrides any value for the `variant` prop |
+| variant | String | 'medium' | a value of `small`, `medium`, or `large` results in smaller or larger Button text size; no effect if `fontSize` prop is set |
 
 ### ButtonGroup
 `ButtonGroup` has access to the same props as `Box`

--- a/docs/content/Buttons.md
+++ b/docs/content/Buttons.md
@@ -30,7 +30,7 @@ To create a button group, wrap `Button` elements in the `ButtonGroup` element. `
 
 ## Component props
 
-Props other than the ones listed here are forwarded to the underlying React `button` component.
+Native `<button>` HTML attributes are forwarded to the underlying React `button` component and are not listed below.
 
 ### Button
 | Prop name | Type | Default | Description |

--- a/docs/content/CircleBadge.md
+++ b/docs/content/CircleBadge.md
@@ -23,7 +23,9 @@ CircleBadge and CircleBadge.Icon components get `COMMON` system props. Read our 
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |
 | as | String | `div` | sets the HTML tag for the component |
-| size | String or Number | | Use `small`, `medium`, or `large` for default sizes, or provide a custom size |
+| inline | Boolean | false | Styles the badge to display inline |
+| size | Number | | sets the size of the badge in pixels; overrides any value for `variant` prop when set |
+| variant | String | 'medium' | a value of `small`, `medium`, or `large` creates a smaller or larger badge; no effect if `size` prop is set |
 
 ### CircleBadge.Icon
 CircleBadge.Icon components do not receive any additional props besides `COMMON` system props.

--- a/docs/content/Label.md
+++ b/docs/content/Label.md
@@ -21,6 +21,6 @@ Label components get `COMMON` system props. Read our [System Props](/system-prop
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |
 | outline | Boolean | | Creates an outline style label |
-| size | String | 'medium' | Can be one of `small`, `medium` (default), `large` or `xl` .
+| variant | String | 'medium' | Can be one of `small`, `medium` (default), `large` or `xl` .
 | dropshadow | Boolean | | Adds a dropshadow to the label |
 | bg | String | 'gray.5' | Part of the `COMMON` system props, used to change the background of the label.

--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -6,7 +6,9 @@ TextInput is a form component to add default styling to the native text input. D
 ## Default example
 
 ```jsx live
-<TextInput aria-label="Zipcode" name="zipcode" />
+<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block variant="small"/>
+<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block />
+<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block variant="large" />
 ```
 
 ## System props
@@ -26,5 +28,5 @@ TextInput components get `COMMON` system props. Read our [System Props](/system-
 | onChange | Function | | Function to be called when content in Input changes |
 | placeholder | String | | Sets the placeholder text |
 | required | Boolean | | Sets the `required` attribute on the element |
-| size | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
+| variant | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
 | value | String | | Current value of the Input. |

--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -6,9 +6,7 @@ TextInput is a form component to add default styling to the native text input. D
 ## Default example
 
 ```jsx live
-<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block variant="small"/>
-<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block />
-<TextInput aria-label="Zipcode" name="zipcode" placeholder="Hello there" block variant="large" />
+<TextInput aria-label="Zipcode" name="zipcode" placeholder="Zipcode" autocomplete="postal-code" />
 ```
 
 ## System props

--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -15,7 +15,7 @@ TextInput components get `COMMON` system props. Read our [System Props](/system-
 
 ## Component props
 
-Props other than the ones listed here are forwarded to the underlying React `input` component.
+Native `<input>` attributes are forwarded to the underlying React `input` component and are not listed below.
 
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |

--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -6,7 +6,7 @@ TextInput is a form component to add default styling to the native text input. D
 ## Default example
 
 ```jsx live
-<TextInput aria-label="Zipcode" name="zipcode" placeholder="Zipcode" autocomplete="postal-code" />
+<TextInput aria-label="Zipcode" name="zipcode" placeholder="Zipcode" autoComplete="postal-code" />
 ```
 
 ## System props
@@ -15,16 +15,9 @@ TextInput components get `COMMON` system props. Read our [System Props](/system-
 
 ## Component props
 
+Props other than the ones listed here are forwarded to the underlying React `input` component.
+
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |
-| autocomplete | String | | Allows user to set `autocomplete` attribute on input. See [MDN docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-autocomplete) for attribute documentation. |
-| aria-label | String | | Label that describes the input for screen reader users |
 | block | Boolean | | Adds `display: block` to element |
-| disabled | Boolean | | Sets the `disabled` attribute on the element |
-| id | String | | Sets the `id` attribute on the element |
-| name | String | | Sets the `name` attribute on the element |
-| onChange | Function | | Function to be called when content in Input changes |
-| placeholder | String | | Sets the placeholder text |
-| required | Boolean | | Sets the `required` attribute on the element |
 | variant | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
-| value | String | | Current value of the Input. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -119,8 +119,8 @@ declare module '@primer/components' {
     extends BaseProps,
       CommonProps,
       Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
-    grouped?: boolean
-    size?: 'sm' | 'large'
+    fontSize?: number
+    variant?: 'small' | 'medium' | 'large'
   }
 
   export const ButtonPrimary: React.FunctionComponent<ButtonProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -153,7 +153,9 @@ declare module '@primer/components' {
   export const BranchName: React.FunctionComponent<BranchNameProps>
 
   export interface CircleBadgeProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
-    size?: string | number
+    inline?: boolean
+    size?: number
+    variant?: 'small' | 'medium' | 'large'
   }
 
   export const CircleBadge: React.FunctionComponent<CircleBadgeProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -267,7 +267,6 @@ declare module '@primer/components' {
   export interface TextInputProps
     extends CommonProps, StyledSystem.WidthProps,
       Omit<React.InputHTMLAttributes<HTMLInputElement>, 'color' | 'size'> {
-    autocomplete?: string
     block?: boolean
     variant?: 'small' | 'large'
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -214,7 +214,7 @@ declare module '@primer/components' {
 
   export interface LabelProps extends CommonProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {
     outline?: boolean
-    size?: 'small' | 'medium' | 'large' | 'xl'
+    variant?: 'small' | 'medium' | 'large' | 'xl'
     dropshadow?: boolean
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -269,7 +269,7 @@ declare module '@primer/components' {
       Omit<React.InputHTMLAttributes<HTMLInputElement>, 'color' | 'size'> {
     autocomplete?: string
     block?: boolean
-    size?: 'small' | 'large'
+    variant?: 'small' | 'large'
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/src/AvatarStack.js
+++ b/src/AvatarStack.js
@@ -1,10 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled, {css} from 'styled-components'
+import styled from 'styled-components'
 import {get, COMMON} from './constants'
 import theme from './theme'
 
-const alignRightStyles = css`
+const alignRightStyles = theme => {
+  return `
     right: 0;
     flex-direction: row-reverse;
 
@@ -14,14 +15,14 @@ const alignRightStyles = css`
     }
 
     .AvatarItem-more {
-      background: ${get('colors.gray.3')};
+      background: ${get('colors.gray.3')(theme)};
 
       &::before {
         width: 5px;
       }
 
       &::after {
-        background: ${get('colors.gray.1')};
+        background: ${get('colors.gray.1')(theme)};
         width: 2px;
       }
     }
@@ -30,9 +31,10 @@ const alignRightStyles = css`
       margin-right: 0;
       margin-left: -11px;
       border-right: 0;
-      border-left: ${get('borders.1')} ${get('colors.white')};
+      border-left: ${get('borders.1')(theme)} ${get('colors.white')(theme)};
     }
   `
+}
 
 const transformChildren = children => {
   const count = children.length
@@ -133,7 +135,7 @@ const AvatarStackBody = styled.span`
       background: ${get('colors.gray.3')};
     }
   }
-  ${props => (props.alignRight ? alignRightStyles : '')}
+  ${props => (props.alignRight ? alignRightStyles(props.theme) : '')}
 `
 const AvatarStack = ({children = [], alignRight, ...rest}) => {
   return (

--- a/src/AvatarStack.js
+++ b/src/AvatarStack.js
@@ -1,11 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, {css} from 'styled-components'
 import {get, COMMON} from './constants'
 import theme from './theme'
 
-const alignRightStyles = theme => {
-  return `
+const alignRightStyles = css`
     right: 0;
     flex-direction: row-reverse;
 
@@ -15,14 +14,14 @@ const alignRightStyles = theme => {
     }
 
     .AvatarItem-more {
-      background: ${get('colors.gray.3')(theme)};
+      background: ${get('colors.gray.3')};
 
       &::before {
         width: 5px;
       }
 
       &::after {
-        background: ${get('colors.gray.1')(theme)};
+        background: ${get('colors.gray.1')};
         width: 2px;
       }
     }
@@ -31,10 +30,9 @@ const alignRightStyles = theme => {
       margin-right: 0;
       margin-left: -11px;
       border-right: 0;
-      border-left: ${get('borders.1')(theme)} ${get('colors.white')(theme)};
+      border-left: ${get('borders.1')} ${get('colors.white')};
     }
   `
-}
 
 const transformChildren = children => {
   const count = children.length
@@ -135,7 +133,7 @@ const AvatarStackBody = styled.span`
       background: ${get('colors.gray.3')};
     }
   }
-  ${props => (props.alignRight ? alignRightStyles(props.theme) : '')}
+  ${props => (props.alignRight ? alignRightStyles : '')}
 `
 const AvatarStack = ({children = [], alignRight, ...rest}) => {
   return (

--- a/src/Button.js
+++ b/src/Button.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import {COMMON, get} from './constants'
 import theme from './theme'
 import buttonStyles from './ButtonStyles'
-import {compose, system, layout} from 'styled-system'
+import {compose, layout, fontSize} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 
 const fontSizeVariants = {
@@ -23,13 +23,7 @@ const Button = styled.button.attrs(({disabled, onClick}) => ({
   ${buttonStyles}
   ${variants}
   ${compose(
-    system({
-      fontSize: {
-        property: 'fontSize',
-        cssProperty: 'fontSize',
-        scale: 'fontSizes'
-      }
-    }),
+    fontSize,
     COMMON,
     layout
   )}
@@ -45,7 +39,7 @@ Button.propTypes = {
   as: PropTypes.oneOfType([PropTypes.oneOf(['button', 'a', 'summary', 'input']), PropTypes.func]),
   children: PropTypes.node,
   disabled: PropTypes.bool,
-  fontSize: PropTypes.number,
+  fontSize: systemPropTypes.fontSize,
   onClick: PropTypes.func,
   theme: PropTypes.object,
   variant: PropTypes.oneOf(['small', 'medium', 'large']),

--- a/src/Button.js
+++ b/src/Button.js
@@ -2,38 +2,53 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {COMMON, get} from './constants'
 import theme from './theme'
-import getButtonStyles from './ButtonStyles'
-import {layout} from 'styled-system'
+import buttonStyles from './ButtonStyles'
+import {compose, system, layout} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 
-function fontSize({size = '14px', ...props}) {
-  return {
-    fontSize:
-      size === 'sm' ? `${get('fontSizes.0')(props)}px` : size === 'large' ? `${get('fontSizes.2')(props)}px` : size
-  }
+const fontSizeVariants = {
+  small: get('fontSizes.0'),
+  medium: get('fontSizes.1'),
+  large: get('fontSizes.2')
 }
 
-const Button = styled.button.attrs(props => ({
-  onClick: props.disabled ? undefined : props.onClick,
-  className: props.disabled ? 'disabled' : ''
+const variants = ({variant, theme}) => {
+  const getter = fontSizeVariants[variant] || fontSizeVariants['medium']
+  return {fontSize: getter(theme)}
+}
+
+const Button = styled.button.attrs(({disabled, onClick}) => ({
+  onClick: disabled ? undefined : onClick
 }))`
-  ${props => (props.theme ? getButtonStyles(props.theme) : '')};
-  ${fontSize};
-  ${COMMON};
-  ${layout};
+  ${buttonStyles}
+  ${variants}
+  ${compose(
+    system({
+      fontSize: {
+        property: 'fontSize',
+        cssProperty: 'fontSize',
+        scale: 'fontSizes'
+      }
+    }),
+    COMMON,
+    layout
+  )}
 `
 
 Button.defaultProps = {
-  theme
+  fontSize: undefined,
+  theme,
+  variant: 'medium'
 }
 
 Button.propTypes = {
   as: PropTypes.oneOfType([PropTypes.oneOf(['button', 'a', 'summary', 'input']), PropTypes.func]),
   children: PropTypes.node,
   disabled: PropTypes.bool,
+  fontSize: PropTypes.number,
   onClick: PropTypes.func,
-  size: PropTypes.oneOf(['sm', 'large']),
   theme: PropTypes.object,
+  variant: PropTypes.oneOf(['small', 'medium', 'large']),
   ...COMMON.propTypes,
   ...systemPropTypes.layout
 }

--- a/src/Button.js
+++ b/src/Button.js
@@ -30,7 +30,6 @@ const Button = styled.button.attrs(({disabled, onClick}) => ({
 `
 
 Button.defaultProps = {
-  fontSize: undefined,
   theme,
   variant: 'medium'
 }

--- a/src/Button.js
+++ b/src/Button.js
@@ -3,19 +3,22 @@ import styled from 'styled-components'
 import {COMMON, get} from './constants'
 import theme from './theme'
 import buttonStyles from './ButtonStyles'
-import {compose, layout, fontSize} from 'styled-system'
+import {compose, variant, layout, fontSize} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 
-const fontSizeVariants = {
-  small: get('fontSizes.0'),
-  medium: get('fontSizes.1'),
-  large: get('fontSizes.2')
-}
-
-const variants = ({variant, theme}) => {
-  const getter = fontSizeVariants[variant] || fontSizeVariants['medium']
-  return {fontSize: getter(theme)}
-}
+const variants = variant({
+  variants: {
+    small: {
+      fontSize: 0,
+    },
+    medium: {
+      fontSize: 1,
+    },
+    large: {
+      fontSize: 2,
+    }
+  }
+})
 
 const Button = styled.button.attrs(({disabled, onClick}) => ({
   onClick: disabled ? undefined : onClick

--- a/src/Button.js
+++ b/src/Button.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import {COMMON, get} from './constants'
+import {COMMON} from './constants'
 import theme from './theme'
 import buttonStyles from './ButtonStyles'
 import {compose, variant, layout, fontSize} from 'styled-system'
@@ -9,13 +9,13 @@ import systemPropTypes from '@styled-system/prop-types'
 const variants = variant({
   variants: {
     small: {
-      fontSize: 0,
+      fontSize: 0
     },
     medium: {
-      fontSize: 1,
+      fontSize: 1
     },
     large: {
-      fontSize: 2,
+      fontSize: 2
     }
   }
 })

--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -1,93 +1,88 @@
+import {css} from 'styled-components'
 import {get} from './constants'
 
-const getButtonStyles = theme => {
-  return `
-      position: relative;
-      display: inline-block;
-      padding: 6px 12px;
-      color: ${get('colors.gray.9')(theme)};
-      background-color: ${get('colors.gray.1')(theme)};
-      background-image: linear-gradient(-180deg, ${get('colors.gray.0')(theme)} 0%, ${get('colors.button.bg2')(
-    theme
-  )} 90%);
-      font-size: ${get('fontSizes.1')(theme)}px;
-      font-weight: ${get('fontWeights.bold')(theme)};
-      line-height: 20px;
-      white-space: nowrap;
-      vertical-align: middle;
-      cursor: pointer;
-      user-select: none;
-      background-repeat: repeat-x;
-      background-position: -1px -1px;
-      background-size: 110% 110%;
-      border: 1px solid ${get('colors.button.border')(theme)};
-      border-radius: 0.25em;
-      appearance: none;
-      text-decoration: none;
+export default css`
+  position: relative;
+  display: inline-block;
+  padding: 6px 12px;
+  color: ${get('colors.gray.9')};
+  background-color: ${get('colors.gray.1')};
+  background-image: linear-gradient(-180deg, ${get('colors.gray.0')} 0%, ${get('colors.button.bg2')} 90%);
+  font-size: ${get('fontSizes.1')}px;
+  font-weight: ${get('fontWeights.bold')};
+  line-height: 20px;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  background-repeat: repeat-x;
+  background-position: -1px -1px;
+  background-size: 110% 110%;
+  border: 1px solid ${get('colors.button.border')};
+  border-radius: 0.25em;
+  appearance: none;
+  text-decoration: none;
 
-      &:hover {
-        background-color: ${get('colors.button.hoverBg')(theme)};
-        background-image: linear-gradient(-180deg, ${get('colors.button.bg2')(theme)} 0%, ${get(
-    'colors.button.hoverBg'
-  )(theme)} 90%);
-        background-position: -0.5em center;
-        border-color: ${get('colors.blackfade35')(theme)};
-        text-decoration: none;
-        background-repeat: repeat-x;
+  &:hover {
+    background-color: ${get('colors.button.hoverBg')};
+    background-image: linear-gradient(-180deg, ${get('colors.button.bg2')} 0%, ${get('colors.button.hoverBg')} 90%);
+    background-position: -0.5em center;
+    border-color: ${get('colors.blackfade35')};
+    text-decoration: none;
+    background-repeat: repeat-x;
+  }
+
+  &:active {
+    background-color: ${get('colors.button.activeBg')};
+    background-image: none;
+    box-shadow: ${get('colors.blackfade15')} 0px 0.15em 0.3em inset;
+    border-color: ${get('colors.button.border')}; //convert black to rbg here
+  }
+
+  ${props =>
+    props.disabled &&
+    css`
+      color: ${get('colors.button.disabledColor')} !important;
+      background-color: ${get('colors.gray.1')} !important;
+      background-image: none !important;
+      border-color: ${get('colors.blackfade20')} !important;
+      box-shadow: none !important;
+      cursor: default;
+    `}
+
+  &:focus {
+    outline: none;
+    box-shadow: ${get('colors.button.focusShadow')} 0px 0px 0px 0.2em;
+  }
+
+  &.grouped {
+    position: relative;
+    border-right-width: 0;
+    border-radius: 0;
+
+    &:first-child {
+      border-top-left-radius: ${get('radii.1')}px;
+      border-bottom-left-radius: ${get('radii.1')}px;
+    }
+
+    &:last-child {
+      border-right-width: 1px;
+      border-top-right-radius: ${get('radii.1')}px;
+      border-bottom-right-radius: ${get('radii.1')}px;
+    }
+
+    &:focus,
+    &:active,
+    &:hover {
+      border-right-width: 1px;
+
+      + .grouped {
+        border-left-width: 0;
       }
-
-      &:active {
-        background-color: ${get('colors.button.activeBg')(theme)};
-        background-image: none;
-        box-shadow: ${get('colors.blackfade15')(theme)} 0px 0.15em 0.3em inset;
-        border-color: ${get('colors.button.border')(theme)}; //convert black to rbg here
-      }
-
-      &.disabled {
-        color: ${get('colors.button.disabledColor')(theme)}!important;
-        background-color: ${get('colors.gray.1')(theme)}!important;
-        background-image: none!important;
-        border-color: ${get('colors.blackfade20')(theme)}!important;
-        box-shadow: none!important;
-        cursor: default;
-      }
-
-      &:focus {
-        outline: none;
-        box-shadow: ${get('colors.button.focusShadow')(theme)} 0px 0px 0px 0.2em;
-      }
-
-      &.grouped {
-        position: relative;
-        border-right-width: 0;
-        border-radius: 0;
-
-        &:first-child {
-          border-top-left-radius:  ${get('radii.1')(theme)}px;
-          border-bottom-left-radius: ${get('radii.1')(theme)}px;
-        }
-
-        &:last-child {
-          border-right-width: 1px;
-          border-top-right-radius: ${get('radii.1')(theme)}px;
-          border-bottom-right-radius: ${get('radii.1')(theme)}px;
-        }
-
-        &:focus,
-        &:active,
-        &:hover {
-          border-right-width: 1px;
-
-          + .grouped {
-            border-left-width: 0;
-          }
-        }
-      }
-      &:focus,
-      &:active {
-        z-index: 1;
-      }
-    `
-}
-
-export default getButtonStyles
+    }
+  }
+  &:focus,
+  &:active {
+    z-index: 1;
+  }
+`

--- a/src/CircleBadge.js
+++ b/src/CircleBadge.js
@@ -39,7 +39,6 @@ CircleBadge.Icon = Icon
 
 CircleBadge.defaultProps = {
   inline: false,
-  size: undefined,
   theme,
   variant: 'medium'
 }

--- a/src/CircleBadge.js
+++ b/src/CircleBadge.js
@@ -4,25 +4,24 @@ import Octicon from '@primer/octicons-react'
 import {COMMON, get} from './constants'
 import theme from './theme'
 
-const sizeMapper = (size = 'medium') => {
-  if (typeof size === 'number') return size
-  const map = {
-    small: 56,
-    medium: 96,
-    large: 128
-  }
-  return map[size]
+const isNumeric = n => !isNaN(parseFloat(n)) && isFinite(n)
+
+const variantSizes = {
+  small: 56,
+  medium: 96,
+  large: 128
 }
 
-const sizeStyles = ({size}) => {
+const sizeStyles = ({size, variant}) => {
+  const calc = isNumeric(size) ? size : variantSizes[variant]
   return {
-    width: sizeMapper(size),
-    height: sizeMapper(size)
+    width: calc,
+    height: calc
   }
 }
 
 const CircleBadge = styled.div`
-  display: flex;
+  display: ${props => (props.inline ? 'inline-flex' : 'flex')};
   align-items: center;
   justify-content: center;
   background-color: ${get('colors.white')};
@@ -40,13 +39,17 @@ const Icon = styled(Octicon)`
 CircleBadge.Icon = Icon
 
 CircleBadge.defaultProps = {
+  inline: false,
+  size: undefined,
   theme,
-  size: 'medium'
+  variant: 'medium'
 }
 
 CircleBadge.propTypes = {
-  size: PropTypes.oneOfType([PropTypes.oneOf(['small', 'medium', 'large']), PropTypes.number]),
+  inline: PropTypes.bool,
+  size: PropTypes.number,
   theme: PropTypes.object,
+  variant: PropTypes.oneOf(['small', 'medium', 'large']),
   ...COMMON.propTypes
 }
 

--- a/src/CircleBadge.js
+++ b/src/CircleBadge.js
@@ -2,9 +2,8 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import Octicon from '@primer/octicons-react'
 import {COMMON, get} from './constants'
+import isNumeric from './utils/isNumeric'
 import theme from './theme'
-
-const isNumeric = n => !isNaN(parseFloat(n)) && isFinite(n)
 
 const variantSizes = {
   small: 56,

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,21 +1,20 @@
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import styled, {css} from 'styled-components'
 import {variant} from 'styled-system'
 import theme, {colors} from './theme'
-import {COMMON} from './constants'
+import {COMMON, get} from './constants'
 
-const outlineStyles = `
+const outlineStyles = css`
   margin-top: -1px; // offsets the 1px border
   margin-bottom: -1px; // offsets the 1px border
   font-weight: 400;
-  color: ${colors.gray[6]};
+  color: ${get('colors.gray.6')};
   background-color: transparent;
-  border: ${theme.borders[1]} ${colors.blackfade15};
+  border: ${get('borders.1')} ${get('colors.blackfade15')};
   box-shadow: none;
 `
 
 const sizeVariant = variant({
-  prop: 'size',
   variants: {
     small: {
       fontSize: 0,
@@ -43,8 +42,8 @@ const sizeVariant = variant({
 const Label = styled('span')`
   display: inline-block;
   font-weight: 600;
-  line-height: ${theme.lineHeights.condensedUltra};
-  color: ${colors.white};
+  line-height: ${get('lineHeights.condensedUltra')};
+  color: ${get('colors.white')};
   border-radius: 2px;
   &:hover {
     text-decoration: none;
@@ -57,13 +56,14 @@ const Label = styled('span')`
 Label.defaultProps = {
   theme,
   bg: 'gray.5',
-  size: 'medium'
+  variant: 'medium'
 }
 
 Label.propTypes = {
   dropshadow: PropTypes.bool,
   outline: PropTypes.bool,
   theme: PropTypes.object,
+  variant: PropTypes.oneOf(['small', 'medium', 'large', 'xl']),
   ...COMMON.propTypes
 }
 

--- a/src/Label.js
+++ b/src/Label.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import styled, {css} from 'styled-components'
 import {variant} from 'styled-system'
-import theme, {colors} from './theme'
+import theme from './theme'
 import {COMMON, get} from './constants'
 
 const outlineStyles = css`

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -10,13 +10,13 @@ const sizeVariants = variant({
   variants: {
     small: {
       minHeight: '28px',
-      px: 1,
+      px: 2,
       py: '3px',
       fontSize: 0,
       lineHeight: '20px'
     },
     large: {
-      px: 1,
+      px: 2,
       py: '10px',
       fontSize: 3
     }

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -1,26 +1,34 @@
-import React from 'react'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
-import styled from 'styled-components'
+import systemPropTypes from '@styled-system/prop-types'
+import styled, {css} from 'styled-components'
+import {variant, layout} from 'styled-system'
 import {COMMON, get} from './constants'
 import theme from './theme'
 
-function TextInputBase({autocomplete, theme, variant, block, className, ...rest}) {
-  const classes = classnames(className, 'form-control', {
-    'input-block': block,
-    'input-sm': variant === 'small',
-    'input-lg': variant === 'large'
-  })
-  const inputProps = {
-    className: classes,
-    autoComplete: autocomplete,
-    type: 'text',
-    ...rest
+const sizeVariants = variant({
+  variants: {
+    small: {
+      minHeight: '28px',
+      px: 1,
+      py: '3px',
+      fontSize: 0,
+      lineHeight: '20px'
+    },
+    large: {
+      px: 1,
+      py: '10px',
+      fontSize: 3
+    }
   }
-  return <input {...inputProps} />
-}
+})
 
-const TextInput = styled(TextInputBase)`
+const TextInput = styled.input.attrs(({autocomplete, theme, variant, block, className, ...rest}) => ({
+  className: classnames(className, 'form-control'),
+  autoComplete: autocomplete,
+  type: 'text',
+  ...rest
+}))`
   min-height: 34px;
   padding: 6px ${get('space.2')}px;
   font-size: ${get('fontSizes.2')}px;
@@ -41,29 +49,19 @@ const TextInput = styled(TextInputBase)`
     box-shadow: ${get('shadows.formControl')}, ${get('shadows.formControlFocus')};
   }
 
-  &.input-sm {
-    min-height: 28px;
-    padding-top: 3px;
-    padding-bottom: 3px;
-    font-size: $font-size-small;
-    line-height: 20px;
-  }
+  ${sizeVariants}
 
-  &.input-lg {
-    padding: $spacer-1 10px;
-    font-size: $h4-size;
-  }
-
-  &.input-block {
+  ${props => props.block && css`
     display: block;
     width: 100%;
-  }
+  `}
 
   // Ensures inputs don't zoom on mobile but are body-font size on desktop
   @media (max-width: ${get('breakpoints.1')}) {
     font-size: ${get('fontSizes.1')}px;
   }
   ${COMMON};
+  ${layout.width}
 `
 
 TextInput.defaultProps = {theme}
@@ -77,10 +75,11 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  size: PropTypes.oneOf(['small', 'large']),
+  variant: PropTypes.oneOf(['small', 'large']),
   theme: PropTypes.object,
   value: PropTypes.string,
-  ...COMMON.propTypes
+  ...COMMON.propTypes,
+  width: systemPropTypes.layout.width
 }
 
 export default TextInput

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -1,4 +1,3 @@
-import classnames from 'classnames'
 import PropTypes from 'prop-types'
 import systemPropTypes from '@styled-system/prop-types'
 import styled, {css} from 'styled-components'
@@ -23,9 +22,7 @@ const sizeVariants = variant({
   }
 })
 
-const TextInput = styled.input.attrs(({autocomplete, theme, variant, block, className, ...rest}) => ({
-  className: classnames(className, 'form-control'),
-  autoComplete: autocomplete,
+const TextInput = styled.input.attrs(({theme, variant, block, ...rest}) => ({
   type: 'text',
   ...rest
 }))`

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -51,10 +51,12 @@ const TextInput = styled.input.attrs(({autocomplete, theme, variant, block, clas
 
   ${sizeVariants}
 
-  ${props => props.block && css`
-    display: block;
-    width: 100%;
-  `}
+  ${props =>
+    props.block &&
+    css`
+      display: block;
+      width: 100%;
+    `}
 
   // Ensures inputs don't zoom on mobile but are body-font size on desktop
   @media (max-width: ${get('breakpoints.1')}) {
@@ -75,9 +77,9 @@ TextInput.propTypes = {
   onChange: PropTypes.func,
   placeholder: PropTypes.string,
   required: PropTypes.bool,
-  variant: PropTypes.oneOf(['small', 'large']),
   theme: PropTypes.object,
   value: PropTypes.string,
+  variant: PropTypes.oneOf(['small', 'large']),
   ...COMMON.propTypes,
   width: systemPropTypes.layout.width
 }

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -5,11 +5,11 @@ import styled from 'styled-components'
 import {COMMON, get} from './constants'
 import theme from './theme'
 
-function TextInputBase({autocomplete, theme, size, block, className, ...rest}) {
+function TextInputBase({autocomplete, theme, variant, block, className, ...rest}) {
   const classes = classnames(className, 'form-control', {
     'input-block': block,
-    'input-sm': size === 'small',
-    'input-lg': size === 'large'
+    'input-sm': variant === 'small',
+    'input-lg': variant === 'large'
   })
   const inputProps = {
     className: classes,

--- a/src/__tests__/Button.js
+++ b/src/__tests__/Button.js
@@ -24,21 +24,27 @@ describe('Button', () => {
     expect(Button).toImplementSystemProps(layout)
   })
 
+  it('preserves "onClick" prop', () => {
+    expect(render(<Button onClick={noop} />).props.onClick).toEqual(noop)
+  })
+
   it('respects width props', () => {
     expect(render(<Button width={200} />)).toHaveStyleRule('width', '200px')
   })
 
   it('respects the "disabled" prop', () => {
-    expect(render(<Button disabled />).props.disabled).toEqual(true)
+    const item = render(<Button disabled />)
+    expect(item.props.disabled).toEqual(true)
+    expect(item).toMatchSnapshot()
   })
 
-  it('respects the "size" prop', () => {
-    expect(render(<Button size="sm" />)).toHaveStyleRule('font-size', '12px')
-    expect(render(<Button size="large" />)).toHaveStyleRule('font-size', '16px')
+  it('respects the "variant" prop', () => {
+    expect(render(<Button variant="small" />)).toHaveStyleRule('font-size', '12px')
+    expect(render(<Button variant="large" />)).toHaveStyleRule('font-size', '16px')
   })
 
-  it('preserves "onClick" prop', () => {
-    expect(render(<Button onClick={noop} />).props.onClick).toEqual(noop)
+  it('respects the "fontSize" prop over the "variant" prop', () => {
+    expect(render(<Button variant="small" fontSize={20} />)).toHaveStyleRule('font-size', '20px')
   })
 })
 

--- a/src/__tests__/CircleBadge.js
+++ b/src/__tests__/CircleBadge.js
@@ -16,6 +16,18 @@ describe('CircleBadge', () => {
     expect(CircleBadge).toSetDefaultTheme()
   })
 
+  it('respects the inline prop', () => {
+    expect(render(<CircleBadge inline />)).toMatchSnapshot()
+  })
+
+  it('respects the variant prop', () => {
+    expect(render(<CircleBadge variant="large" />)).toMatchSnapshot()
+  })
+
+  it('uses the size prop to override the variant prop', () => {
+    expect(render(<CircleBadge variant="large" size={20} />)).toMatchSnapshot()
+  })
+
   it('implements system props', () => {
     expect(CircleBadge).toImplementSystemProps(COMMON)
   })

--- a/src/__tests__/Label.js
+++ b/src/__tests__/Label.js
@@ -12,6 +12,10 @@ describe('Label', () => {
     expect(render(<Label outline />)).toMatchSnapshot()
   })
 
+  it('respects the "variant" prop', () => {
+    expect(render(<Label variant="xl" />)).toMatchSnapshot()
+  })
+
   it('respects the "as" prop', () => {
     expect(render(<Label as="span" />).type).toEqual('span')
   })

--- a/src/__tests__/TextInput.js
+++ b/src/__tests__/TextInput.js
@@ -13,7 +13,7 @@ describe('TextInput', () => {
   })
 
   it('renders small', () => {
-    expect(render(<TextInput name="zipcode" size="small" />)).toMatchSnapshot()
+    expect(render(<TextInput name="zipcode" variant="small" />)).toMatchSnapshot()
   })
 
   it('has default theme', () => {
@@ -21,7 +21,7 @@ describe('TextInput', () => {
   })
 
   it('renders large', () => {
-    expect(render(<TextInput name="zipcode" size="large" />)).toMatchSnapshot()
+    expect(render(<TextInput name="zipcode" variant="large" />)).toMatchSnapshot()
   })
 
   it('renders block', () => {

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Button respects the "disabled" prop 1`] = `
+.c0 {
+  position: relative;
+  display: inline-block;
+  padding: 6px 12px;
+  color: #24292e;
+  background-color: #f6f8fa;
+  background-image: linear-gradient(-180deg,#fafbfc 0%,rgb(239,243,246) 90%);
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  background-repeat: repeat-x;
+  background-position: -1px -1px;
+  background-size: 110% 110%;
+  border: 1px solid rgba(27,31,35,0.2);
+  border-radius: 0.25em;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  color: rgba(36,41,46,0.4) !important;
+  background-color: #f6f8fa !important;
+  background-image: none !important;
+  border-color: rgba(27,31,35,0.20) !important;
+  box-shadow: none !important;
+  cursor: default;
+  font-size: 14px;
+}
+
+.c0:hover {
+  background-color: rgb(230,235,241);
+  background-image: linear-gradient(-180deg,rgb(239,243,246) 0%,rgb(230,235,241) 90%);
+  background-position: -0.5em center;
+  border-color: rgba(27,31,35,0.35);
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  background-repeat: repeat-x;
+}
+
+.c0:active {
+  background-color: rgb(233,236,239);
+  background-image: none;
+  box-shadow: rgba(27,31,35,0.15) 0px 0.15em 0.3em inset;
+  border-color: rgba(27,31,35,0.2);
+}
+
+.c0:focus {
+  outline: none;
+  box-shadow: rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
+}
+
+.c0.grouped {
+  position: relative;
+  border-right-width: 0;
+  border-radius: 0;
+}
+
+.c0.grouped:first-child {
+  border-top-left-radius: 3px;
+  border-bottom-left-radius: 3px;
+}
+
+.c0.grouped:last-child {
+  border-right-width: 1px;
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+.c0.grouped:focus,
+.c0.grouped:active,
+.c0.grouped:hover {
+  border-right-width: 1px;
+}
+
+.c0.grouped:focus + .grouped,
+.c0.grouped:active + .grouped,
+.c0.grouped:hover + .grouped {
+  border-left-width: 0;
+}
+
+.c0:focus,
+.c0:active {
+  z-index: 1;
+}
+
+<button
+  className="c0"
+  disabled={true}
+/>
+`;

--- a/src/__tests__/__snapshots__/CircleBadge.js.snap
+++ b/src/__tests__/__snapshots__/CircleBadge.js.snap
@@ -23,6 +23,84 @@ exports[`CircleBadge respects "as" prop 1`] = `
 
 <a
   className="c0"
-  size="medium"
+/>
+`;
+
+exports[`CircleBadge respects the inline prop 1`] = `
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 5px rgba(27,31,35,0.15);
+  width: 96px;
+  height: 96px;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`CircleBadge respects the variant prop 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 5px rgba(27,31,35,0.15);
+  width: 128px;
+  height: 128px;
+}
+
+<div
+  className="c0"
+/>
+`;
+
+exports[`CircleBadge uses the size prop to override the variant prop 1`] = `
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  background-color: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 5px rgba(27,31,35,0.15);
+  width: 20px;
+  height: 20px;
+}
+
+<div
+  className="c0"
+  size={20}
 />
 `;

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -48,15 +48,6 @@ exports[`Dropdown matches the snapshots 1`] = `
   border-color: rgba(27,31,35,0.2);
 }
 
-.c2.disabled {
-  color: rgba(36,41,46,0.4)!important;
-  background-color: #f6f8fa!important;
-  background-image: none!important;
-  border-color: rgba(27,31,35,0.20)!important;
-  box-shadow: none!important;
-  cursor: default;
-}
-
 .c2:focus {
   outline: none;
   box-shadow: rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
@@ -183,15 +174,6 @@ exports[`Dropdown matches the snapshots 2`] = `
   background-image: none;
   box-shadow: rgba(27,31,35,0.15) 0px 0.15em 0.3em inset;
   border-color: rgba(27,31,35,0.2);
-}
-
-.c2.disabled {
-  color: rgba(36,41,46,0.4)!important;
-  background-color: #f6f8fa!important;
-  background-image: none!important;
-  border-color: rgba(27,31,35,0.20)!important;
-  box-shadow: none!important;
-  cursor: default;
 }
 
 .c2:focus {

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -29,6 +29,30 @@ exports[`Label respects the "outline" prop 1`] = `
 
 <span
   className="c0"
-  size="medium"
+/>
+`;
+
+exports[`Label respects the "variant" prop 1`] = `
+.c0 {
+  display: inline-block;
+  font-weight: 600;
+  line-height: 1;
+  color: #fff;
+  border-radius: 2px;
+  font-size: 16px;
+  padding-left: 4px;
+  padding-right: 4px;
+  padding-top: 8px;
+  padding-bottom: 8px;
+  background-color: #6a737d;
+}
+
+.c0:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<span
+  className="c0"
 />
 `;

--- a/src/__tests__/__snapshots__/LabelGroup.js.snap
+++ b/src/__tests__/__snapshots__/LabelGroup.js.snap
@@ -57,19 +57,16 @@ exports[`BranchName matches snapshot 1`] = `
 >
   <span
     className="c1 LabelItem"
-    size="medium"
   >
     Default label
   </span>
   <span
     className="c1 LabelItem"
-    size="medium"
   >
     Darker gray label
   </span>
   <span
     className="c2 LabelItem"
-    size="medium"
   >
     Default outline label
   </span>

--- a/src/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/__tests__/__snapshots__/TextInput.js.snap
@@ -23,24 +23,6 @@ exports[`TextInput renders 1`] = `
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
 }
 
-.c0.input-sm {
-  min-height: 28px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  font-size: $font-size-small;
-  line-height: 20px;
-}
-
-.c0.input-lg {
-  padding: $spacer-1 10px;
-  font-size: $h4-size;
-}
-
-.c0.input-block {
-  display: block;
-  width: 100%;
-}
-
 @media (max-width:768px) {
   .c0 {
     font-size: 14px;
@@ -69,30 +51,14 @@ exports[`TextInput renders block 1`] = `
   border-radius: 3px;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset;
+  display: block;
+  width: 100%;
 }
 
 .c0:focus {
   border-color: #2188ff;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
-}
-
-.c0.input-sm {
-  min-height: 28px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  font-size: $font-size-small;
-  line-height: 20px;
-}
-
-.c0.input-lg {
-  padding: $spacer-1 10px;
-  font-size: $h4-size;
-}
-
-.c0.input-block {
-  display: block;
-  width: 100%;
 }
 
 @media (max-width:768px) {
@@ -102,7 +68,7 @@ exports[`TextInput renders block 1`] = `
 }
 
 <input
-  className="c0 form-control input-block"
+  className="c0 form-control"
   name="zipcode"
   type="text"
 />
@@ -123,30 +89,17 @@ exports[`TextInput renders large 1`] = `
   border-radius: 3px;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 20px;
 }
 
 .c0:focus {
   border-color: #2188ff;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
-}
-
-.c0.input-sm {
-  min-height: 28px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  font-size: $font-size-small;
-  line-height: 20px;
-}
-
-.c0.input-lg {
-  padding: $spacer-1 10px;
-  font-size: $h4-size;
-}
-
-.c0.input-block {
-  display: block;
-  width: 100%;
 }
 
 @media (max-width:768px) {
@@ -156,7 +109,7 @@ exports[`TextInput renders large 1`] = `
 }
 
 <input
-  className="c0 form-control input-lg"
+  className="c0 form-control"
   name="zipcode"
   type="text"
 />
@@ -177,30 +130,19 @@ exports[`TextInput renders small 1`] = `
   border-radius: 3px;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset;
+  min-height: 28px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  font-size: 12px;
+  line-height: 20px;
 }
 
 .c0:focus {
   border-color: #2188ff;
   outline: none;
   box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
-}
-
-.c0.input-sm {
-  min-height: 28px;
-  padding-top: 3px;
-  padding-bottom: 3px;
-  font-size: $font-size-small;
-  line-height: 20px;
-}
-
-.c0.input-lg {
-  padding: $spacer-1 10px;
-  font-size: $h4-size;
-}
-
-.c0.input-block {
-  display: block;
-  width: 100%;
 }
 
 @media (max-width:768px) {
@@ -210,7 +152,7 @@ exports[`TextInput renders small 1`] = `
 }
 
 <input
-  className="c0 form-control input-sm"
+  className="c0 form-control"
   name="zipcode"
   type="text"
 />

--- a/src/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/__tests__/__snapshots__/TextInput.js.snap
@@ -30,7 +30,7 @@ exports[`TextInput renders 1`] = `
 }
 
 <input
-  className="c0 form-control"
+  className="c0"
   name="zipcode"
   type="text"
 />
@@ -68,7 +68,7 @@ exports[`TextInput renders block 1`] = `
 }
 
 <input
-  className="c0 form-control"
+  className="c0"
   name="zipcode"
   type="text"
 />
@@ -109,7 +109,7 @@ exports[`TextInput renders large 1`] = `
 }
 
 <input
-  className="c0 form-control"
+  className="c0"
   name="zipcode"
   type="text"
 />
@@ -152,7 +152,7 @@ exports[`TextInput renders small 1`] = `
 }
 
 <input
-  className="c0 form-control"
+  className="c0"
   name="zipcode"
   type="text"
 />

--- a/src/utils/isNumeric.js
+++ b/src/utils/isNumeric.js
@@ -1,0 +1,3 @@
+export default function isNumeric(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n)
+}


### PR DESCRIPTION
#579, which upgrades `styled-system` and other dependencies, revealed some bugs in the way some props are handled. In particular, `size` is part of `styled-system`'s layout group, and adds `width` and `height` properties based on that prop. That means `size="medium"` translates to `width: "medium"; height: "medium"` which is clearly not correct.

To resolve this issue, we've decided to switch to using `variant` for these props. This is a breaking change, so this PR is targeting the Node 10 upgrade branch so it will all land together.