### PR TITLE
Update Dropdown title type

### DIFF
--- a/docs/content/Dropdown.md
+++ b/docs/content/Dropdown.md
@@ -26,7 +26,7 @@ Dropdown, Dropdown.Menu, and Dropdown.Item all get `COMMON` system props. Read o
 | Name | Type | Default | Description |
 | :- | :- | :-: | :- |
 | direction | String | 'sw' | Sets the direction of the dropdown menu. |
-| title | String | | Sets the text inside of the button |
+| title | String or Node | | Sets the text inside of the button, can be either a string or a React node |
 
 #### Dropdown.Item
 No additional props.

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,7 +149,7 @@ declare module '@primer/components' {
 
   export interface DropdownMenuProps extends CommonProps, Omit<React.HTMLAttributes<HTMLUListElement>, 'color'> {
     direction?: string
-    title: string
+    title: string | React.ReactNode
   }
 
   export const Dropdown: React.FunctionComponent<DropdownProps> & {

--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -139,7 +139,7 @@ Dropdown.Item.propTypes = {
 Dropdown.defaultProps = {theme}
 Dropdown.propTypes = {
   children: PropTypes.node,
-  title: PropTypes.string,
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   ...COMMON.propTypes
 }
 


### PR DESCRIPTION
This PR adds the ability to pass a React node to the `title` prop of the `Dropdown` component. This will allow users to add Octicons to the title.

Closes: #699 

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contibuting guidelines for more infomation on how we review PRs.
