### PR TITLE
More Visual Refresh Tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
   "license": "MIT",
   "dependencies": {
     "@primer/octicons-react": "^9.2.0",
+    "@primer/primitives": "2.0.1",
     "@reach/dialog": "0.3.0",
     "@styled-system/prop-types": "5.1.2",
     "@styled-system/props": "5.1.4",
     "@styled-system/theme-get": "5.1.2",
-    "@types/styled-components": "^4.4.0",
     "@testing-library/react": "9.4.0",
+    "@types/styled-components": "^4.4.0",
     "@types/styled-system": "5.1.2",
     "babel-plugin-macros": "2.6.1",
     "babel-polyfill": "6.26.0",
@@ -50,8 +51,6 @@
     "details-element-polyfill": "2.4.0",
     "jest-axe": "3.2.0",
     "nanoid": "2.1.4",
-    "primer-colors": "1.0.1",
-    "primer-typography": "1.0.1",
     "react": "^16.10.2",
     "react-is": "16.10.2",
     "styled-system": "5.1.2"

--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -27,4 +27,8 @@ export default css`
   &:disabled {
     cursor: default;
   }
+
+  &[disabled] svg {
+    opacity: 0.6;
+  }
 `

--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -28,7 +28,7 @@ export default css`
     cursor: default;
   }
 
-  &[disabled] svg {
+  &:disabled svg {
     opacity: 0.6;
   }
 `

--- a/src/Label.js
+++ b/src/Label.js
@@ -43,7 +43,7 @@ const sizeVariant = variant({
 
 const Label = styled('span')`
   display: inline-block;
-  font-weight: 400;
+  font-weight: ${get('fontWeights.normal')};
   color: ${get('colors.white')};
   border-radius: ${get('radii.3')};
   &:hover {

--- a/src/Label.js
+++ b/src/Label.js
@@ -43,7 +43,7 @@ const sizeVariant = variant({
 
 const Label = styled('span')`
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   color: ${get('colors.white')};
   border-radius: ${get('radii.3')};
   &:hover {

--- a/src/Pagination/Pagination.js
+++ b/src/Pagination/Pagination.js
@@ -20,7 +20,7 @@ const Page = styled.a`
   cursor: pointer;
   user-select: none;
   background: ${get('pagination.colors.normal.bg')};
-  border-radius: ${get('radii.2')};
+  border: ${get('borders.1')} ${get('pagination.colors.normal.border')};
   text-decoration: none;
 
   &:first-child {

--- a/src/Pagination/Pagination.js
+++ b/src/Pagination/Pagination.js
@@ -20,7 +20,7 @@ const Page = styled.a`
   cursor: pointer;
   user-select: none;
   background: ${get('pagination.colors.normal.bg')};
-  border: ${get('borders.1')} ${get('pagination.colors.normal.border')};
+  border-radius: ${get('radii.2')};
   text-decoration: none;
 
   &:first-child {

--- a/src/SelectMenu/SelectMenuHeader.js
+++ b/src/SelectMenu/SelectMenuHeader.js
@@ -21,6 +21,7 @@ const StyledHeader = styled.header`
   display: flex;
   flex: none; // fixes header from getting squeezed in Safari iOS
   padding: ${get('space.3')};
+  border-bottom: ${get('borders.1')} ${get('colors.border.gray')};
   ${COMMON}
   ${TYPOGRAPHY}
 

--- a/src/SelectMenu/SelectMenuList.js
+++ b/src/SelectMenu/SelectMenuList.js
@@ -10,7 +10,6 @@ const listStyles = css`
   overflow-x: hidden;
   overflow-y: auto;
   background-color: ${get('colors.white')};
-  border-top: ${get('borders.1')} ${get('colors.border.gray')};
   -webkit-overflow-scrolling: touch; // Adds momentum + bouncy scrolling
 
   @media (hover: hover) {

--- a/src/SelectMenu/SelectMenuTab.js
+++ b/src/SelectMenu/SelectMenuTab.js
@@ -24,6 +24,7 @@ const tabStyles = css`
     border-bottom-width: 0;
     border-top-left-radius: ${get('radii.2')};
     border-top-right-radius: ${get('radii.2')};
+    background-color: ${get('colors.white')};
   }
 
   &[aria-selected='true'] {

--- a/src/SelectMenu/SelectMenuTab.js
+++ b/src/SelectMenu/SelectMenuTab.js
@@ -13,7 +13,7 @@ const tabStyles = css`
   font-weight: 500;
   color: ${get('colors.gray.5')};
   text-align: center;
-  background-color: transparent;
+  background-color: ${get('colors.gray.1')};
   border: 0;
   box-shadow: inset 0 -1px 0 ${get('colors.border.gray')};
 

--- a/src/SelectMenu/SelectMenuTabPanel.js
+++ b/src/SelectMenu/SelectMenuTabPanel.js
@@ -4,7 +4,7 @@ import styled from 'styled-components'
 import {MenuContext} from './SelectMenuContext'
 import SelectMenuList from './SelectMenuList'
 import theme from '../theme'
-import {COMMON} from '../constants'
+import {COMMON, get} from '../constants'
 
 const TabPanelBase = ({tabName, className, children, ...rest}) => {
   const menuContext = useContext(MenuContext)
@@ -16,6 +16,7 @@ const TabPanelBase = ({tabName, className, children, ...rest}) => {
 }
 
 const TabPanel = styled(TabPanelBase)`
+  border-top: ${get('borders.1')} ${get('colors.border.gray')};
   ${COMMON}
 `
 

--- a/src/SelectMenu/SelectMenuTabs.js
+++ b/src/SelectMenu/SelectMenuTabs.js
@@ -7,7 +7,6 @@ const tabWrapperStyles = css`
   display: flex;
   flex-shrink: 0;
   margin-bottom: -1px; // hide border of element below
-  border-top: ${get('borders.1')} ${get('colors.border.gray')};
   -webkit-overflow-scrolling: touch;
   overflow-x: auto;
   overflow-y: hidden;
@@ -19,7 +18,7 @@ const tabWrapperStyles = css`
 
   @media (min-width: ${get('breakpoints.0')}) {
     padding: 0 ${get('space.2')};
-    border-top: 0;
+    margin-top: ${get('space.3')};
   }
 `
 

--- a/src/SelectMenu/SelectMenuTabs.js
+++ b/src/SelectMenu/SelectMenuTabs.js
@@ -9,6 +9,8 @@ const tabWrapperStyles = css`
   margin-bottom: -1px; // hide border of element below
   border-top: ${get('borders.1')} ${get('colors.border.gray')};
   -webkit-overflow-scrolling: touch;
+  overflow-x: auto;
+  overflow-y: hidden;
 
   // Hide scrollbar so it doesn't cover the text
   &::-webkit-scrollbar {

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -67,6 +67,16 @@ SideNav.Link = styled(Link).attrs(props => {
     border-bottom: none;
   }
 
+  &:first-child {
+    border-top-right-radius: ${get('radii.2')};
+    border-top-left-radius: ${get('radii.2')};
+  }
+
+  &:last-child {
+    border-bottom-right-radius: ${get('radii.2')};
+    border-bottom-left-radius: ${get('radii.2')};
+  }
+
   ${SideNav}.variant-normal > & {
     color: ${get('colors.gray.6')};
     padding: ${get('space.3')};

--- a/src/SideNav.js
+++ b/src/SideNav.js
@@ -24,7 +24,7 @@ function SideNavBase({variant, className, bordered, children, ...props}) {
 }
 
 const SideNav = styled(SideNavBase)`
-  background-color: ${get('colors.gray.0')};
+  background-color: ${get('colors.white')};
 
   ${props =>
     props.bordered &&
@@ -95,26 +95,16 @@ SideNav.Link = styled(Link).attrs(props => {
       text-decoration: none;
       background-color: ${get('colors.gray.1')};
       outline: none;
-
-      // Bar on the left
-      &::before {
-        background-color: ${get('colors.gray.4')};
-      }
-    }
-
-    &:active {
-      background-color: ${get('colors.white')};
     }
 
     &[aria-current='page'],
     &[aria-selected='true'] {
       font-weight: ${get('fontWeights.semibold')};
       color: ${get('colors.gray.9')};
-      background-color: ${get('colors.white')};
 
       // Bar on the left
       &::before {
-        background-color: ${get('colors.orange.5')};
+        background-color: ${get('colors.accent')};
       }
     }
   }

--- a/src/UnderlineNav.js
+++ b/src/UnderlineNav.js
@@ -67,7 +67,7 @@ UnderlineNav.Link = styled.a.attrs(props => ({
   &:focus {
     color: ${get('colors.gray.9')};
     text-decoration: none;
-    border-bottom-color: ${get('colors.accent')};
+    border-bottom-color: ${get('colors.gray.2')};
     transition: 0.2s ease;
 
     .UnderlineNav-octicon {

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -23,8 +23,8 @@ exports[`Button respects the "disabled" prop 1`] = `
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
-  border: 1px solid #e1e4e8;
-  box-shadow: 0px 1px 0px rgba(149,157,165,0.1),inset 0px 2px 0px rgba(255,255,255,0.25);
+  border: 1px solid rgba(27,31,35,0.12);
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.04),inset 0px 2px 0px rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -38,6 +38,10 @@ exports[`Button respects the "disabled" prop 1`] = `
 
 .c0:disabled {
   cursor: default;
+}
+
+.c0[disabled] svg {
+  opacity: 0.6;
 }
 
 .c0:hover {
@@ -108,11 +112,15 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   cursor: default;
 }
 
+.c0[disabled] svg {
+  opacity: 0.6;
+}
+
 .c0:hover {
   color: #fff;
   background-color: #cb2431;
-  border-color: #b31d28;
-  box-shadow: 0px 1px 0px rgba(149,157,165,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
+  border-color: rgba(27,31,35,0.15);
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
 }
 
 .c0:focus {
@@ -123,8 +131,8 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
 .c0:active {
   color: #fff;
   background-color: #be222e;
-  box-shadow: inset 0px 2px 0px rgba(179,29,40,0.4);
-  border-color: #9e1c23;
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
+  border-color: rgba(27,31,35,0.15);
 }
 
 .c0:disabled {
@@ -160,7 +168,7 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   font-size: 14px;
-  color: #005cc5;
+  color: #0366d6;
   border: 1px solid #e1e4e8;
   background-color: #fafbfc;
   box-shadow: 0px 1px 0px rgba(149,157,165,0.1),inset 0px 2px 0px rgba(255,255,255,0.25);
@@ -179,11 +187,15 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   cursor: default;
 }
 
+.c0[disabled] svg {
+  opacity: 0.6;
+}
+
 .c0:hover {
   color: #fff;
   background-color: #0366d6;
-  border-color: #005cc5;
-  box-shadow: 0px 1px 0px rgba(149,157,165,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
+  border-color: rgba(27,31,35,0.15);
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
 }
 
 .c0:focus {
@@ -194,8 +206,8 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
 .c0:active {
   color: #fff;
   background-color: #035fc7;
-  border-color: rgba(4,66,137,.5);
-  box-shadow: inset 0px 1px 0px rgba(4,66,137,0.2);
+  border-color: rgba(27,31,35,0.15);
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
 }
 
 .c0:disabled {
@@ -232,7 +244,7 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   text-decoration: none;
   font-size: 14px;
   color: #fff;
-  background-color: #159739;
+  background-color: #2EA44F;
   border: 1px solid #22863a;
   box-shadow: 0px 1px 0px rgba(20,70,32,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
 }
@@ -250,21 +262,25 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   cursor: default;
 }
 
+.c0[disabled] svg {
+  opacity: 0.6;
+}
+
 .c0:hover {
-  background-color: #138934;
-  border-color: #176f2c;
+  background-color: #2C974B;
+  border-color: rgba(27,31,35,0.15);
 }
 
 .c0:focus {
   border-color: transparent;
   box-shadow: 0 0 0 3px #94D3A2;
-  background-color: #138934;
+  background-color: #2C974B;
 }
 
 .c0:active {
   background-color: #128031;
-  box-shadow: inset 0px 1px 0px rgba(20,70,32,0.2);
-  border-color: #176f2c;
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.1),inset 0px 2px 0px rgba(255,255,255,0.03);
+  border-color: rgba(27,31,35,0.15);
 }
 
 .c0:disabled {

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -40,7 +40,7 @@ exports[`Button respects the "disabled" prop 1`] = `
   cursor: default;
 }
 
-.c0[disabled] svg {
+.c0:disabled svg {
   opacity: 0.6;
 }
 
@@ -112,7 +112,7 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   cursor: default;
 }
 
-.c0[disabled] svg {
+.c0:disabled svg {
   opacity: 0.6;
 }
 
@@ -187,7 +187,7 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   cursor: default;
 }
 
-.c0[disabled] svg {
+.c0:disabled svg {
   opacity: 0.6;
 }
 
@@ -262,7 +262,7 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   cursor: default;
 }
 
-.c0[disabled] svg {
+.c0:disabled svg {
   opacity: 0.6;
 }
 

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -69,8 +69,8 @@ exports[`Dropdown.Button matches the snapshots 1`] = `
   font-size: 14px;
   color: #24292e;
   background-color: #fafbfc;
-  border: 1px solid #e1e4e8;
-  box-shadow: 0px 1px 0px rgba(149,157,165,0.1),inset 0px 2px 0px rgba(255,255,255,0.25);
+  border: 1px solid rgba(27,31,35,0.12);
+  box-shadow: 0px 1px 0px rgba(27,31,35,0.04),inset 0px 2px 0px rgba(255,255,255,0.25);
 }
 
 .c0:hover {
@@ -84,6 +84,10 @@ exports[`Dropdown.Button matches the snapshots 1`] = `
 
 .c0:disabled {
   cursor: default;
+}
+
+.c0[disabled] svg {
+  opacity: 0.6;
 }
 
 .c0:hover {

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -86,7 +86,7 @@ exports[`Dropdown.Button matches the snapshots 1`] = `
   cursor: default;
 }
 
-.c0[disabled] svg {
+.c0:disabled svg {
   opacity: 0.6;
 }
 

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -3,7 +3,7 @@
 exports[`Label respects the "outline" prop 1`] = `
 .c0 {
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   color: #fff;
   border-radius: 100px;
   font-size: 12px;
@@ -32,7 +32,7 @@ exports[`Label respects the "outline" prop 1`] = `
 exports[`Label respects the "variant" prop 1`] = `
 .c0 {
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   color: #fff;
   border-radius: 100px;
   font-size: 14px;

--- a/src/__tests__/__snapshots__/LabelGroup.js.snap
+++ b/src/__tests__/__snapshots__/LabelGroup.js.snap
@@ -11,7 +11,7 @@ exports[`BranchName matches snapshot 1`] = `
 
 .c1 {
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   color: #fff;
   border-radius: 100px;
   font-size: 12px;
@@ -27,7 +27,7 @@ exports[`BranchName matches snapshot 1`] = `
 
 .c2 {
   display: inline-block;
-  font-weight: 600;
+  font-weight: 400;
   color: #fff;
   border-radius: 100px;
   font-size: 12px;

--- a/src/__tests__/__snapshots__/SideNav.js.snap
+++ b/src/__tests__/__snapshots__/SideNav.js.snap
@@ -8,7 +8,7 @@ exports[`SideNav and SideNav.Link renders with default props 1`] = `
 }
 
 .c2 {
-  background-color: #fafbfc;
+  background-color: #fff;
 }
 
 .c3 > .c1 {
@@ -46,20 +46,10 @@ exports[`SideNav and SideNav.Link renders with default props 1`] = `
   outline: none;
 }
 
-.c1.variant-normal > .c3:hover::before,
-.c1.variant-normal > .c3:focus::before {
-  background-color: #959da5;
-}
-
-.c1.variant-normal > .c3:active {
-  background-color: #fff;
-}
-
 .c1.variant-normal > .c3[aria-current='page'],
 .c1.variant-normal > .c3[aria-selected='true'] {
   font-weight: 500;
   color: #24292e;
-  background-color: #fff;
 }
 
 .c1.variant-normal > .c3[aria-current='page']::before,
@@ -112,6 +102,16 @@ exports[`SideNav and SideNav.Link renders with default props 2`] = `
   border-bottom: none;
 }
 
+.c0:first-child {
+  border-top-right-radius: 6px;
+  border-top-left-radius: 6px;
+}
+
+.c0:last-child {
+  border-bottom-right-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
+
 .c1.variant-normal > .c0 {
   color: #586069;
   padding: 16px;
@@ -143,20 +143,10 @@ exports[`SideNav and SideNav.Link renders with default props 2`] = `
   outline: none;
 }
 
-.c1.variant-normal > .c0:hover::before,
-.c1.variant-normal > .c0:focus::before {
-  background-color: #959da5;
-}
-
-.c1.variant-normal > .c0:active {
-  background-color: #fff;
-}
-
 .c1.variant-normal > .c0[aria-current='page'],
 .c1.variant-normal > .c0[aria-selected='true'] {
   font-weight: 500;
   color: #24292e;
-  background-color: #fff;
 }
 
 .c1.variant-normal > .c0[aria-current='page']::before,

--- a/src/__tests__/__snapshots__/UnderlineNavLink.js.snap
+++ b/src/__tests__/__snapshots__/UnderlineNavLink.js.snap
@@ -18,7 +18,7 @@ exports[`UnderlineNav.Link renders the given "as" prop 1`] = `
   color: #24292e;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom-color: #f66a0a;
+  border-bottom-color: #e1e4e8;
   -webkit-transition: 0.2s ease;
   transition: 0.2s ease;
 }
@@ -61,7 +61,7 @@ exports[`UnderlineNav.Link respects the "selected" prop 1`] = `
   color: #24292e;
   -webkit-text-decoration: none;
   text-decoration: none;
-  border-bottom-color: #f66a0a;
+  border-bottom-color: #e1e4e8;
   -webkit-transition: 0.2s ease;
   transition: 0.2s ease;
 }

--- a/src/theme.js
+++ b/src/theme.js
@@ -204,7 +204,7 @@ const buttons = {
   },
   outline: {
     color: {
-      default: blue[6],
+      default: blue[5],
       hover: white,
       active: white,
       disabled: gray[4]

--- a/src/theme.js
+++ b/src/theme.js
@@ -150,7 +150,7 @@ const buttons = {
     },
     shadow: {
       default: ' 0px 1px 0px rgba(20, 70, 32, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
-      active: 'inset 0px 1px 0px rgba(20, 70, 32, 0.2)',
+      active: 'inset 0px 2px 0px rgba(20, 70, 32, 0.2)',
       focus: '0 0 0 3px #94D3A2'
     }
   },
@@ -200,7 +200,7 @@ const buttons = {
     shadow: {
       default: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.25)',
       hover: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
-      active: 'inset 0px 1px 0px rgba(4, 66, 137, 0.2)',
+      active: 'inset 0px 2px 0px rgba(4, 66, 137, 0.2)',
       focus: '0 0 0 3px rgba(3, 102, 214, 0.3)'
     }
   }

--- a/src/theme.js
+++ b/src/theme.js
@@ -136,7 +136,7 @@ const buttons = {
       disabled: gray[4]
     },
     border: {
-      default: colors.border.gray,
+      default: 'rgba(27, 31, 35, 0.12)',
       active: colors.border.grayDark,
       disabled: colors.border.grayLight
     },
@@ -147,7 +147,7 @@ const buttons = {
       disabled: colors.bg.grayLight
     },
     shadow: {
-      default: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.25)',
+      default: '0px 1px 0px rgba(27, 31, 35, 0.04), inset 0px 2px 0px rgba(255, 255, 255, 0.25)',
       hover: '0px 1px 0px rgba(209, 213, 218, 0.2), inset 0px 2px 0px rgba(255, 255, 255, 0.1)',
       active: 'inset 0px 2px 0px rgba(149, 157, 165, 0.1)',
       focus: '0 0 0 3px rgba(3, 102, 214, 0.3)'
@@ -160,20 +160,21 @@ const buttons = {
     },
     border: {
       default: green[6],
-      hover: green[7],
-      active: green[7],
+      hover: 'rgba(27, 31, 35, 0.15)',
+      active: 'rgba(27, 31, 35, 0.15)',
       disabled: 'rgba(34, 134, 58, 0.1)'
     },
     bg: {
-      default: '#159739', //custom green
-      focus: '#138934', //custom green
-      hover: '#138934', //custom green
+      default: '#2EA44F', //custom green
+      focus: '#2C974B', //custom green
+      hover: '#2C974B', //custom green
       active: '#128031', // 2% darker than hover bg
       disabled: '#94D3A2' // custom gray
     },
     shadow: {
       default: ' 0px 1px 0px rgba(20, 70, 32, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
-      active: 'inset 0px 2px 0px rgba(20, 70, 32, 0.2)',
+      active: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
+      hover: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
       focus: '0 0 0 3px #94D3A2'
     }
   },
@@ -186,8 +187,8 @@ const buttons = {
     },
     border: {
       default: colors.border.gray,
-      hover: red[7],
-      active: red[8]
+      hover: 'rgba(27, 31, 35, 0.15)',
+      active: 'rgba(27, 31, 35, 0.15)'
     },
     bg: {
       default: gray[0],
@@ -197,8 +198,8 @@ const buttons = {
     },
     shadow: {
       default: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.25)',
-      hover: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
-      active: 'inset 0px 2px 0px rgba(179, 29, 40, 0.4)',
+      active: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
+      hover: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
       focus: '0 0 0 3px rgba(203, 36, 49, 0.4)'
     }
   },
@@ -211,8 +212,8 @@ const buttons = {
     },
     border: {
       default: gray[2], //border-gray
-      hover: blue[6],
-      active: 'rgba(4, 66, 137, .5)'
+      hover: 'rgba(27, 31, 35, 0.15)',
+      active: 'rgba(27, 31, 35, 0.15)'
     },
     bg: {
       default: gray[0],
@@ -222,8 +223,8 @@ const buttons = {
     },
     shadow: {
       default: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.25)',
-      hover: '0px 1px 0px rgba(149, 157, 165, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
-      active: 'inset 0px 2px 0px rgba(4, 66, 137, 0.2)',
+      active: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
+      hover: '0px 1px 0px rgba(27, 31, 35, 0.1), inset 0px 2px 0px rgba(255, 255, 255, 0.03)',
       focus: '0 0 0 3px rgba(3, 102, 214, 0.3)'
     }
   }

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,6 +1,7 @@
-import {black, white, gray, blue, green, orange, purple, red, yellow} from 'primer-colors'
-import {lineHeights} from 'primer-typography'
+import {colors as colorPrimitives, typography} from '@primer/primitives'
 
+const {lineHeights} = typography
+const {black, white, pink, gray, blue, green, orange, purple, red, yellow} = colorPrimitives
 // General
 const colors = {
   bodytext: gray[9],
@@ -13,6 +14,7 @@ const colors = {
   purple,
   red,
   yellow,
+  pink,
   blackfade15: 'rgba(27, 31, 35, 0.15)',
   blackfade20: 'rgba(27, 31, 35, 0.20)',
   blackfade30: 'rgba(27,31,35,0.3)',
@@ -50,7 +52,28 @@ const colors = {
     grayLight: gray[0],
     disabled: '#F3F4F6'
   },
-  accent: orange[5]
+  accent: orange[5],
+  labels: {
+    gray: gray[2],
+    grayText: gray[9],
+    grayDark: gray[5],
+    grayDarkText: gray[9],
+    blue: blue[5],
+    blueText: blue[5],
+    orange: orange[5],
+    orangeText: orange[6],
+    green: green[5],
+    greenText: green[6],
+    red: red[6],
+    redText: red[6],
+    yellow: yellow[6],
+    yellowText: yellow[9],
+    pink: pink[4],
+    pinkText: pink[6],
+    purple: purple[4],
+    purple: [5]
+
+  }
 }
 
 const breakpoints = ['544px', '768px', '1012px', '1280px']

--- a/src/theme.js
+++ b/src/theme.js
@@ -71,8 +71,7 @@ const colors = {
     pink: pink[4],
     pinkText: pink[6],
     purple: purple[4],
-    purple: [5]
-
+    purpleText: [5]
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1982,6 +1982,11 @@
   dependencies:
     prop-types "^15.6.1"
 
+"@primer/primitives@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@primer/primitives/-/primitives-2.0.1.tgz#060b0882cdf75c3100db84100bb40538628bb63f"
+  integrity sha512-1zMGwqAfeTU3bOcsxzVgJlCPKTeDtDIP3h+Hm7qTvU0ez/87WZqjLKY6Jl7EBp9WH5VSm+LNwo56KfajInd3/w==
+
 "@reach/component-component@^0.3.0":
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/@reach/component-component/-/component-component-0.3.0.tgz#ccf593e26132cbec0ad92774b80356dcf544d5c5"
@@ -8653,16 +8658,6 @@ pretty-format@^25.0.0:
     ansi-regex "^4.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.8.4"
-
-primer-colors@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-colors/-/primer-colors-1.0.1.tgz#9bc2dbfefeba3ec987eb7d71c6a3d14c67ae9c35"
-  integrity sha512-bxo3OPoIO1F/C07RpKbLjPzuSsTkOMzo9Yl9OJFHGD7/UxA+JvNdZK0GbJzWtz5Y8H6KabbHadxwVWRp1xl08A==
-
-primer-typography@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/primer-typography/-/primer-typography-1.0.1.tgz#559c03e0d2470fa2d48a4166a63091f4b1162759"
-  integrity sha512-9f1MNOMYOWemosmJIG8FToqZoL7YKQW3KHNsMS3DddTUzJefnVzeqmiiTBPc2ok0yE7fE2PgobG9iRY+itgdVg==
 
 private@^0.1.6, private@~0.1.5:
   version "0.1.8"


### PR DESCRIPTION
This PR makes the tweaks listed out in #731 ✨



- [x] Update selected style for primary and outline box shadow to 2px instead of 1px
- [x] Update UnderlineNav & SideNav states (removed bar on the left on hover/focus)
- [x] SideNav should have had a white background, but it was grey so I updated that
- [x] The grey background hover on SideNav items was overlapping the border radius of the container, so I added border radius to the first and last SideNav items
- [x] Fix SelectMenu tab styles
- [x] disabled state for buttons with color icon
- [x] Change back the text in labels and topic tags from font-weight 500 to 400
- [x] Add label colors to the theme
- [x] Spacing between select menu header and select menu tabs was mistakingly set as 24px. I have no changed it to 16px. 
- [x] Update blue text in Links, Outline button to blue[5]
- [x] A bunch of button tweaks: https://github.com/github/design-systems/issues/770#issuecomment-605783773 

#### Notes
- I added the label colors to the theme so that folks can pull from the theme if they'd like to use them, but we might want to think about whether or not we want to add some kind of `colorScheme` prop in the future to make using these easier.

- I removed `primer-colors` and `primer-typography` and moved over to `@primer/primitives`

- I had one question for @auareyou about the active/selected/hover state for SideNav that I left in the comments

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
