### PR TITLE
FlexProps should extend BoxProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,8 @@ declare module '@primer/components' {
       StyledSystem.AlignContentProps,
       StyledSystem.AlignItemsProps,
       StyledSystem.JustifyContentProps,
-      StyledSystem.JustifyItemsProps {}
+      StyledSystem.JustifyItemsProps,
+      BoxProps {}
 
   export const Flex: React.FunctionComponent<FlexProps> & {
     Item: React.FunctionComponent<FlexItemProps>


### PR DESCRIPTION
`Flex` ends up rendering a `Box` under the covers, so `FlexProps` should extend `BoxProps` so that we can add native props, such as `<Flex id="foo />`.