### PR TITLE
Fix typo 'Dropdown.Caret.propTpyes' to 'Dropdown.Caret.propTypes'

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -140,7 +140,7 @@ Dropdown.Item.propTypes = {
 Dropdown.Button.defaultProps = {theme}
 
 Dropdown.Caret.defaultProps = {theme}
-Dropdown.Caret.propTpyes = {
+Dropdown.Caret.propTypes = {
   ...COMMON.propTypes
 }
 


### PR DESCRIPTION
I noticed that this line was typo'd

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
