### PR TITLE
Add `ButtonGroup` to “index.d.ts”

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -126,6 +126,7 @@ declare module '@primer/components' {
   export const ButtonPrimary: React.FunctionComponent<ButtonProps>
   export const ButtonOutline: React.FunctionComponent<ButtonProps>
   export const ButtonDanger: React.FunctionComponent<ButtonProps>
+  export const ButtonGroup: React.FunctionComponent<BoxProps>
   export const Button: React.FunctionComponent<ButtonProps>
 
   export interface AvatarProps extends CommonProps, Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'color'> {
@@ -361,6 +362,11 @@ declare module '@primer/components/src/ButtonPrimary' {
 declare module '@primer/components/src/ButtonOutline' {
   import {ButtonOutline} from '@primer/components'
   export default ButtonOutline
+}
+
+declare module '@primer/components/src/ButtonGroup' {
+  import {ButtonGroup} from '@primer/components'
+  export default ButtonGroup
 }
 
 declare module '@primer/components/src/Button' {


### PR DESCRIPTION
[`ButtonGroup`](https://primer.style/components/Buttons#buttongroup) is documented on the website, but it is not included in the Primer TypeScript type definition, so it cannot be used in TypeScript files.

#### Merge checklist
- [x] Changed base branch to release branch
- [x] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
