### PR TITLE
SideNav Visual Refresh

### DIFF
--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -77,11 +77,6 @@ SideNav.Link = styled(Link).attrs(props => {
       border-top: 0;
     }
 
-    &:last-child {
-      // makes sure there is a "bottom border" in case the list is not long enough
-      box-shadow: 0 1px 0 ${get('colors.gray.2')};
-    }
-
     // Bar on the left
     &::before {
       position: absolute;

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -119,7 +119,7 @@ SideNav.Link = styled(Link).attrs(props => {
 
       // Bar on the left
       &::before {
-        background-color: ${get('colors.orange.7')};
+        background-color: ${get('colors.orange.5')};
       }
     }
   }

--- a/src/__tests__/__snapshots__/SideNav.js.snap
+++ b/src/__tests__/__snapshots__/SideNav.js.snap
@@ -26,10 +26,6 @@ exports[`SideNav and SideNav.Link renders with default props 1`] = `
   border-top: 0;
 }
 
-.c1.variant-normal > .c3:last-child {
-  box-shadow: 0 1px 0 #e1e4e8;
-}
-
 .c1.variant-normal > .c3::before {
   position: absolute;
   top: 0;
@@ -68,7 +64,7 @@ exports[`SideNav and SideNav.Link renders with default props 1`] = `
 
 .c1.variant-normal > .c3[aria-current='page']::before,
 .c1.variant-normal > .c3[aria-selected='true']::before {
-  background-color: #d15704;
+  background-color: #f66a0a;
 }
 
 .c1.variant-lightweight > .c3 {
@@ -127,10 +123,6 @@ exports[`SideNav and SideNav.Link renders with default props 2`] = `
   border-top: 0;
 }
 
-.c1.variant-normal > .c0:last-child {
-  box-shadow: 0 1px 0 #e1e4e8;
-}
-
 .c1.variant-normal > .c0::before {
   position: absolute;
   top: 0;
@@ -169,7 +161,7 @@ exports[`SideNav and SideNav.Link renders with default props 2`] = `
 
 .c1.variant-normal > .c0[aria-current='page']::before,
 .c1.variant-normal > .c0[aria-selected='true']::before {
-  background-color: #d15704;
+  background-color: #f66a0a;
 }
 
 .c1.variant-lightweight > .c0 {


### PR DESCRIPTION
This PR updates the SideNav with the new visual refresh styles! So far I've just updated the orange color that we're using. @auareyou I wasn't sure if there are any other changes that should be made?  I didn't see anything in the Figma file under the navigation frame that corresponds to our SideNav (there's a vertical navigation component but I think that is corresponding to the [Menu Component](https://primer.style/css/components/navigation#menu).

The current SideNav has a grey background, and selected items turn white. Should we keep those styles and just update the orange color?

Primer CSS SideNav: https://primer.style/css/components/navigation#side-nav
Primer Components SideNav: https://primer.style/components/SideNav

| Before  | After |
| ------------- | ------------- |
| ![image](https://user-images.githubusercontent.com/8960591/76127069-92830200-5fb5-11ea-854a-a4ec8b2cac34.png)  |  ![image](https://user-images.githubusercontent.com/8960591/76127036-8434e600-5fb5-11ea-9eae-fab2155eb368.png) |