### PR TITLE
Contribution Docs Addtions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ If you're looking for something to work on, a great place to start is our issues
 
 ## Before Getting Started
 
-A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, but here are a few things we take into consideration:
+A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, here are a few things we take into consideration:
 
 - Is the new feature an existing pattern in Primer CSS or related to UI built at GitHub? Primer Components is first and foremost a library for building UI at GitHub - patterns that aren't currently being used in GitHub UI (either on github.com or in a GitHub owned project outside the monolith) probably shouldn't be added to Primer Components. Exceptions to this could be helper components that don't necessarily render UI but help with the development process (like `Flex`, `Grid`, or `Box`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ If you're looking for something to work on, a great place to start is our issues
 
 A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, here are a few things we take into consideration:
 
-- Is the new feature an existing pattern in Primer CSS or related to UI built at GitHub? Primer Components is first and foremost a library for building UI at GitHub - patterns that aren't currently being used in GitHub UI (either on github.com or in a GitHub owned project outside the monolith) probably shouldn't be added to Primer Components. Exceptions to this could be helper components that don't necessarily render UI but help with the development process (like `Flex`, `Grid`, or `Box`).
+- Is the new feature an existing pattern in Primer CSS or related to UI built at GitHub? Primer Components is first and foremost a library for building UI at GitHub - patterns that aren't currently being used in GitHub UI (either on github.com or in a GitHub owned project outside of github.com) probably shouldn't be added to Primer Components. Exceptions to this could be helper components that don't necessarily render UI but help with the development process (like `Flex`, `Grid`, or `Box`).
 
 - Does the proposed component get used in more than one or two places across GitHub UI? A component that's only meant to be used in one place and doesn't have potential to be reused in many places probably should exist as a local component. An example of something like this might be a component that renders content specific to a single GitHub product.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,7 @@
 # Contribution guidelines
 
 1. [Roadmap](#roadmap)
+2. [Before Getting Started](#before-getting-started)
 2. [Developing Components](#developing-components)
     * [Tools we use](#tools-we-use)
     * [Component patterns](#component-patterns)
@@ -27,12 +28,15 @@
 
 If you're looking for something to work on, a great place to start is our issues labeled [up for grabs](https://github.com/primer/components/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)! If you've got a feature that you'd like to implement, be sure to check out our [Primer Components Roadmap](https://github.com/primer/components/projects/3) to make sure it hasn't already been started on.
 
-## New Feature Proposals
-A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, here are a few things we take into consideration:
+## Before Getting Started
+
+A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, but here are a few things we take into consideration:
 
 - Is the new feature an existing pattern in Primer CSS or related to UI built at GitHub? Primer Components is first and foremost a library for building UI at GitHub - patterns that aren't currently being used in GitHub UI (either on github.com or in a GitHub owned project outside the monolith) probably shouldn't be added to Primer Components. Exceptions to this could be helper components that don't necessarily render UI but help with the development process (like `Flex`, `Grid`, or `Box`).
 
 - Does the proposed component get used in more than one or two places across GitHub UI? A component that's only meant to be used in one place and doesn't have potential to be reused in many places probably should exist as a local component. An example of something like this might be a component that renders content specific to a single GitHub product.
+
+**In general, we tend to be pretty excited about 99% of feature proposals and contributions,** but if you'd like to double check before starting work, feel free to leave open an issue in our repo!
 
 
 ## Developing components

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,14 @@
 
 If you're looking for something to work on, a great place to start is our issues labeled [up for grabs](https://github.com/primer/components/issues?q=is%3Aopen+is%3Aissue+label%3A%22up+for+grabs%22)! If you've got a feature that you'd like to implement, be sure to check out our [Primer Components Roadmap](https://github.com/primer/components/projects/3) to make sure it hasn't already been started on.
 
+## New Feature Proposals
+A common question asked about Primer Components is how to know what should be added to Primer Components and what is best left as a local component in a consuming applcation. Though there are no hard & fast rules about what can and cannot be added to Primer Components, here are a few things we take into consideration:
+
+- Is the new feature an existing pattern in Primer CSS or related to UI built at GitHub? Primer Components is first and foremost a library for building UI at GitHub - patterns that aren't currently being used in GitHub UI (either on github.com or in a GitHub owned project outside the monolith) probably shouldn't be added to Primer Components. Exceptions to this could be helper components that don't necessarily render UI but help with the development process (like `Flex`, `Grid`, or `Box`).
+
+- Does the proposed component get used in more than one or two places across GitHub UI? A component that's only meant to be used in one place and doesn't have potential to be reused in many places probably should exist as a local component. An example of something like this might be a component that renders content specific to a single GitHub product.
+
+
 ## Developing components
 
 We primarily use our documentation site as a workspace to develop new components or make changes to existing components (stay tuned for a better development environment coming soon!).

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## Documentation
 
-Our documentation site lives at [primer.style/components](https://primer.style/components). You'll be able to find the information listed in this README as well as detailed docs for each component, our theme, and system props.
+Our documentation site lives at [primer.style/components](https://primer.style/components). You'll be able to find detailed documentation on getting started, all of the components, our theme, our principles, and more.
 
 ## Installation
 
@@ -42,106 +42,11 @@ npm install @primer/components
 yarn add @primer/components
 ```
 
-## Usage
 
-All of our components are exported by name from `@primer/components`, so you can import them with:
-
-```js
-import {
-  Box,
-  Button,
-  Heading,
-  Text
-} from '@primer/components'
-```
-
-Primer Components come with all the necessary CSS built-in, so you don't need to worry about including [Primer CSS].
-
-#### Base styles
-
-You can establish base Primer styles for your app by wrapping all of your Primer components in `<BaseStyles>`:
-
-```jsx
-import {BaseStyles, Box, Heading} from '@primer/components'
-
-export default () => (
-  <BaseStyles>
-    <Box m={4}>
-      <Heading mb={2}>Hello, world!</Heading>
-      <p>This will get Primer text styles.</p>
-    </Box>
-  </BaseStyles>
-)
-```
-
-This will set the `color`, `font-family`, and `line-height` CSS properties to the same ones used in [primer-base](https://github.com/primer/primer/blob/master/modules/primer-base/lib/base.scss#L15).
-
-#### Theming
-
-Components are styled using Primer's [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) by default, but you can provide your own theme by using [styled-component's][styled-components] `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/master/src/theme-preval.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
-
-```jsx
-import {ThemeProvider} from 'styled-components'
-
-const theme = { ... }
-
-const App = (props) => {
-  return (
-    <div>
-      <ThemeProvider theme={theme}>
-        <div>your app here</div>
-      </ThemeProvider>
-    </div>
-  )
-}
-
-```
-
-If you'd like to merge the Primer theme with your theme, you can do so importing the Primer theme and merging using Object.assign:
-
-```jsx
-import {ThemeProvider} from 'styled-components'
-import {theme} from '@primer/components'
-
-const customTheme = { ... }
-
-
-const App = (props) => {
-  return (
-    <div>
-      <ThemeProvider theme={Object.assign({}, theme, customTheme)}> // matching keys in customTheme will override keys in the Primer theme
-        <div>your app here</div>
-      </ThemeProvider>
-    </div>
-  )
-}
-```
-
-*Note that using `Object.assign` will only create a shallow merge. This means that if both themes have a `color` object, the _entire_ `color` object will be replaced with the new `color` object, instead of only replacing duplicate values from the original theme's color object.
-
-#### Static CSS rendering
-
-If you're rendering React components both server-side _and_ client-side, we suggest following [styled-component's server-side rendering instructions](https://www.styled-components.com/docs/advanced#server-side-rendering) to avoid the flash of unstyled content for server-rendered components.
-
-## Local Development
-
-To run `@primer/components` locally when adding or updating components:
-
-1. Clone this repo: `git clone https://github.com/primer/components`
-1. Install dependencies in the repo root and `docs` subfolder: `pushd docs && yarn && popd && yarn`
-1. Run the dev app: `yarn start`
-
+## Contributing
+ We love collaborating with folks inside and outside of GitHub and welcome contributions! 
+ 
 > 👉 See [the contributing docs](CONTRIBUTING.md) for more info on code style, testing, coverage, and troubleshooting.
-
-
-## Principles
-
-- Everything is a component.
-- Aim for total style encapsulation; don't rely on inheritance to provide default styles.
-- Build small building blocks with minimal props to keep complexity low.
-- Keep system constrained by only including props needed per component.
-- Favor extending or wrapping components for more complex operations.
-- Maintain design system consistency with utilities as props (for spacing, color, font-size, line-height, widths, and radii).
 
 
 [styled-components]: https://www.styled-components.com/docs

--- a/README.md
+++ b/README.md
@@ -17,9 +17,6 @@
     <img alt="" src=
   "https://img.shields.io/github/last-commit/primer/components.svg">
   </a>
-  <a aria-label="join us in spectrum" href="https://spectrum.chat/?t=492cd17e-6e41-4e66-9160-2297e245b596">
-    <img alt="" src="https://withspectrum.github.io/badge/badge.svg">
-  </a>
   <a aria-label="license" href="https://github.com/primer/components/blob/master/LICENSE">
     <img src="https://img.shields.io/github/license/primer/components.svg" alt="">
   </a>


### PR DESCRIPTION
- Added a section called "Before Getting Started" in the contribution guidelines about what kinds of things we accept in Primer Components
- I removed a ton of content from the README - all of this content lives in primer.style/components and is ripe for getting out of date fast 😬 So I think it's better to link to the docs site than have it duplicated in two places.
- Removed link to Spectrum since we aren't monitoring it anymore