### PR TITLE
⚠️ Update link to theme file ⚠️

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ Default values for system props can be set in `Component.defaultProps`.
 
 Prop Types from system props such as `COMMON` or `TYPOGRAPHY` as well as styled-system functions can be spread in the component's prop types declaration (see example below). These need to go *after* any built-in styles that you want to be overridable.
 
- ⚠️ **Make sure to always set the default `theme` prop to our [theme](https://github.com/primer/components/blob/master/src/theme.js)! This allows consumers of our components to access our theme values without a ThemeProvider.**
+ ⚠️ **Make sure to always set the default `theme` prop to our [theme](https://github.com/primer/components/blob/master/src/theme-preval.js)! This allows consumers of our components to access our theme values without a ThemeProvider.**
 
 Additionally, every component should support [the `sx` prop](https://primer.style/components/overriding-styles); remember to add `${sx}` to the style literal and `...sx.propTypes` to the component's `propTypes`.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This will set the `color`, `font-family`, and `line-height` CSS properties to th
 
 #### Theming
 
-Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme.js) by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
 ```jsx
 import {ThemeProvider} from 'styled-components'

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -71,7 +71,7 @@ This will apply the same `color`, `font-family`, and `line-height` styles to the
 
 ## Theming
 
-Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme.js) by default, but you can provide your own theme by using [styled-component's](https://styled-components.com/) `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) by default, but you can provide your own theme by using [styled-component's](https://styled-components.com/) `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
 
 ```jsx
 import {ThemeProvider} from 'styled-components'

--- a/docs/content/primer-theme.md
+++ b/docs/content/primer-theme.md
@@ -4,13 +4,13 @@ title: Primer Theme
 
 import {theme} from '@primer/components'
 
-Primer Components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
+Primer Components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
 
 Many of our theme keys correspond to system props on our components. For example, if you'd like to set the max width on a `<Box>` set the `maxWidth` prop to `medium`: `<Box maxWidth='medium'>`
 
 In the background, [styled-system](https://github.com/styled-system/styled-system) does the work of finding the `medium` value from `maxWidth` key in the theme file and applying the corresponding CSS.
 
-Our full theme can be found [here](https://github.com/primer/components/blob/master/src/theme.js).
+Our full theme can be found [here](https://github.com/primer/components/blob/master/src/theme-preval.js).
 
 ### Custom Theming
 


### PR DESCRIPTION
Fixes a issue where the link to the theme file from the documentation page does not link to the actual theme file on github. This fixes this.

Closes #805

### Screenshots

#### Before

![CleanShot 2020-05-08 at 22 44 02](https://user-images.githubusercontent.com/19674362/81447725-751d1080-917d-11ea-82dc-beb68598eefa.gif)

#### After

![CleanShot 2020-05-08 at 22 44 59](https://user-images.githubusercontent.com/19674362/81447812-98e05680-917d-11ea-88ac-fd5bc5db0273.gif)


### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge