### PR TITLE
Additional TextInput variants

### DIFF
--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -2,7 +2,7 @@
 title: TextInput
 ---
 
-TextInput is a form component to add default styling to the native text input. 
+TextInput is a form component to add default styling to the native text input.
 
 **Note:** Don't forget to set `aria-label` to make the TextInput accessible to screen reader users.
 ## Default example
@@ -11,6 +11,17 @@ TextInput is a form component to add default styling to the native text input.
 <TextInput aria-label="Zipcode" name="zipcode" placeholder="Zipcode" autoComplete="postal-code" />
 
 <TextInput ml={4} icon={Search} aria-label="Zipcode" name="zipcode" placeholder="Find user" autoComplete="postal-code" />
+
+<TextInput placeholder="test" state="error" />
+```
+
+```jsx live
+<TextInput placeholder="email" state="error" />
+<Popover relative open={true} caret="top-left" ml={2}>
+  <Popover.Content p={1} mt={2} borderColor='red.5'>
+    <Text fontSize={1}>This field has an error</Text>
+  </Popover.Content>
+</Popover>
 ```
 
 ## System props
@@ -29,4 +40,4 @@ Native `<input>` attributes are forwarded to the underlying React `input` compon
 | width | String or Number | | Set the width of the input |
 | maxWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the maximum width of the input |
 | minWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the minimum width of the input |
-| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the right edge. | 
+| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the right edge. |

--- a/src/BorderBox.js
+++ b/src/BorderBox.js
@@ -8,7 +8,8 @@ const BorderBox = styled(Box)(BORDER)
 
 BorderBox.defaultProps = {
   theme,
-  border: '1px solid',
+  borderWidth: '1px',
+  borderStyle: 'solid',
   borderColor: 'gray.2',
   borderRadius: 2
 }

--- a/src/Popover.js
+++ b/src/Popover.js
@@ -20,6 +20,14 @@ const Popover = styled.div.attrs(({className, caret}) => {
   ${POSITION};
 `
 
+function getPopoverBorderColor(props) {
+  if (props.borderColor) {
+    return get(`colors.${props.borderColor}`)(props)
+  } else {
+    return get('popovers.colors.caret')(props)
+  }
+}
+
 Popover.Content = styled(BorderBox)`
   position: relative;
   width: 232px;
@@ -44,7 +52,7 @@ Popover.Content = styled(BorderBox)`
     top: -${get('space.3')};
     margin-left: -9px;
     border: ${get('space.2')} solid transparent; // TODO: solid?
-    border-bottom-color: ${get('popovers.colors.caret')};
+    border-bottom-color: ${getPopoverBorderColor};
   }
 
   &::after {
@@ -66,7 +74,7 @@ Popover.Content = styled(BorderBox)`
 
     &::before {
       bottom: -${get('space.3')};
-      border-top-color: ${get('popovers.colors.caret')};
+      border-top-color: ${getPopoverBorderColor};
     }
 
     &::after {
@@ -145,7 +153,7 @@ Popover.Content = styled(BorderBox)`
   ${Popover}.caret-pos--right-bottom & {
     &::before {
       right: -${get('space.3')};
-      border-left-color: ${get('popovers.colors.caret')};
+      border-left-color: ${getPopoverBorderColor};
     }
 
     &::after {
@@ -161,7 +169,7 @@ Popover.Content = styled(BorderBox)`
   ${Popover}.caret-pos--left-bottom & {
     &::before {
       left: -${get('space.3')};
-      border-right-color: ${get('popovers.colors.caret')};
+      border-right-color: ${getPopoverBorderColor};
     }
 
     &::after {

--- a/src/TextInput.js
+++ b/src/TextInput.js
@@ -26,7 +26,22 @@ const sizeVariants = variant({
   }
 })
 
-const TextInput = ({icon, className, block, disabled, ...rest}) => {
+const stateVariants = variant({
+  prop: 'state',
+  variants: {
+    normal: {
+      borderColor: 'border.gray'
+    },
+    error: {
+      borderColor: 'red.7'
+    },
+    warning: {
+      borderColor: 'yellow.7'
+    }
+  }
+})
+
+const TextInput = ({icon, className, block, disabled, state, ...rest}) => {
   // this class is necessary to style FilterSearch, plz no touchy!
   const wrapperClasses = classnames(className, 'TextInput-wrapper')
   const wrapperProps = pick(rest)
@@ -38,6 +53,7 @@ const TextInput = ({icon, className, block, disabled, ...rest}) => {
       block={block}
       theme={theme}
       disabled={disabled}
+      state={state}
       {...wrapperProps}
     >
       {icon && <Octicon className="TextInput-icon" icon={icon} />}
@@ -74,6 +90,8 @@ const Wrapper = styled.span`
   border-radius: ${get('radii.2')};
   outline: none;
   box-shadow: ${get('shadows.formControl')};
+
+  ${stateVariants};
 
   ${props => {
     if (props.hasIcon) {
@@ -112,7 +130,7 @@ const Wrapper = styled.span`
     css`
       display: block;
       width: 100%;
-    `}    
+    `}
 
   // Ensures inputs don't zoom on mobile but are body-font size on desktop
   @media (max-width: ${get('breakpoints.1')}) {
@@ -125,12 +143,16 @@ const Wrapper = styled.span`
   ${sizeVariants}
 `
 
-TextInput.defaultProps = {theme}
+TextInput.defaultProps = {
+  state: 'normal',
+  theme
+}
 
 TextInput.propTypes = {
   block: PropTypes.bool,
   maxWidth: systemPropTypes.layout.maxWidth,
   minWidth: systemPropTypes.layout.minWidth,
+  state: PropTypes.oneOf(['normal', 'error', 'warning']),
   variant: PropTypes.oneOf(['small', 'large']),
   ...COMMON.propTypes,
   width: systemPropTypes.layout.width


### PR DESCRIPTION
WIP

* Fixes bug in `BorderBox` where setting `borderColor` did not set border color
* Fixes bug in `Popover` where setting `borderColor` did not affect caret

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
