### PR TITLE
fix: floating stack over nav-bar

### DIFF
--- a/src/AvatarStack.js
+++ b/src/AvatarStack.js
@@ -60,6 +60,7 @@ const AvatarStackBody = styled.span`
   display: flex;
   position: absolute;
   background: white;
+  z-index: 0;
 
   &:hover {
     .AvatarItem {


### PR DESCRIPTION
Fixed #588 
Describe your changes here.
Adding a z-index property to avoid it from floating over the navbar
![Screen Shot 2019-10-14 at 9 45 24 AM](https://user-images.githubusercontent.com/34168281/66730077-bd36b780-ee68-11e9-8a2f-f8665b89f7a3.png)


#### If development process was changed
Description of changes

- [ ] Updated README

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
