### PR TITLE
PointerBox fix

### DIFF
--- a/docs/content/PointerBox.md
+++ b/docs/content/PointerBox.md
@@ -12,6 +12,43 @@ PointerBox is a [BorderBox](./BorderBox) component with a caret added to it.
 </PointerBox>
 ```
 
+```javascript live noinline
+function PointerBoxDemo(props) {
+  const [pos, setPos] = React.useState('top')
+
+  return (
+    <Box>
+      <Heading as="h3" fontSize={3}>Caret Position</Heading>
+      <CaretSelector current={pos} onChange={setPos} />
+      <Relative pt={4}>
+        <PointerBox m={4} p={2} minHeight={100} bg="green.1" borderColor="green.5" caret={pos}> Content </PointerBox>
+      </Relative>
+    </Box>
+  )
+}
+
+function CaretSelector(props) {
+  const choices = [
+    'top',         'bottom',      'left',         'right',
+    'left-bottom', 'left-top',    'right-bottom', 'right-top',
+    'top-left',    'bottom-left', 'top-right',    'bottom-right'
+  ].map((dir) => (
+    <label>
+      <input key={dir} type='radio' name='caret' value={dir}
+        checked={dir === props.current} onChange={() => props.onChange(dir)} /> {dir}
+    </label>
+))
+
+  return (
+    <Grid gridTemplateColumns="repeat(4, auto)" gridGap={3} my={2}>
+      {choices}
+    </Grid>
+  )
+}
+
+render(<PointerBoxDemo />)
+```
+
 ## System props
 
 PointerBox components get `COMMON`, `LAYOUT`, `BORDER`, and `FLEX` system props. Read our [System Props](/system-props) doc page for a full list of available props.

--- a/src/Caret.js
+++ b/src/Caret.js
@@ -49,8 +49,7 @@ function Caret(props) {
     ...getPosition(edge, align, size),
     // if align is set (top|right|bottom|left),
     // then we don't need an offset margin
-    [`margin${perp}`]: align ? null : -size,
-    marginTop: '-1px'
+    [`margin${perp}`]: align ? null : -size
   }
 
   // note: these arrays represent points in the form [x, y]

--- a/src/PointerBox.js
+++ b/src/PointerBox.js
@@ -7,16 +7,14 @@ import {Relative} from './Position'
 
 function PointerBox(props) {
   // don't destructure these, just grab them
-  const {bg, border, borderColor, as} = props
+  const {bg, border, borderColor} = props
   const {caret, children, ...boxProps} = props
   const caretProps = {bg, borderColor, borderWidth: border, location: caret}
   return (
-    <Relative as={as}>
-      <BorderBox {...boxProps}>
-        {children}
-        <Caret {...caretProps} />
-      </BorderBox>
-    </Relative>
+    <BorderBox sx={{position: 'relative'}} {...boxProps}>
+      {children}
+      <Caret {...caretProps} />
+    </BorderBox>
   )
 }
 

--- a/src/PointerBox.js
+++ b/src/PointerBox.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types'
 import BorderBox from './BorderBox'
 import Caret from './Caret'
 import theme from './theme'
-import {Relative} from './Position'
 
 function PointerBox(props) {
   // don't destructure these, just grab them

--- a/src/__tests__/__snapshots__/Caret.js.snap
+++ b/src/__tests__/__snapshots__/Caret.js.snap
@@ -8,7 +8,6 @@ exports[`Caret renders cardinal directions 1`] = `
       "bottom": "100%",
       "left": "50%",
       "marginLeft": -8,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
     }
@@ -38,7 +37,7 @@ exports[`Caret renders cardinal directions 2`] = `
   style={
     Object {
       "left": "100%",
-      "marginTop": "-1px",
+      "marginTop": -8,
       "pointerEvents": "none",
       "position": "absolute",
       "top": "50%",
@@ -70,7 +69,6 @@ exports[`Caret renders cardinal directions 3`] = `
     Object {
       "left": "50%",
       "marginLeft": -8,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
       "top": "100%",
@@ -100,7 +98,7 @@ exports[`Caret renders cardinal directions 4`] = `
   height={16}
   style={
     Object {
-      "marginTop": "-1px",
+      "marginTop": -8,
       "pointerEvents": "none",
       "position": "absolute",
       "right": "100%",
@@ -134,7 +132,6 @@ exports[`Caret renders cardinal directions 5`] = `
       "bottom": "100%",
       "left": 8,
       "marginLeft": null,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
     }
