### PR TITLE
Moving size variants off of wrapper and onto input

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "description": "Primer react components",
   "main": "dist/index.umd.js",
   "module": "dist/index.esm.js",

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -61,6 +61,8 @@ const Input = styled.input.attrs(props => ({
   &:focus {
     outline: 0;
   }
+
+  ${sizeVariants}
 `
 
 const Wrapper = styled.span`
@@ -88,8 +90,6 @@ const Wrapper = styled.span`
     border-color: ${get('colors.blue.4')};
     box-shadow: ${get('shadows.formControl')}, ${get('shadows.formControlFocus')};
   }
-
-  ${sizeVariants}
 
   ${props =>
     props.block &&

--- a/src/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/__tests__/__snapshots__/TextInput.js.snap
@@ -143,6 +143,11 @@ exports[`TextInput renders large 1`] = `
   color: inherit;
   width: 100%;
   padding-left: 8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 10px;
+  padding-bottom: 10px;
+  font-size: 20px;
 }
 
 .c1:focus {
@@ -210,6 +215,13 @@ exports[`TextInput renders small 1`] = `
   color: inherit;
   width: 100%;
   padding-left: 8px;
+  min-height: 28px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 3px;
+  padding-bottom: 3px;
+  font-size: 12px;
+  line-height: 20px;
 }
 
 .c1:focus {


### PR DESCRIPTION
The `variant` prop of `<TextInput />` isn't working and I think it's due to the fact that the `${sizeVariants}` was on the `<Wrapper />` instead of the underlying `<input />`.