### PR TITLE
Add `className` and `css` to `BaseProps`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,8 @@ declare module '@primer/components' {
 
   export interface BaseProps extends React.Props<any> {
     as?: React.ReactType
+    className?: string
+    css?: string
     title?: string
     // NOTE(@mxstbr): Necessary workaround to make <Component as={Link} to="/bla" /> work
     to?: History.LocationDescriptor
@@ -145,7 +147,11 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-  export interface DropdownProps extends React.Props<any>, StyledSystem.ColorProps, StyledSystem.SpaceProps, ButtonProps {
+  export interface DropdownProps
+    extends React.Props<any>,
+      StyledSystem.ColorProps,
+      StyledSystem.SpaceProps,
+      ButtonProps {
     as?: React.ReactType
     title?: string | React.ReactNode
   }


### PR DESCRIPTION
`className` is a default DOM-level prop in React, and it feels wrong to omit this since it's possible in vanilla JS to pass this.

`css` is exposed via styled-components, but only works with the Babel plugin, which rewrites any element with a `css` prop and converts it into a proper styled-component component. See https://styled-components.com/docs/api#css-prop for more information.

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary