### PR TITLE
Type 'SelectMenuItem' according to 'as'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -302,10 +302,16 @@ declare module '@primer/components' {
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
-  export interface SelectMenuItemProps extends CommonProps,
-    Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
-    selected?: boolean
+  interface SelectMenuItemCommonProps extends CommonProps {
+    selected?: boolean;
   }
+  interface SelectMenuItemAsButtonProps extends SelectMenuItemCommonProps, Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'color'> {
+    as: "button"
+  }
+  interface SelectMenuItemAsAnchorProps extends SelectMenuItemCommonProps, Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
+    as: "a"
+  }
+  export type SelectMenuItemProps = SelectMenuItemAsButtonProps | SelectMenuItemAsAnchorProps;
 
   export interface SelectMenuFooterProps extends CommonProps, Omit<React.HTMLAttributes<HTMLElement>, 'color'> {}
 


### PR DESCRIPTION
Defines `SelectMenuItemProps` as a [discriminated union](https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).

Follow-up testing: Does this mean the `as` prop is required? If so, can/should we default to either `a` or `button`?