### PR TITLE
`text-align: center` on base button styles

### DIFF
--- a/src/ButtonStyles.js
+++ b/src/ButtonStyles.js
@@ -14,6 +14,7 @@ export default css`
   border-radius: ${get('radii.2')};
   appearance: none;
   text-decoration: none;
+  text-align: center;
 
   &:hover {
     // needed to override link styles


### PR DESCRIPTION
Currently, buttons that use the `as` property placed inside of a `Flex` container will automatically get a left-aligned text. I suppose this is not a expected behaviour. If it is, please let me know 👍 

My solution is to default the `ButtonStyles` to align it's text to `center` (ie. `text-align: center`)

Closes https://github.com/primer/components/issues/771

### Screenshots
**Before**
![image](https://user-images.githubusercontent.com/19674362/79639322-7c0ebf80-818b-11ea-87d4-465844c5b085.png)

**After**
![image](https://user-images.githubusercontent.com/19674362/79639313-6f8a6700-818b-11ea-82dd-0950384c5944.png)

### Merge checklist
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge