### PR TITLE
[FIX] Remove z-index on focused button

### DIFF
--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -35,6 +35,11 @@ const ButtonGroup = styled(Box)`
         border-left-width: 0;
       }
     }
+
+    :focus,
+    :active {
+      z-index: 1;
+    }
   }
 `
 ButtonGroup.defaultProps = {

--- a/src/ButtonGroup.js
+++ b/src/ButtonGroup.js
@@ -35,11 +35,6 @@ const ButtonGroup = styled(Box)`
         border-left-width: 0;
       }
     }
-
-    :focus,
-    :active {
-      z-index: 1;
-    }
   }
 `
 ButtonGroup.defaultProps = {

--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -24,11 +24,6 @@ export default css`
     outline: none;
   }
 
-  &:focus,
-  &:active {
-    z-index: 1;
-  }
-
   &:disabled {
     cursor: default;
   }

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -36,11 +36,6 @@ exports[`Button respects the "disabled" prop 1`] = `
   outline: none;
 }
 
-.c0:focus,
-.c0:active {
-  z-index: 1;
-}
-
 .c0:disabled {
   cursor: default;
 }
@@ -107,11 +102,6 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
 
 .c0:focus {
   outline: none;
-}
-
-.c0:focus,
-.c0:active {
-  z-index: 1;
 }
 
 .c0:disabled {
@@ -185,11 +175,6 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   outline: none;
 }
 
-.c0:focus,
-.c0:active {
-  z-index: 1;
-}
-
 .c0:disabled {
   cursor: default;
 }
@@ -259,11 +244,6 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
 
 .c0:focus {
   outline: none;
-}
-
-.c0:focus,
-.c0:active {
-  z-index: 1;
 }
 
 .c0:disabled {

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -36,11 +36,6 @@ exports[`Dropdown matches the snapshots 1`] = `
   outline: none;
 }
 
-.c2:focus,
-.c2:active {
-  z-index: 1;
-}
-
 .c2:disabled {
   cursor: default;
 }
@@ -143,11 +138,6 @@ exports[`Dropdown matches the snapshots 2`] = `
 
 .c2:focus {
   outline: none;
-}
-
-.c2:focus,
-.c2:active {
-  z-index: 1;
 }
 
 .c2:disabled {


### PR DESCRIPTION
This PR fixes #711 - it looks like I added a `z-index: 1` to focused buttons [when I created the ButtonGroup component](https://github.com/primer/components/pull/495/files#diff-e202ebba38c7b211cd3f1aa7498baae5R85
). As far as I can tell, this is a remnant of handling the button group css within the Button component and isn't necessary because we're setting the `z-index` of buttons inside ButtonGroup [within the `ButtonGroup` styles](https://github.com/primer/components/pull/495/files#diff-b8c81ad4d8f2770a5faf19e0a00ee091R32).

It's fine to leave the z-index of the button elements inside of the ButtonGroup component since they are children of `ButtonGroup` and the entire group should sit wherever ButtonGroup is in the stacking context. I've double checked this with the test environment that @acknosyn provided in #711 reproducing the bug. Using `ButtonGroup` works fine in that test case.

### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contibuting guidelines for more infomation on how we review PRs.
