### PR TITLE
update Grid type definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,7 @@ declare module '@primer/components' {
 
   export const CounterLabel: React.FunctionComponent<CounterLabelProps>
 
-  export interface GridProps extends BoxProps, StyledSystem.GridProps, Omit<React.HTMLAttributes<HTMLSpanElement>, 'color'> {}
+  export interface GridProps extends BoxProps, StyledSystem.GridProps {}
 
   export const Grid: React.FunctionComponent<GridProps>
 


### PR DESCRIPTION
This PR fixes a typescript issue with the `Grid` component. The `Omit<React.HTMLAttributes<HTMLSpanElement>` was clashing with the `Omit<React.HTMLAttributes<HTMLDivElement>` in `BoxProps`. I don't _think_ the HTML attribute types need to be redefined on `Grid` since they are already defined in the `BoxProps` interface, so I removed them. 

TS experts plz advise: @T-Hugs @smockle @dmarcey 🙏 