### PR TITLE
Separate test and publish workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Primer Components Workflow
+name: Primer Components
 on: [push]
 
 jobs:
@@ -10,12 +10,6 @@ jobs:
 
       - name: Install dependencies
         run: yarn
-
-      - name: Lint
-        run: yarn run lint
-
-      - name: Test
-        run: yarn test
 
       - name: Publish to the npm registry
         uses: "primer/publish@v2.0.0"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Primer Components
+on: [pull_request]
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install dependencies
+        run: yarn
+
+      - name: Lint
+        run: yarn run lint
+
+      - name: Test
+        run: yarn test


### PR DESCRIPTION
Currently, the test suite does not run for pull requests from a forked repository. This PR separates our workflows into `publish`, which is responsible for publishing new RCs to npm, and `test`, which runs the test suite and runs on `pull_request` instead of `push`.