### PR TITLE
Fix small spelling typo

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -14,7 +14,7 @@ Import them individually from the main bundle:
 import {Box, Flex} from '@primer/components'
 ```
 
-or, if you've configured your application to tree-shake with webpack, you can import them indivdually from the `src` folder:
+or, if you've configured your application to tree-shake with webpack, you can import them individually from the `src` folder:
 
 ```
 import Box from '@primer/components/src/Box'


### PR DESCRIPTION
Fixed a small typo of the word "individually" in the Getting Started documentation.



### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contibuting guidelines for more infomation on how we review PRs.
