### PR TITLE
Add Grid type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,11 +189,11 @@ declare module '@primer/components' {
     scheme?: string
   }
 
+  export const CounterLabel: React.FunctionComponent<CounterLabelProps>
+
   export interface GridProps extends BoxProps, StyledSystem.GridProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {}
 
   export const Grid: React.FunctionComponent<GridProps>
-
-  export const CounterLabel: React.FunctionComponent<CounterLabelProps>
 
   export interface LabelProps extends CommonProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {
     outline?: boolean

--- a/index.d.ts
+++ b/index.d.ts
@@ -189,6 +189,10 @@ declare module '@primer/components' {
     scheme?: string
   }
 
+  export interface GridProps extends BoxProps, StyledSystem.GridProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {}
+
+  export const Grid: React.FunctionComponent<GridProps>
+
   export const CounterLabel: React.FunctionComponent<CounterLabelProps>
 
   export interface LabelProps extends CommonProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {
@@ -455,6 +459,11 @@ declare module '@primer/components/src/FilterList' {
 declare module '@primer/components/src/Flash' {
   import {Flash} from '@primer/components'
   export default Flash
+}
+
+declare module '@primer/components/src/Grid' {
+  import {Grid} from '@primer/components'
+  export default Grid
 }
 
 declare module '@primer/components/src/CounterLabel' {


### PR DESCRIPTION
It looks like `Grid` was missing type definitions 😬 

Closes #718 

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
