### PR TITLE
Use React.ReactNode type for TextInput icon property

### DIFF
--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -29,4 +29,4 @@ Native `<input>` attributes are forwarded to the underlying React `input` compon
 | width | String or Number | | Set the width of the input |
 | maxWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the maximum width of the input |
 | minWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the minimum width of the input |
-| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the right edge. | 
+| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the left edge. | 

--- a/index.d.ts
+++ b/index.d.ts
@@ -379,7 +379,7 @@ declare module '@primer/components' {
       StyledSystem.MinWidthProps,
       Omit<React.InputHTMLAttributes<HTMLInputElement>, 'color' | 'size' | 'width'> {
     block?: boolean
-    icon?: React.ReactElement
+    icon?: React.ReactNode
     variant?: 'small' | 'large'
   }
 


### PR DESCRIPTION
Small fix for TextInput types:

In all places Icon passed as `React.ReactNode`, but only `TextInput` uses `React.ReactElement` which throws type error

<img width="1552" alt="image" src="https://user-images.githubusercontent.com/827338/81593633-97c54a00-9374-11ea-8ce2-2d7ccd22e28a.png">


Also fixed note about icon position, because it is actually on the left edge:

<img width="654" alt="image" src="https://user-images.githubusercontent.com/827338/81593344-25ed0080-9374-11ea-94f5-6964e6734a18.png">
<img width="649" alt="image" src="https://user-images.githubusercontent.com/827338/81593388-3a30fd80-9374-11ea-8221-b4e804dd4cf0.png">

