### PR TITLE
[FIX] updates Button small variant padding

### DIFF
--- a/src/Button.js
+++ b/src/Button.js
@@ -9,6 +9,7 @@ import systemPropTypes from '@styled-system/prop-types'
 const variants = variant({
   variants: {
     small: {
+      p: '3px 10px',
       fontSize: 0
     },
     medium: {


### PR DESCRIPTION
• resolves issue 

Describe your changes here.

Closes #681 

### Screenshots

Gatsby docs running in Chrome:
<img width="1387" alt="Screen Shot 2020-02-03 at 1 09 45 AM" src="https://user-images.githubusercontent.com/4818182/73635999-f6668380-4621-11ea-8eef-4edf21a80e59.png">



### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x ] Tested in Chrome
- [x ] Tested in Firefox
- [x ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contibuting guidelines for more infomation on how we review PRs.
