### PR TITLE
Let 'TextInput' use 'maxWidth' and 'minWidth' from 'styled-system'

### DIFF
--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -27,4 +27,6 @@ Native `<input>` attributes are forwarded to the underlying React `input` compon
 | block | Boolean | | Adds `display: block` to element |
 | variant | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
 | width | String or Number | | Set the width of the input |
+| maxWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the maximum width of the input |
+| minWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the minimum width of the input |
 | icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the right edge. | 

--- a/index.d.ts
+++ b/index.d.ts
@@ -269,6 +269,8 @@ declare module '@primer/components' {
   export interface TextInputProps
     extends CommonProps,
       StyledSystem.WidthProps,
+      StyledSystem.MaxWidthProps,
+      StyledSystem.MinWidthProps,
       Omit<React.InputHTMLAttributes<HTMLInputElement>, 'color' | 'size' | 'width'> {
     block?: boolean
     icon?: React.ReactElement

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -5,7 +5,7 @@ import systemPropTypes from '@styled-system/prop-types'
 import {omit, pick} from '@styled-system/props'
 import styled, {css} from 'styled-components'
 import Octicon from './StyledOcticon'
-import {variant, width} from 'styled-system'
+import {variant, width, minWidth, maxWidth} from 'styled-system'
 import {COMMON, get} from './constants'
 import theme from './theme'
 
@@ -120,6 +120,8 @@ const Wrapper = styled.span`
   }
   ${COMMON}
   ${width}
+  ${minWidth}
+  ${maxWidth}
   ${sizeVariants}
 `
 
@@ -129,7 +131,9 @@ TextInput.propTypes = {
   block: PropTypes.bool,
   variant: PropTypes.oneOf(['small', 'large']),
   ...COMMON.propTypes,
-  width: systemPropTypes.layout.width
+  width: systemPropTypes.layout.width,
+  minWidth: systemPropTypes.layout.minWidth,
+  maxWidth: systemPropTypes.layout.maxWidth
 }
 
 export default TextInput

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -129,11 +129,11 @@ TextInput.defaultProps = {theme}
 
 TextInput.propTypes = {
   block: PropTypes.bool,
+  maxWidth: systemPropTypes.layout.maxWidth,
+  minWidth: systemPropTypes.layout.minWidth,
   variant: PropTypes.oneOf(['small', 'large']),
   ...COMMON.propTypes,
   width: systemPropTypes.layout.width,
-  minWidth: systemPropTypes.layout.minWidth,
-  maxWidth: systemPropTypes.layout.maxWidth
 }
 
 export default TextInput

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -133,7 +133,7 @@ TextInput.propTypes = {
   minWidth: systemPropTypes.layout.minWidth,
   variant: PropTypes.oneOf(['small', 'large']),
   ...COMMON.propTypes,
-  width: systemPropTypes.layout.width,
+  width: systemPropTypes.layout.width
 }
 
 export default TextInput


### PR DESCRIPTION
`styled-system` supports `maxWidth` and `minWidth` props: https://styled-system.com/api#layout

Primer’s `TextInput` component currently accepts `styled-system`’s `width` prop. This PR lets it also accept `maxWidth` and `minWidth`.

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
