### PR TITLE
Loosen 'as' prop for Heading

### DIFF
--- a/docs/content/Heading.md
+++ b/docs/content/Heading.md
@@ -19,4 +19,4 @@ Heading components get `TYPOGRAPHY` and `COMMON` system props. Read our [System 
 
 | Prop name | Type    | Description                                      |
 | :-------- | :------ | :----------------------------------------------- |
-| as        | String  | sets the HTML tag for the component              |
+| as        | String or React element  | sets the HTML tag for the component              |

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,9 +72,7 @@ declare module '@primer/components' {
     extends BaseProps,
       CommonProps,
       TypographyProps,
-      Omit<React.HTMLAttributes<HTMLHeadingElement>, 'color'> {
-    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
-  }
+      Omit<React.HTMLAttributes<HTMLHeadingElement>, 'color'> { }
 
   export const Heading: React.FunctionComponent<HeadingProps>
 
@@ -303,7 +301,7 @@ declare module '@primer/components' {
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
-  
+
   export interface SelectMenuItemProps extends Omit<CommonProps, 'as'>,
     Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
     selected?: boolean

--- a/src/Heading.js
+++ b/src/Heading.js
@@ -15,7 +15,6 @@ Heading.defaultProps = {
 }
 
 Heading.propTypes = {
-  as: PropTypes.oneOf(['h1', 'h2', 'h3', 'h4', 'h5', 'h6']),
   theme: PropTypes.object,
   ...COMMON.propTypes,
   ...TYPOGRAPHY.propTypes

--- a/src/__tests__/Heading.js
+++ b/src/__tests__/Heading.js
@@ -46,7 +46,7 @@ describe('Heading', () => {
     expect(Heading).toSetDefaultTheme()
   })
 
-  it('respects the is prop', () => {
+  it('respects the as prop', () => {
     expect(render(<Heading as="h6" />).type).toEqual('h6')
   })
 


### PR DESCRIPTION
At first glance, it makes sense to restrict the `as` prop on `Heading` to `h1` through `h6`; however, this makes styled components invalid for this prop, and breaks patterns [like this one](https://github.com/primer/doctocat/blob/c55bdc6a4ef464e6330260034e28d3b7991b41f8/theme/src/components/heading.js#L79-L84):

```javascript
const StyledH1 = styled(StyledHeading).attrs({as: 'h1'})`
  padding-bottom: ${themeGet('space.1')};
  font-size: ${themeGet('fontSizes.5')};
  border-bottom: 1px solid ${themeGet('colors.gray.2')};
`

const StyledH2 = styled(StyledHeading).attrs({as: 'h2'})`
  padding-bottom: ${themeGet('space.1')};
  font-size: ${themeGet('fontSizes.4')};
  border-bottom: 1px solid ${themeGet('colors.gray.2')};
`

const StyledH3 = styled(StyledHeading).attrs({as: 'h3'})`
  font-size: ${themeGet('fontSizes.3')};
`

const StyledH4 = styled(StyledHeading).attrs({as: 'h4'})`
  font-size: ${themeGet('fontSizes.2')};
`

const StyledH5 = styled(StyledHeading).attrs({as: 'h5'})`
  font-size: ${themeGet('fontSizes.1')};
`

const StyledH6 = styled(StyledHeading).attrs({as: 'h6'})`
  font-size: ${themeGet('fontSizes.1')};
  color: ${themeGet('colors.gray.5')};
`

export const H1 = props => <MarkdownHeading as={StyledH1} {...props} />
export const H2 = props => <MarkdownHeading as={StyledH2} {...props} />
export const H3 = props => <MarkdownHeading as={StyledH3} {...props} />
export const H4 = props => <MarkdownHeading as={StyledH4} {...props} />
export const H5 = props => <MarkdownHeading as={StyledH5} {...props} />
export const H6 = props => <MarkdownHeading as={StyledH6} {...props} />
```

This PR loosens the restriction to the standard `as` prop, which is any `React.ReactType`.