### PR TITLE
Hotline Changes (update Dropdown type & add accent color to theme)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,7 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-  export interface DropdownProps extends StyledSystem.ColorProps, StyledSystem.SpaceProps, ButtonProps {
+  export interface DropdownProps extends React.Props<any>, StyledSystem.ColorProps, StyledSystem.SpaceProps, ButtonProps {
     as?: React.ReactType
     title: string | React.ReactNode
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -147,7 +147,7 @@ declare module '@primer/components' {
 
   export interface DropdownProps extends React.Props<any>, StyledSystem.ColorProps, StyledSystem.SpaceProps, ButtonProps {
     as?: React.ReactType
-    title: string | React.ReactNode
+    title?: string | React.ReactNode
   }
 
   export interface DropdownMenuProps extends CommonProps, Omit<React.HTMLAttributes<HTMLUListElement>, 'color'> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,11 +145,12 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-  export interface DropdownProps extends CommonProps, ButtonProps {}
+  export interface DropdownProps extends CommonProps, ButtonProps {
+    title: string | React.ReactNode
+  }
 
   export interface DropdownMenuProps extends CommonProps, Omit<React.HTMLAttributes<HTMLUListElement>, 'color'> {
     direction?: string
-    title: string | React.ReactNode
   }
 
   export const Dropdown: React.FunctionComponent<DropdownProps> & {

--- a/index.d.ts
+++ b/index.d.ts
@@ -145,7 +145,8 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-  export interface DropdownProps extends CommonProps, ButtonProps {
+  export interface DropdownProps extends StyledSystem.ColorProps, StyledSystem.SpaceProps, ButtonProps {
+    as?: React.ReactType
     title: string | React.ReactNode
   }
 

--- a/src/UnderlineNav.js
+++ b/src/UnderlineNav.js
@@ -67,7 +67,7 @@ UnderlineNav.Link = styled.a.attrs(props => ({
   &:focus {
     color: ${get('colors.gray.9')};
     text-decoration: none;
-    border-bottom-color: ${get('colors.orange.5')};
+    border-bottom-color: ${get('colors.accent')};
     transition: 0.2s ease;
 
     .UnderlineNav-octicon {
@@ -77,7 +77,7 @@ UnderlineNav.Link = styled.a.attrs(props => ({
 
   &.selected {
     color: ${get('colors.gray.9')};
-    border-bottom-color: ${get('colors.orange.5')};
+    border-bottom-color: ${get('colors.accent')};
 
     .UnderlineNav-octicon {
       color: ${get('colors.gray.5')};

--- a/src/__tests__/__snapshots__/BreadcrumbItem.js.snap
+++ b/src/__tests__/__snapshots__/BreadcrumbItem.js.snap
@@ -135,6 +135,7 @@ exports[`Breadcrumb.Item renders the given "as" prop 1`] = `
         },
       },
       "colors": Object {
+        "accent": "#f66a0a",
         "bg": Object {
           "disabled": "#F3F4F6",
           "gray": "#f6f8fa",

--- a/src/__tests__/__snapshots__/FilterListItem.js.snap
+++ b/src/__tests__/__snapshots__/FilterListItem.js.snap
@@ -148,6 +148,7 @@ exports[`FilterList.Item renders the given "as" prop 1`] = `
         },
       },
       "colors": Object {
+        "accent": "#f66a0a",
         "bg": Object {
           "disabled": "#F3F4F6",
           "gray": "#f6f8fa",

--- a/src/__tests__/__snapshots__/SubNavLink.js.snap
+++ b/src/__tests__/__snapshots__/SubNavLink.js.snap
@@ -175,6 +175,7 @@ exports[`SubNav.Link renders the given "as" prop 1`] = `
         },
       },
       "colors": Object {
+        "accent": "#f66a0a",
         "bg": Object {
           "disabled": "#F3F4F6",
           "gray": "#f6f8fa",

--- a/src/__tests__/__snapshots__/UnderlineNavLink.js.snap
+++ b/src/__tests__/__snapshots__/UnderlineNavLink.js.snap
@@ -152,6 +152,7 @@ exports[`UnderlineNav.Link renders the given "as" prop 1`] = `
         },
       },
       "colors": Object {
+        "accent": "#f66a0a",
         "bg": Object {
           "disabled": "#F3F4F6",
           "gray": "#f6f8fa",

--- a/src/theme.js
+++ b/src/theme.js
@@ -48,7 +48,8 @@ const colors = {
     gray: gray[1],
     grayLight: gray[0],
     disabled: '#F3F4F6'
-  }
+  },
+  accent: orange[5]
 }
 
 const buttons = {


### PR DESCRIPTION
This PR fixes a few issues brought up by the Hotline team this morning:

- Dropdown `title` type defintion is clashing with the `CommonProps` types that it extends. It was also on `DropdownMenu` when it should have just been on `Dropdown`. 

  `BaseTypes` extends `React.Props<any>` and adds the `title` attribute as an acceptable type. I'm honestly not sure why `title` is included in `BaseTypes` 🤔 but because it's set as only a `string` it conflicts with the `title` prop in `Dropdown`. I ended up needing to redefine all the types we want from `BaseTypes` and `CommonTypes` on Dropdown to get around this.

- Changed the theme call in `UnderlineNav` to access `colors.accent` instead of `colors.orange[5]` to allow users of the component to override this color if needed by changing the `accent` color in the theme

