### PR TITLE
Fix system styles for buttons

### DIFF
--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 import sx from '../sx'
 import {get} from '../constants'
 import theme from '../theme'
-import ButtonBase from './ButtonBase'
+import ButtonBase, {systemStyles} from './ButtonBase'
 
 const Button = styled(ButtonBase)`
   color: ${get('buttons.default.color.default')};
@@ -34,6 +34,7 @@ const Button = styled(ButtonBase)`
     border-color: ${get('buttons.default.border.disabled')};
   }
 
+  ${systemStyles}
   ${sx};
 `
 

--- a/src/Button/ButtonBase.js
+++ b/src/Button/ButtonBase.js
@@ -27,8 +27,9 @@ const ButtonBase = styled.button.attrs(({disabled, onClick}) => ({
 }))`
   ${buttonBaseStyles}
   ${variants}
-  ${compose(fontSize, COMMON, LAYOUT)}
 `
+
+export const systemStyles = compose(fontSize, COMMON, LAYOUT)
 
 ButtonBase.defaultProps = {
   theme,

--- a/src/Button/ButtonDanger.js
+++ b/src/Button/ButtonDanger.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import ButtonBase from './ButtonBase'
+import ButtonBase, {systemStyles} from './ButtonBase'
 import {get} from '../constants'
 import theme from '../theme'
 import sx from '../sx'
@@ -35,6 +35,7 @@ const ButtonDanger = styled(ButtonBase)`
     border: 1px solid ${get('buttons.danger.border.default')};
   }
 
+  ${systemStyles}
   ${sx};
 `
 

--- a/src/Button/ButtonOutline.js
+++ b/src/Button/ButtonOutline.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import ButtonBase from './ButtonBase'
+import ButtonBase, {systemStyles} from './ButtonBase'
 import {get} from '../constants'
 import theme from '../theme'
 import sx from '../sx'
@@ -35,6 +35,7 @@ const ButtonOutline = styled(ButtonBase)`
     background-color: ${get('buttons.outline.bg.disabled')};
   }
 
+  ${systemStyles}
   ${sx};
 `
 

--- a/src/Button/ButtonPrimary.js
+++ b/src/Button/ButtonPrimary.js
@@ -1,5 +1,5 @@
 import styled from 'styled-components'
-import ButtonBase from './ButtonBase'
+import ButtonBase, {systemStyles} from './ButtonBase'
 import {get} from '../constants'
 import theme from '../theme'
 import sx from '../sx'
@@ -33,6 +33,7 @@ const ButtonPrimary = styled(ButtonBase)`
     border-color: ${get('buttons.primary.border.disabled')};
   }
 
+  ${systemStyles}
   ${sx};
 `
 


### PR DESCRIPTION
Some system props were not being appropriately applied to the various buttons because the system styles were applied *before* the individual button styles, and thus were being overridden. This PR moves the system styles out of `ButtonBase` and into the individual buttons.

Closes #818 

### Screenshots

![image](https://user-images.githubusercontent.com/189606/83060191-eed34c00-a00f-11ea-8666-5249a2d39bed.png)

### Release notes

- [x] Fixed a bug where some system props were not properly applied to buttons #819 @BinaryMuse 