### PR TITLE
Update UnderlineNav.Link prop type

### DIFF
--- a/src/UnderlineNav.js
+++ b/src/UnderlineNav.js
@@ -104,7 +104,7 @@ UnderlineNav.Link.defaultProps = {
 }
 
 UnderlineNav.Link.propTypes = {
-  as: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  as: PropTypes.node,
   href: PropTypes.string,
   selected: PropTypes.bool,
   ...COMMON.propTypes


### PR DESCRIPTION
This PR loosens the prop type definition for `UnderlineNav.Link`'s `as` prop - it allows any `node` instead of just strings or functions. The `PropTypes.func` wasn't recognizing elements passed in. `PropTypes.node` encompasses strings, elements, functions, etc.

Addresses: https://github.slack.com/archives/CT16VV4R5/p1584981111066700?thread_ts=1584716771.042300&cid=CT16VV4R5