### PR TITLE
Dropdown type fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -157,7 +157,6 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-  export interface DropdownProps extends DetailsProps, Omit<React.HTMLAttributes<HTMLElement>, 'color'> {}
 
   export interface DropdownItem extends CommonProps, Omit<React.HTMLAttributes<HTMLLIElement>, 'color'> {}
 
@@ -169,9 +168,9 @@ declare module '@primer/components' {
 
   export interface DropdownCaretProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
-  export const Dropdown: React.FunctionComponent<DropdownProps> & {
+  export const Dropdown: React.FunctionComponent<DetailsProps> & {
     Menu: React.FunctionComponent<DropdownMenuProps>
-    Item: React.FunctionComponent<DropdownProps>
+    Item: React.FunctionComponent<DropdownItemProps>
     Button: React.FunctionComponent<DropdownButtonProps>
     Caret: React.FunctionComponent<DropdownCaretProps>
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -157,7 +157,7 @@ declare module '@primer/components' {
 
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
-
+  export interface DropdownProps extends DetailsProps {}
   export interface DropdownItem extends CommonProps, Omit<React.HTMLAttributes<HTMLLIElement>, 'color'> {}
 
   export interface DropdownMenuProps extends CommonProps, Omit<React.HTMLAttributes<HTMLUListElement>, 'color'> {
@@ -168,7 +168,7 @@ declare module '@primer/components' {
 
   export interface DropdownCaretProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
-  export const Dropdown: React.FunctionComponent<DetailsProps> & {
+  export const Dropdown: React.FunctionComponent<DropdownProps> & {
     Menu: React.FunctionComponent<DropdownMenuProps>
     Item: React.FunctionComponent<DropdownItemProps>
     Button: React.FunctionComponent<DropdownButtonProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -158,13 +158,13 @@ declare module '@primer/components' {
   export const StyledOcticon: React.FunctionComponent<StyledOcticonProps>
 
   export interface DropdownProps extends DetailsProps {}
-  export interface DropdownItem extends CommonProps, Omit<React.HTMLAttributes<HTMLLIElement>, 'color'> {}
+  export interface DropdownItemProps extends CommonProps, Omit<React.HTMLAttributes<HTMLLIElement>, 'color'> {}
 
   export interface DropdownMenuProps extends CommonProps, Omit<React.HTMLAttributes<HTMLUListElement>, 'color'> {
     direction?: 'ne'| 'e'| 'se'| 's'| 'sw'| 'w'
   }
 
-  export interface DropdownButtonProps extends ButtonProps, Omit<React.HTMLAttributes, 'color'> {}
+  export interface DropdownButtonProps extends ButtonProps {}
 
   export interface DropdownCaretProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
@@ -307,7 +307,7 @@ declare module '@primer/components' {
     selected?: boolean
   }
 
-  export interface SelectMenuFooterProps extends CommonProps, Omit<React.FooterHTMLAttributes<HTMLElement>, 'color'> {}
+  export interface SelectMenuFooterProps extends CommonProps, Omit<React.HTMLAttributes<HTMLElement>, 'color'> {}
 
   export interface SelectMenuDividerProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 


### PR DESCRIPTION
Updates the dropdown type that was throwing some errors, the Dropdown type should mirror the `Details` types