### PR TITLE
Add BORDER system prop to BorderBox docs

### DIFF
--- a/docs/content/BorderBox.md
+++ b/docs/content/BorderBox.md
@@ -13,7 +13,7 @@ BorderBox is a Box component with a border. When no `borderColor` is present, th
 
 ## System props
 
-BorderBox components get `COMMON` and `LAYOUT` system props. Read our [System Props](/system-props) doc page for a full list of available props.
+BorderBox components get `COMMON`, `LAYOUT` and `BORDER` system props. Read our [System Props](/system-props) doc page for a full list of available props.
 
 ## Component props
 


### PR DESCRIPTION
You forgot to add the `BORDER` system prop to the BorderBox component docs. 😊

#### Merge checklist
- [ ] Changed base branch to release branch
- [ ] Add or update TypeScript definitions (`index.d.ts`) if necessary
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
