### PR TITLE
Remove "Segoe UI Symbol" from font stack

### DIFF
--- a/src/theme.js
+++ b/src/theme.js
@@ -64,8 +64,7 @@ const fonts = {
     'Arial',
     'sans-serif',
     'Apple Color Emoji',
-    'Segoe UI Emoji',
-    'Segoe UI Symbol'
+    'Segoe UI Emoji'
   ]),
   mono: fontStack(['SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', 'Courier', 'monospace'])
 }


### PR DESCRIPTION
Hi there 👋 , I'm from GitHub Insights.

@lukehefson recently pointed out that `Segoe UI Symbol` was removed in https://github.com/primer/css/pull/906 to support Chinese characters. Looks like that fix didn't make it's way into Primer Components. This PR adds that fix to Primer Components.

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

cc @levindixon