### PR TITLE
Support children in LabelGroup which without `mr`

### DIFF
--- a/src/LabelGroup.js
+++ b/src/LabelGroup.js
@@ -1,17 +1,17 @@
 import React from 'react'
 import styled from 'styled-components'
 import theme from './theme'
+import classnames from 'classnames'
 import {COMMON, get} from './constants'
 
 const transformChildren = children => {
   return React.Children.map(children, child => {
-    return React.cloneElement(child, {className: 'LabelItem'})
+    const classes = classnames(child.props['className'], 'LabelItem')
+    return React.cloneElement(child, {className: classes})
   })
 }
 
-const LabelGroup = styled.span.attrs(props => ({
-  children: transformChildren(props.children)
-}))`
+const StyledLabelGroup = styled.span`
   ${COMMON}
   & .LabelItem {
     margin-right: ${get('space.1')}px;
@@ -20,6 +20,8 @@ const LabelGroup = styled.span.attrs(props => ({
     margin-right: 0;
   }
 `
+
+const LabelGroup = ({children, ...rest}) => <StyledLabelGroup {...rest}>{transformChildren(children)}</StyledLabelGroup>
 
 LabelGroup.defaultProps = {
   theme

--- a/src/LabelGroup.js
+++ b/src/LabelGroup.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import styled from 'styled-components'
 import theme from './theme'
-import {COMMON} from './constants'
+import {COMMON, get} from './constants'
 
 const transformChildren = children => {
   return React.Children.map(children, child => {
-    return React.cloneElement(child, {mr: 1, className: 'LabelItem'})
+    return React.cloneElement(child, {className: 'LabelItem'})
   })
 }
 
@@ -13,6 +13,9 @@ const LabelGroup = styled.span.attrs(props => ({
   children: transformChildren(props.children)
 }))`
   ${COMMON}
+  & .LabelItem {
+    margin-right: ${get('space.1')}px;
+  }
   & .LabelItem:last-child {
     margin-right: 0;
   }

--- a/src/__tests__/LabelGroup.js
+++ b/src/__tests__/LabelGroup.js
@@ -25,6 +25,16 @@ describe('BranchName', () => {
     expect(LabelGroup).toImplementSystemProps(COMMON)
   })
 
+  it('preserves className on children', () => {
+    expect(
+      render(
+        <LabelGroup>
+          <Label className="custom-className" />
+        </LabelGroup>
+      )
+    ).toMatchSnapshot()
+  })
+
   it('matches snapshot', () => {
     expect(render(comp)).toMatchSnapshot()
   })

--- a/src/__tests__/__snapshots__/LabelGroup.js.snap
+++ b/src/__tests__/__snapshots__/LabelGroup.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BranchName matches snapshot 1`] = `
+.c0 .LabelItem {
+  margin-right: 4px;
+}
+
 .c0 .LabelItem:last-child {
   margin-right: 0;
 }

--- a/src/__tests__/__snapshots__/LabelGroup.js.snap
+++ b/src/__tests__/__snapshots__/LabelGroup.js.snap
@@ -62,22 +62,62 @@ exports[`BranchName matches snapshot 1`] = `
   className="c0"
 >
   <span
-    className="c1"
+    className="LabelItem c1"
     size="medium"
   >
     Default label
   </span>
   <span
-    className="c1"
+    className="LabelItem c1"
     size="medium"
   >
     Darker gray label
   </span>
   <span
-    className="c2"
+    className="LabelItem c2"
     size="medium"
   >
     Default outline label
   </span>
+</span>
+`;
+
+exports[`BranchName preserves className on children 1`] = `
+.c0 .LabelItem {
+  margin-right: 4px;
+}
+
+.c0 .LabelItem:last-child {
+  margin-right: 0;
+}
+
+.c1 {
+  display: inline-block;
+  font-weight: 600;
+  line-height: 1;
+  color: #fff;
+  border-radius: 2px;
+  font-size: 12px;
+  padding-left: 3px;
+  padding-right: 3px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  background-color: #6a737d;
+  width: medium;
+  height: medium;
+}
+
+.c1:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+<span
+  className="c0"
+>
+  <span
+    className="custom-className LabelItem c1"
+    size="medium"
+  />
 </span>
 `;


### PR DESCRIPTION
`<LabelGroup>` passed the `mr={1}` prop along to its children in order to get the correct spacing between the children. However, if the child is not a component that supports the `mr` prop, then no margin is applied to the element. This comes up if we want the children of the LabelGroup to be `<a>` tags which wrap `<Label>` components like this:

```
<LabelGroup>
  <a href="#">
    <Label>Default label</Label>
  </a>
  <a href="#">
    <Label bg="red.4">Label with red background</Label>
  </a>
  <a href="#">
    <Label outline>Default outline label</Label>
  </a>
</LabelGroup>
```

This change will use the custom class name that we put onto the children to provide all the `margin-right`.


#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
