### PR TITLE
Add `shape` prop to `Avatar` component

### DIFF
--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -31,3 +31,4 @@ Avatar components get `COMMON` system props. Read our [System Props](/system-pro
 | isChild | Boolean | | adds the `avatar-child` class if present |
 | size | Number | 20 | adds the `avatar-small` class if less than 24 |
 | src | String | | The source url of the avatar image |
+| form | String | `square` | The form of the avatar image. Can be `square` or `round` |

--- a/docs/content/Avatar.mdx
+++ b/docs/content/Avatar.mdx
@@ -31,4 +31,4 @@ Avatar components get `COMMON` system props. Read our [System Props](/system-pro
 | isChild | Boolean | | adds the `avatar-child` class if present |
 | size | Number | 20 | adds the `avatar-small` class if less than 24 |
 | src | String | | The source url of the avatar image |
-| form | String | `square` | The form of the avatar image. Can be `square` or `round` |
+| shape | String | `square` | The shape of the avatar image. Can be `square` or `round` |

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,7 +114,7 @@ declare module '@primer/components' {
   export interface AvatarProps extends CommonProps, Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'color'> {
     isChild?: boolean
     size?: number
-    form?: 'square' | 'round'
+    shape?: 'square' | 'round'
   }
 
   export const Avatar: React.FunctionComponent<AvatarProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -114,6 +114,7 @@ declare module '@primer/components' {
   export interface AvatarProps extends CommonProps, Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'color'> {
     isChild?: boolean
     size?: number
+    form?: 'square' | 'round'
   }
 
   export const Avatar: React.FunctionComponent<AvatarProps>

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -5,9 +5,9 @@ import {space} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 import theme from './theme'
 
-function borderRadius({size, form}) {
+function borderRadius({size, shape}) {
   return {
-    borderRadius: form === 'round' ? '50%' : (size <= 24 ? '2px' : '3px')
+    borderRadius: shape === 'round' ? '50%' : size <= 24 ? '2px' : '3px'
   }
 }
 
@@ -28,7 +28,7 @@ Avatar.defaultProps = {
   theme,
   size: 20,
   alt: '',
-  form: 'square'
+  shape: 'square'
 }
 
 Avatar.propTypes = {
@@ -36,8 +36,8 @@ Avatar.propTypes = {
   size: PropTypes.number,
   src: PropTypes.string,
   ...systemPropTypes.space,
-  theme: PropTypes.object,
-  form: PropTypes.PropTypes.oneOf(['square', 'round'])
+  shape: PropTypes.PropTypes.oneOf(['square', 'round']),
+  theme: PropTypes.object
 }
 
 export default Avatar

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -5,9 +5,18 @@ import {space} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 import theme from './theme'
 
+function borderRadiusValue({size, shape}) {
+  switch (shape) {
+    case 'round':
+      return '50%'
+    default:
+      return size <= 24 ? '2px' : '3px'
+  }
+}
+
 function borderRadius({size, shape}) {
   return {
-    borderRadius: shape === 'round' ? '50%' : size <= 24 ? '2px' : '3px'
+    borderRadius: borderRadiusValue({size, shape})
   }
 }
 

--- a/src/Avatar.js
+++ b/src/Avatar.js
@@ -5,9 +5,9 @@ import {space} from 'styled-system'
 import systemPropTypes from '@styled-system/prop-types'
 import theme from './theme'
 
-function borderRadius({size}) {
+function borderRadius({size, form}) {
   return {
-    borderRadius: size <= 24 ? '2px' : '3px'
+    borderRadius: form === 'round' ? '50%' : (size <= 24 ? '2px' : '3px')
   }
 }
 
@@ -27,7 +27,8 @@ const Avatar = styled.img.attrs(props => ({
 Avatar.defaultProps = {
   theme,
   size: 20,
-  alt: ''
+  alt: '',
+  form: 'square'
 }
 
 Avatar.propTypes = {
@@ -35,7 +36,8 @@ Avatar.propTypes = {
   size: PropTypes.number,
   src: PropTypes.string,
   ...systemPropTypes.space,
-  theme: PropTypes.object
+  theme: PropTypes.object,
+  form: PropTypes.PropTypes.oneOf(['square', 'round'])
 }
 
 export default Avatar

--- a/src/__tests__/Avatar.js
+++ b/src/__tests__/Avatar.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Avatar from '../Avatar'
 import theme from '../theme'
-import {px, render} from '../utils/testing'
+import {px, render, percent} from '../utils/testing'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
@@ -42,5 +42,9 @@ describe('Avatar', () => {
 
   it('respects margin props', () => {
     expect(render(<Avatar m={2} alt="" />)).toHaveStyleRule('margin', px(theme.space[2]))
+  })
+
+  it('respects form prop', () => {
+    expect(render(<Avatar form="round" alt="" />)).toHaveStyleRule('border-radius', percent(50))
   })
 })

--- a/src/__tests__/Avatar.js
+++ b/src/__tests__/Avatar.js
@@ -44,7 +44,7 @@ describe('Avatar', () => {
     expect(render(<Avatar m={2} alt="" />)).toHaveStyleRule('margin', px(theme.space[2]))
   })
 
-  it('respects form prop', () => {
-    expect(render(<Avatar form="round" alt="" />)).toHaveStyleRule('border-radius', percent(50))
+  it('respects shape prop', () => {
+    expect(render(<Avatar shape="round" alt="" />)).toHaveStyleRule('border-radius', percent(50))
   })
 })

--- a/src/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/__tests__/__snapshots__/Avatar.js.snap
@@ -12,8 +12,8 @@ exports[`Avatar renders default props 1`] = `
 <img
   alt=""
   className="c0"
-  form="square"
   height={20}
+  shape="square"
   size={20}
   width={20}
 />

--- a/src/__tests__/__snapshots__/Avatar.js.snap
+++ b/src/__tests__/__snapshots__/Avatar.js.snap
@@ -12,6 +12,7 @@ exports[`Avatar renders default props 1`] = `
 <img
   alt=""
   className="c0"
+  form="square"
   height={20}
   size={20}
   width={20}

--- a/src/utils/testing.js
+++ b/src/utils/testing.js
@@ -70,6 +70,10 @@ export function px(value) {
   return typeof value === 'number' ? `${value}px` : value
 }
 
+export function percent(value) {
+  return typeof value === 'number' ? `${value}%` : value
+}
+
 export function renderStyles(node) {
   const {
     props: {className}


### PR DESCRIPTION
First pull request here. Not sure if I might be braking some design rules. If so, I would gladly discuss this with you with the goal to achieve a better solution.

If you want (which you more or less always want, although maybe not on github.com) to use a round `Avatar` component, you currently have to supply inline styling. From my short time with building with primer components (outside of github.com) I sense this is an anti-pattern.

My solution here is to add a `shape` prop to the `Avatar` component that can either be passed in as `square` or `round`. If passed in as `square`, everything is as normal, but if passed in as `round`, the `borderRadius` will be set to `50%` to achieve a round avatar image.  

### Screenshots

**Before**
![image](https://user-images.githubusercontent.com/19674362/79507882-cf242d80-8038-11ea-9b74-d1a7eec81e82.png)


**After**
![image](https://user-images.githubusercontent.com/19674362/79507843-b7e54000-8038-11ea-9e2a-6f1d77f7bb68.png)


### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge
