### PR TITLE
Fixed TextInput type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "15.1.1",
+  "version": "15.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -25,7 +25,7 @@ const sizeVariants = variant({
   }
 })
 
-const TextInput = ({icon, type, className, width, theme, ...rest}) => {
+const TextInput = ({icon, className, width, theme, ...rest}) => {
   const wrapperClasses = classnames(className, 'TextInput-wrapper')
   const inputClasses = classnames(icon ? 'input-icon' : 'input-no-icon')
   const hasIcon = !!icon

--- a/src/__tests__/TextInput.js
+++ b/src/__tests__/TextInput.js
@@ -34,4 +34,8 @@ describe('TextInput', () => {
     component.find('input').simulate('change')
     expect(onChangeMock).toHaveBeenCalled()
   })
+
+  it('should render a password input', () => {
+    expect(render(<TextInput name="password" type="password" />)).toMatchSnapshot()
+  })
 })

--- a/src/__tests__/__snapshots__/TextInput.js.snap
+++ b/src/__tests__/__snapshots__/TextInput.js.snap
@@ -279,3 +279,70 @@ exports[`TextInput renders small 1`] = `
   />
 </span>
 `;
+
+exports[`TextInput should render a password input 1`] = `
+.c1 {
+  border: 0;
+  margin-right: 4px;
+  font-size: 16px;
+  background-color: transparent;
+  color: inherit;
+  width: 100%;
+  padding-left: 8px;
+}
+
+.c1:focus {
+  outline: 0;
+}
+
+.c0 {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-align-items: stretch;
+  -webkit-box-align: stretch;
+  -ms-flex-align: stretch;
+  align-items: stretch;
+  min-height: 34px;
+  font-size: 16px;
+  line-height: 20px;
+  color: #24292e;
+  vertical-align: middle;
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  border: 1px solid #d1d5da;
+  border-radius: 3px;
+  outline: none;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset;
+}
+
+.c0 .TextInput-icon {
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  align-self: center;
+  color: #959da5;
+  margin: 0 8px;
+}
+
+.c0:focus-within {
+  border-color: #2188ff;
+  box-shadow: rgba(27,31,35,0.075) 0px 1px 2px inset,rgba(3,102,214,0.3) 0px 0px 0px 0.2em;
+}
+
+@media (max-width:768px) {
+  .c0 {
+    font-size: 14px;
+  }
+}
+
+<span
+  className="c0 TextInput-wrapper"
+>
+  <input
+    className="c1 input-no-icon"
+    name="password"
+    type="password"
+  />
+</span>
+`;


### PR DESCRIPTION
In 15.1.2, password inputs are not obscured.
This PR fix this issue.

#### If development process was changed
Description of changes

- [ ] Updated README

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
