### PR TITLE
Allow SelectMenu.Item to be `a` or `button`

### DIFF
--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -116,6 +116,8 @@ SelectMenu.List components do not get any additional props besides system props.
 
 Individual items in a select menu. SelectMenu.Item renders an anchor tag by default, you'll need to make sure to provide the appropriate `href`. 
 
+You can use a `button` tag instead by utilizing the [`as` prop](/core-concepts#the-as-prop). Be sure to consider [which HTML element is the right choice](https://marcysutton.com/links-vs-buttons-in-modern-web-applications) for your usage of the component. 
+
 ```jsx
 <SelectMenu.Item href="/link/to/thing" selected={true}>
   {/* wraps an individual list item*/}

--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -114,10 +114,10 @@ SelectMenu.List components do not get any additional props besides system props.
 
 ## SelectMenu.Item
 
-Individual items in a select menu.
+Individual items in a select menu. SelectMenu.Item renders an anchor tag by default, you'll need to make sure to provide the appropriate `href`. 
 
 ```jsx
-<SelectMenu.Item selected={true}>
+<SelectMenu.Item href="/link/to/thing" selected={true}>
   {/* wraps an individual list item*/}
 </SelectMenu.Item>
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -302,7 +302,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
-  export interface SelectMenuItemProps extends Omit<CommonProps, 'as'>,
+  export interface SelectMenuItemProps extends CommonProps,
     Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
     selected?: boolean
   }

--- a/src/SelectMenu/SelectMenuItem.js
+++ b/src/SelectMenu/SelectMenuItem.js
@@ -19,6 +19,8 @@ export const listItemStyles = css`
   border-bottom: ${get('borders.1')} ${get('colors.border.grayLight')};
   color: ${get('colors.text.gray')};
   text-decoration: none;
+  font-size: ${get('fontSizes.0')};
+  width: 100%;
 
   &:hover {
     text-decoration: none;

--- a/src/SelectMenu/SelectMenuItem.js
+++ b/src/SelectMenu/SelectMenuItem.js
@@ -95,9 +95,7 @@ const StyledItem = styled.a.attrs(() => ({
   ${COMMON}
 `
 
-// 'as' is spread out because we don't want users to be able to change the tag. using something
-// other than 'a' will break a11y.
-const SelectMenuItem = ({children, selected, theme, onClick, as, ...rest}) => {
+const SelectMenuItem = ({children, selected, theme, onClick, ...rest}) => {
   const menuContext = useContext(MenuContext)
 
   // close the menu when an item is clicked

--- a/src/__tests__/SelectMenu.js
+++ b/src/__tests__/SelectMenu.js
@@ -74,16 +74,6 @@ describe('SelectMenu', () => {
     expect(component.find('details').length).toEqual(1)
   })
 
-  it('does not allow the "as" prop on SelectMenu.Item', () => {
-    const component = mount(<BasicSelectMenu as="span" />)
-    expect(
-      component
-        .find("[data-test='menu-item']")
-        .first()
-        .getDOMNode().tagName
-    ).toEqual('A')
-  })
-
   it('shows correct initial tab', () => {
     const testInstance = renderRoot(<MenuWithTabs />)
     expect(testInstance.findByProps({'aria-selected': true}).props.children).toBe('Organization')


### PR DESCRIPTION
This PR allows the `SelectMenu.Item` component to have access to the `as` prop so that users can make it a ` button` if needed. @dmarcey made a good point that sometimes you might want a button instead of an anchor tag as a select menu item, since not all actions taken in a select menu have an `href`. [More info on links vs buttons in SPAs here](https://marcysutton.com/links-vs-buttons-in-modern-web-applications)

I considered rewriting the type definition to only allow a `button` or `a` tag, but I figured there might be some cases where someone might need to pass in a styled component to the `as` tag (even though generally we recommend against this).


### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/master/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