@@ -165,7 +162,6 @@ exports[`Caret renders cardinal directions 6`] = `
     Object {
       "bottom": "100%",
       "marginLeft": null,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
       "right": 8,
@@ -197,7 +193,6 @@ exports[`Caret renders cardinal directions 7`] = `
     Object {
       "left": 8,
       "marginLeft": null,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
       "top": "100%",
@@ -228,7 +223,6 @@ exports[`Caret renders cardinal directions 8`] = `
   style={
     Object {
       "marginLeft": null,
-      "marginTop": "-1px",
       "pointerEvents": "none",
       "position": "absolute",
       "right": 8,
@@ -259,7 +253,7 @@ exports[`Caret renders cardinal directions 9`] = `
   height={16}
   style={
     Object {
-      "marginTop": "-1px",
+      "marginTop": null,
       "pointerEvents": "none",
       "position": "absolute",
       "right": "100%",
@@ -291,7 +285,7 @@ exports[`Caret renders cardinal directions 10`] = `
   style={
     Object {
       "bottom": 8,
-      "marginTop": "-1px",
+      "marginTop": null,
       "pointerEvents": "none",
       "position": "absolute",
       "right": "100%",
@@ -322,7 +316,7 @@ exports[`Caret renders cardinal directions 11`] = `
   style={
     Object {
       "left": "100%",
-      "marginTop": "-1px",
+      "marginTop": null,
       "pointerEvents": "none",
       "position": "absolute",
       "top": 8,
@@ -354,7 +348,7 @@ exports[`Caret renders cardinal directions 12`] = `
     Object {
       "bottom": 8,
       "left": "100%",
-      "marginTop": "-1px",
+      "marginTop": null,
       "pointerEvents": "none",
       "position": "absolute",
     }

--- a/src/__tests__/__snapshots__/PointerBox.js.snap
+++ b/src/__tests__/__snapshots__/PointerBox.js.snap
@@ -1,206 +1,178 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PointerBox passes the "bg" prop to both <BorderBox> and <Caret> 1`] = `
-.c1 {
+.c0 {
   background-color: #d73a49;
+  position: relative;
   border-width: 1px;
   border-style: solid;
   border-color: #e1e4e8;
   border-radius: 6px;
-}
-
-.c0 {
   position: relative;
 }
 
 <div
   className="c0"
 >
-  <div
-    className="c1"
-  >
-    <svg
-      height={16}
-      style={
-        Object {
-          "left": "50%",
-          "marginLeft": -8,
-          "marginTop": "-1px",
-          "pointerEvents": "none",
-          "position": "absolute",
-          "top": "100%",
-        }
+  <svg
+    height={16}
+    style={
+      Object {
+        "left": "50%",
+        "marginLeft": -8,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": "100%",
       }
-      width={16}
+    }
+    width={16}
+  >
+    <g
+      transform="translate(8,0)"
     >
-      <g
-        transform="translate(8,0)"
-      >
-        <path
-          d="M-8,0L0,8L8,0L-8,0Z"
-          fill="#d73a49"
-        />
-        <path
-          d="M-8,0L0,8L8,0"
-          fill="none"
-          stroke="#e1e4e8"
-          strokeWidth="1px"
-        />
-      </g>
-    </svg>
-  </div>
+      <path
+        d="M-8,0L0,8L8,0L-8,0Z"
+        fill="#d73a49"
+      />
+      <path
+        d="M-8,0L0,8L8,0"
+        fill="none"
+        stroke="#e1e4e8"
+        strokeWidth="1px"
+      />
+    </g>
+  </svg>
 </div>
 `;
 
 exports[`PointerBox passes the "borderColor" prop to both <BorderBox> and <Caret> 1`] = `
-.c1 {
+.c0 {
+  position: relative;
   border-color: #d73a49;
   border-width: 1px;
   border-style: solid;
   border-radius: 6px;
-}
-
-.c0 {
   position: relative;
 }
 
 <div
   className="c0"
 >
-  <div
-    className="c1"
-  >
-    <svg
-      height={16}
-      style={
-        Object {
-          "left": "50%",
-          "marginLeft": -8,
-          "marginTop": "-1px",
-          "pointerEvents": "none",
-          "position": "absolute",
-          "top": "100%",
-        }
+  <svg
+    height={16}
+    style={
+      Object {
+        "left": "50%",
+        "marginLeft": -8,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": "100%",
       }
-      width={16}
+    }
+    width={16}
+  >
+    <g
+      transform="translate(8,0)"
     >
-      <g
-        transform="translate(8,0)"
-      >
-        <path
-          d="M-8,0L0,8L8,0L-8,0Z"
-          fill="#fff"
-        />
-        <path
-          d="M-8,0L0,8L8,0"
-          fill="none"
-          stroke="#d73a49"
-          strokeWidth="1px"
-        />
-      </g>
-    </svg>
-  </div>
+      <path
+        d="M-8,0L0,8L8,0L-8,0Z"
+        fill="#fff"
+      />
+      <path
+        d="M-8,0L0,8L8,0"
+        fill="none"
+        stroke="#d73a49"
+        strokeWidth="1px"
+      />
+    </g>
+  </svg>
 </div>
 `;
 
 exports[`PointerBox renders a <Caret> in <BorderBox> with relative positioning 1`] = `
-.c1 {
+.c0 {
+  position: relative;
   border-width: 1px;
   border-style: solid;
   border-color: #e1e4e8;
   border-radius: 6px;
-}
-
-.c0 {
   position: relative;
 }
 
 <div
   className="c0"
 >
-  <div
-    className="c1"
-  >
-    <svg
-      height={16}
-      style={
-        Object {
-          "left": "50%",
-          "marginLeft": -8,
-          "marginTop": "-1px",
-          "pointerEvents": "none",
-          "position": "absolute",
-          "top": "100%",
-        }
+  <svg
+    height={16}
+    style={
+      Object {
+        "left": "50%",
+        "marginLeft": -8,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": "100%",
       }
-      width={16}
+    }
+    width={16}
+  >
+    <g
+      transform="translate(8,0)"
     >
-      <g
-        transform="translate(8,0)"
-      >
-        <path
-          d="M-8,0L0,8L8,0L-8,0Z"
-          fill="#fff"
-        />
-        <path
-          d="M-8,0L0,8L8,0"
-          fill="none"
-          stroke="#e1e4e8"
-          strokeWidth="1px"
-        />
-      </g>
-    </svg>
-  </div>
+      <path
+        d="M-8,0L0,8L8,0L-8,0Z"
+        fill="#fff"
+      />
+      <path
+        d="M-8,0L0,8L8,0"
+        fill="none"
+        stroke="#e1e4e8"
+        strokeWidth="1px"
+      />
+    </g>
+  </svg>
 </div>
 `;
 
 exports[`PointerBox renders consistently 1`] = `
-.c1 {
+.c0 {
+  position: relative;
   border-width: 1px;
   border-style: solid;
   border-color: #e1e4e8;
   border-radius: 6px;
-}
-
-.c0 {
   position: relative;
 }
 
 <div
   className="c0"
 >
-  <div
-    className="c1"
-  >
-    <svg
-      height={16}
-      style={
-        Object {
-          "left": "50%",
-          "marginLeft": -8,
-          "marginTop": "-1px",
-          "pointerEvents": "none",
-          "position": "absolute",
-          "top": "100%",
-        }
+  <svg
+    height={16}
+    style={
+      Object {
+        "left": "50%",
+        "marginLeft": -8,
+        "pointerEvents": "none",
+        "position": "absolute",
+        "top": "100%",
       }
-      width={16}
+    }
+    width={16}
+  >
+    <g
+      transform="translate(8,0)"
     >
-      <g
-        transform="translate(8,0)"
-      >
-        <path
-          d="M-8,0L0,8L8,0L-8,0Z"
-          fill="#fff"
-        />
-        <path
-          d="M-8,0L0,8L8,0"
-          fill="none"
-          stroke="#e1e4e8"
-          strokeWidth="1px"
-        />
-      </g>
-    </svg>
-  </div>
+      <path
+        d="M-8,0L0,8L8,0L-8,0Z"
+        fill="#fff"
+      />
+      <path
+        d="M-8,0L0,8L8,0"
+        fill="none"
+        stroke="#e1e4e8"
+        strokeWidth="1px"
+      />
+    </g>
+  </svg>
 </div>
 `;


### PR DESCRIPTION
This PR fixes the margin & PointerBox caret issues in #414. Originally I was planning on refactoring `Popover` to use `PointerBox` (see #814) or removing one of the components entirely but I've decided to leave Popover as is for now because:

- PointerBox and Popover do serve different purposes. Popover is used as a container that toggles between being hidden/visible while PointerBox is a static element on the page.
- Popover isn't meant to have different colors for the borders and background color, while PointerBox is.
- The location of the entire Popover component changes depending on where the caret is positioned which makes sense for a Popover component, but doesn't make a lot of sense for a static PointerBox component. This makes it difficult to reuse `PointerBox` in `Popover`.


Fixes: #414 