### PR TITLE
fix: SideNav.Link types is missing `selected`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -268,6 +268,7 @@ declare module '@primer/components' {
       TypographyProps,
       LinkProps,
       Omit<React.HTMLAttributes<HTMLAnchorElement>, 'color'> {
+    selected?: boolean
     variant?: 'normal' | 'full'
   }
 


### PR DESCRIPTION
`selected` prop is missing in the TypeScript definition but defined in PropTypes

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
