### PR TITLE
Add documentation about TypeScript support

### DIFF
--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -56,6 +56,12 @@ This will apply the same `color`, `font-family`, and `line-height` styles to the
 
 Primer Components includes TypeScript support with no additional `@types` package necessary. You will need to install `@types/styled-components` and `@types/react` if you import either of those packages.
 
+Once installed, you can import components and their prop type interfaces from the `@primer/components` package:
+
+```typescript
+import {BorderBox, BorderBoxProps} from '@primer/components'
+```
+
 ### Fixing "Duplicate identifier 'FormData'"
 
 Ever since `@types/styled-components` version `14.1.19`, it has a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -54,7 +54,7 @@ This will apply the same `color`, `font-family`, and `line-height` styles to the
 
 ## TypeScript
 
-Primer Components includes TypeScript support with no additional `@types` package necessary. You will need to install `@types/styled-components` and `@types/react`, as `styled-components` and `react` are [both peer dependencies](#installing-peer-dependencies).
+Primer Components includes TypeScript support with no additional `@types` package necessary. You will need to install `@types/styled-components` and `@types/react` if you import either of those packages.
 
 ### Fixing "Duplicate identifier 'FormData'"
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -51,3 +51,27 @@ export default const MyApp = () => (
 ```
 
 This will apply the same `color`, `font-family`, and `line-height` styles to the `<body>` as [Primer CSS's base styles](https://github.com/primer/css/blob/master/src/base/base.scss#L15-L20).
+
+## TypeScript
+
+Primer Components includes TypeScript support with no additional `@types` package necessary. You will need to install `@types/styled-components` and `@types/react`, as `styled-components` and `react` are [both peer dependencies](#installing-peer-dependencies).
+
+### Fixing "Duplicate identifier 'FormData'"
+
+Since version 14.1.9, `@types/styled-components` has a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.
+
+You may run into this conflict even if you're not importing anything from `react-native` or don't have it installed. This is because the TypeScript compiler automatically includes types from the folders in `node_modules/@types` automatically. The TypeScript compiler allows you to opt-out of this behavior [using the `typeRoots` and `types` configuration options](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
+
+The best solution for this error — for now — seems to be disabling the automatic inclusion of `node_modules/@types` and instead listing the types you want to be included individually.
+
+In your `tsconfig.json`, set the `types` array under the `compilerOptions` like so:
+
+```diff
+{
+  "compilerOptions": {
+    "types": ["node", "react", "styled-components", "jest"]
+  }
+}
+```
+
+Of course, customize the array based on the `@types/` packages you have installed for your project.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -72,7 +72,7 @@ The best solution for this error — for now — seems to be disabling the auto
 
 In your `tsconfig.json`, set the `types` array under the `compilerOptions` like so:
 
-```diff
+```json
 {
   "compilerOptions": {
     "types": ["node", "react", "styled-components", "jest"]

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -54,7 +54,7 @@ This will apply the same `color`, `font-family`, and `line-height` styles to the
 
 ## TypeScript
 
-Primer Components includes TypeScript support with no additional `@types` package necessary. You will need to install `@types/styled-components` and `@types/react` if you import either of those packages.
+Primer Components includes TypeScript support and ships with its own typings. You will need to install `@types/styled-components` and `@types/react` if you import either of those packages directly, as normal.
 
 Once installed, you can import components and their prop type interfaces from the `@primer/components` package:
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -58,7 +58,7 @@ Primer Components includes TypeScript support with no additional `@types` packag
 
 ### Fixing "Duplicate identifier 'FormData'"
 
-Since version 14.1.9, `@types/styled-components` has a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.
+Ever since `@types/styled-components` version `14.1.19`, it has a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.
 
 You may run into this conflict even if you're not importing anything from `react-native` or don't have it installed. This is because the TypeScript compiler automatically includes types from the folders in `node_modules/@types` automatically. The TypeScript compiler allows you to opt-out of this behavior [using the `typeRoots` and `types` configuration options](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -64,7 +64,7 @@ import {BorderBox, BorderBoxProps} from '@primer/components'
 
 ### Fixing "Duplicate identifier 'FormData'"
 
-Ever since `@types/styled-components` version `14.1.19`, it has a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.
+Ever since `@types/styled-components` version `14.1.19`, it has had a dependency of both `@types/react` and `@types/react-native`. Unfortunately, those declarations clash; for more information, see [issue 33311](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33311) and [issue 33015](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/33015) in the DefinitelyTyped repo.
 
 You may run into this conflict even if you're not importing anything from `react-native` or don't have it installed. This is because the TypeScript compiler automatically includes types from the folders in `node_modules/@types` automatically. The TypeScript compiler allows you to opt-out of this behavior [using the `typeRoots` and `types` configuration options](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#types-typeroots-and-types).
 


### PR DESCRIPTION
This PR adds some notes about TypeScript to the Getting Started page. It includes information gathered primarily from @smockle in a PR from another project (thank you @smockle!)

https://primer-components-git-mkt-types-docs.primer.now.sh/components/getting-started#typescript

Closes #782