### PR TITLE
Add BorderProps to BorderBoxProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -140,7 +140,7 @@ declare module '@primer/components' {
 
   export const BaseStyles: React.FunctionComponent<BaseStylesProps>
 
-  export interface BorderBoxProps extends CommonProps, LayoutProps, BoxProps {
+  export interface BorderBoxProps extends CommonProps, LayoutProps, BorderProps, BoxProps {
     border?: string
     borderColor?: string
     borderRadius?: string | number


### PR DESCRIPTION
Adds `BorderProps` to the interfaces `BorderBoxProps` extends in the Typescript definition
Closes #576

#### Merge checklist
- [x] Changed base branch to release branch
- [x] Add or update TypeScript definitions (`index.d.ts`) if necessary
