### PR TITLE
Deploy with GH Pages

### DIFF
--- a/.github/workflows/delete-staging-depoyment.yml
+++ b/.github/workflows/delete-staging-depoyment.yml
@@ -18,7 +18,8 @@ jobs:
                 cp -r public/assets/staging/* .gh-deploy/public/assets/staging
                 ref_type=$(jq --raw-output .ref_type $GITHUB_EVENT_PATH)
                 if [ $ref_type = "branch" ]; then
-                  deleted_branch=$(jq --raw-output .ref $GITHUB_EVENT_PATH | cut -d '/' -f 3)
+                  
+                  deleted_branch=$(jq --raw-output .ref $GITHUB_EVENT_PATH | cut -d '/' -f 3-)
                   rm -rf .gh-deploy/public/assets/staging/${deleted_branch}*
                 fi
             - name: Deploy deletion to GitHub Pages

--- a/.github/workflows/delete-staging-depoyment.yml
+++ b/.github/workflows/delete-staging-depoyment.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Delete stale docs site
               run: |
                 mkdir -p .gh-deploy/public/assets/staging
-                cp -r public/assets/staging/* gh-deploy/public/assets/staging
+                cp -r public/assets/staging/* .gh-deploy/public/assets/staging
                 ref_type=$(jq --raw-output .ref_type $GITHUB_EVENT_PATH)
                 if [ $ref_type = "branch" ]; then
                   deleted_branch=$(jq --raw-output .ref $GITHUB_EVENT_PATH | cut -d '/' -f 3)

--- a/.github/workflows/delete-staging-depoyment.yml
+++ b/.github/workflows/delete-staging-depoyment.yml
@@ -1,0 +1,31 @@
+name: Delete staging deployment
+on: delete
+
+jobs:
+    delete-docs-deployment:
+        name: Docs
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+              with:
+                  ref: gh-pages
+
+            - name: Delete stale docs site
+              run: |
+                mkdir -p .gh-deploy/public/assets/staging
+                cp -r public/assets/staging/* gh-deploy/public/assets/staging
+                ref_type=$(jq --raw-output .ref_type $GITHUB_EVENT_PATH)
+                if [ $ref_type = "branch" ]; then
+                  deleted_branch=$(jq --raw-output .ref $GITHUB_EVENT_PATH | cut -d '/' -f 3)
+                  rm -rf .gh-deploy/public/assets/staging/${deleted_branch}*
+                fi
+            - name: Deploy deletion to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  allow_empty_commits: false
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  keep_files: false
+                  publish_branch: gh-pages
+                  publish_dir: .gh-deploy

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -16,13 +16,9 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 10.x
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install dependencies
               run: cd docs && yarn
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Prepare assets for deployment
               id: prepare_assets

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -33,6 +33,7 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_branch: gh-pages
                   publish_dir: docs/public
+                  keep_files: true
 
             - name: Report deploy success
               uses: octokit/request-action@v2.x

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,0 +1,66 @@
+name: Deploy docs to production
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+    deploy-docs:
+        name: Primer Components Docs
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install Node.js 10.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 10.x
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install dependencies
+              run: cd docs && yarn
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Prepare assets for deployment
+              id: prepare_assets
+              run: cd docs && yarn run build
+
+            - name: Deploy docs to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  allow_empty_commits: false
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_branch: gh-pages
+                  publish_dir: ./public
+
+            - name: Report deploy success
+              uses: octokit/request-action@v2.x
+              if: success()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
+                  mediaType: '{"previews": ["flash", "ant-man"]}'
+                  owner: primer
+                  repo: components
+                  deployment_id: ${{ github.event.deployment.id }}
+                  state: success
+                  environment_url: https://primer.github.com/components
+
+            - name: Report deploy failure
+              uses: octokit/request-action@v2.x
+              if: failure() || cancelled()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
+                  mediaType: '{"previews": ["flash", "ant-man"]}'
+                  owner: github
+                  repo: memex
+                  deployment_id: ${{ github.event.deployment.id }}
+                  state: failure

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -27,6 +27,8 @@ jobs:
             - name: Prepare assets for deployment
               id: prepare_assets
               run: cd docs && yarn run build
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Deploy docs to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -60,7 +60,7 @@ jobs:
               with:
                   route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
                   mediaType: '{"previews": ["flash", "ant-man"]}'
-                  owner: github
-                  repo: memex
+                  owner: primer
+                  repo: components
                   deployment_id: ${{ github.event.deployment.id }}
                   state: failure

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -1,14 +1,12 @@
 name: Deploy docs to production
 
-on:
-  push:
-    branches:
-      - master
+on: deployment
 
 jobs:
     deploy-docs:
         name: Primer Components Docs
         runs-on: ubuntu-latest
+        if: github.event.action == 'created' && github.event.deployment.environment == 'production'
 
         steps:
             - name: Checkout repository

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -34,7 +34,7 @@ jobs:
                   allow_empty_commits: false
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_branch: gh-pages
-                  publish_dir: ./public
+                  publish_dir: docs/public
 
             - name: Report deploy success
               uses: octokit/request-action@v2.x

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -16,13 +16,9 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 10.x
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Install dependencies
               run: cd docs && yarn
-              env:
-                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Prepare assets for deployment
               id: prepare_assets

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -1,0 +1,78 @@
+name: Deploy to staging
+
+on: deployment
+
+jobs:
+    deploy-docs:
+        name: Primer Components Docs
+        runs-on: ubuntu-latest
+        if: github.event.action == 'created' && github.event.deployment.environment == 'staging'
+
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v2
+
+            - name: Install Node.js 10.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 10.x
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Install dependencies
+              run: cd docs && yarn
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Prepare assets for deployment
+              id: prepare_assets
+              env:
+                 DEPLOYMENT_BRANCH: ${{ github.event.deployment.ref }}
+              run: |
+                git fetch --no-tags --prune --depth=1 origin gh-pages
+                branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3)
+                previous_deployment=$(git ls-tree --name-only origin/gh-pages public/assets/staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
+                current_deployment=${previous_deployment}
+                if [ -z $current_deployment ]; then
+                  random_suffix="$(openssl rand -hex 16)"
+                  current_deployment="${branch_name}-${random_suffix}"
+                fi
+                mkdir -p .gh-deploy/public/assets/staging/${current_deployment}
+                cd docs && STAGING_PATH_PREFIX=/public/assets/staging/${current_deployment} yarn run build
+                cd .. && cp -r docs/public/* .gh-deploy/public/assets/staging/${current_deployment}
+                echo "::set-output name=environment_url::https://primer.github.com/components/public/assets/staging/${current_deployment}"
+
+            - name: Deploy docs to GitHub Pages
+              uses: peaceiris/actions-gh-pages@v3
+              with:
+                  allow_empty_commits: false
+                  github_token: ${{ secrets.GITHUB_TOKEN }}
+                  publish_branch: gh-pages
+                  publish_dir: .gh-deploy
+  
+            - name: Report deploy success
+              uses: octokit/request-action@v2.x
+              if: success()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
+                  mediaType: '{"previews": ["flash", "ant-man"]}'
+                  owner: primer
+                  repo: components
+                  deployment_id: ${{ github.event.deployment.id }}
+                  state: success
+                  environment_url: ${{ steps.prepare_assets.outputs.environment_url }}
+
+            - name: Report deploy failure
+              uses: octokit/request-action@v2.x
+              if: failure() || cancelled()
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
+                  mediaType: '{"previews": ["flash", "ant-man"]}'
+                  owner: github
+                  repo: memex
+                  deployment_id: ${{ github.event.deployment.id }}
+                  state: failure

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -47,7 +47,7 @@ jobs:
               with:
                   allow_empty_commits: false
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_branch: gh-pages-${DEPLOYMENT_BRANCH}
+                  publish_branch: gh-pages
                   publish_dir: .gh-deploy
                   keep_files: true
   

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -27,10 +27,18 @@ jobs:
               run: |
                 git fetch --no-tags --prune --depth=1 origin gh-pages
                 branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3-)
-                mkdir -p .gh-deploy/staging/${branch_name}
-                cd docs && STAGING_PATH_PREFIX=/staging/${branch_name} yarn run build
-                cd .. && cp -r docs/public/* .gh-deploy/staging/${branch_name}
-                echo "::set-output name=environment_url::https://primer.github.com/components/staging/${branch_name}"
+
+                previous_deployment=$(git ls-tree --name-only origin/gh-pages staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 2)
+                current_deployment=${previous_deployment}
+
+                if [ -z $current_deployment ]; then
+                  current_deployment=${branch_name}
+                fi
+
+                mkdir -p .gh-deploy/staging/${current_deployment}
+                cd docs && STAGING_PATH_PREFIX=/staging/${current_deployment} yarn run build
+                cd .. && cp -r docs/public/* .gh-deploy/staging/${current_deployment}
+                echo "::set-output name=environment_url::https://primer.github.com/components/staging/${current_deployment}"
 
             - name: Deploy docs to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3
@@ -41,6 +49,7 @@ jobs:
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   publish_branch: gh-pages-${DEPLOYMENT_BRANCH}
                   publish_dir: .gh-deploy
+                  keep_files: true
   
             - name: Report deploy success
               uses: octokit/request-action@v2.x

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -31,16 +31,16 @@ jobs:
               run: |
                 git fetch --no-tags --prune --depth=1 origin gh-pages
                 branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3)
-                previous_deployment=$(git ls-tree --name-only origin/gh-pages public/assets/staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
+                previous_deployment=$(git ls-tree --name-only origin/gh-pages staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
                 current_deployment=${previous_deployment}
                 if [ -z $current_deployment ]; then
                   random_suffix="$(openssl rand -hex 16)"
                   current_deployment="${branch_name}-${random_suffix}"
                 fi
-                mkdir -p .gh-deploy/public/assets/staging/${current_deployment}
-                cd docs && STAGING_PATH_PREFIX=/public/assets/staging/${current_deployment} yarn run build
-                cd .. && cp -r docs/public/* .gh-deploy/public/assets/staging/${current_deployment}
-                echo "::set-output name=environment_url::https://primer.github.com/components/public/assets/staging/${current_deployment}"
+                mkdir -p .gh-deploy/staging/${current_deployment}
+                cd docs && STAGING_PATH_PREFIX=/staging/${current_deployment} yarn run build
+                cd .. && cp -r docs/public/* .gh-deploy/staging/${current_deployment}
+                echo "::set-output name=environment_url::https://primer.github.com/components/staging/${current_deployment}"
 
             - name: Deploy docs to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -27,15 +27,10 @@ jobs:
               run: |
                 git fetch --no-tags --prune --depth=1 origin gh-pages
                 branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3-)
-                previous_deployment=$(git ls-tree --name-only origin/gh-pages staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
-                current_deployment=${previous_deployment}
-                if [ -z $current_deployment ]; then
-                  current_deployment="${branch_name}"
-                fi
-                mkdir -p .gh-deploy/staging/${current_deployment}
-                cd docs && STAGING_PATH_PREFIX=/staging/${current_deployment} yarn run build
-                cd .. && cp -r docs/public/* .gh-deploy/staging/${current_deployment}
-                echo "::set-output name=environment_url::https://primer.github.com/components/staging/${current_deployment}"
+                mkdir -p .gh-deploy/staging/${branch_name}
+                cd docs && STAGING_PATH_PREFIX=/staging/${branch_name} yarn run build
+                cd .. && cp -r docs/public/* .gh-deploy/staging/${branch_name}
+                echo "::set-output name=environment_url::https://primer.github.com/components/staging/${branch_name}"
 
             - name: Deploy docs to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -72,7 +72,7 @@ jobs:
               with:
                   route: POST /repos/:owner/:repo/deployments/:deployment_id/statuses
                   mediaType: '{"previews": ["flash", "ant-man"]}'
-                  owner: github
-                  repo: memex
+                  owner: primer
+                  repo: components
                   deployment_id: ${{ github.event.deployment.id }}
                   state: failure

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -26,7 +26,7 @@ jobs:
                  DEPLOYMENT_BRANCH: ${{ github.event.deployment.ref }}
               run: |
                 git fetch --no-tags --prune --depth=1 origin gh-pages
-                branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3)
+                branch_name=$(echo $DEPLOYMENT_BRANCH | cut -d '/' -f 3-)
                 previous_deployment=$(git ls-tree --name-only origin/gh-pages staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
                 current_deployment=${previous_deployment}
                 if [ -z $current_deployment ]; then

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -34,8 +34,7 @@ jobs:
                 previous_deployment=$(git ls-tree --name-only origin/gh-pages staging/ | grep -m 1 ${branch_name} | cut -d '/' -f 4)
                 current_deployment=${previous_deployment}
                 if [ -z $current_deployment ]; then
-                  random_suffix="$(openssl rand -hex 16)"
-                  current_deployment="${branch_name}-${random_suffix}"
+                  current_deployment="${branch_name}"
                 fi
                 mkdir -p .gh-deploy/staging/${current_deployment}
                 cd docs && STAGING_PATH_PREFIX=/staging/${current_deployment} yarn run build

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -34,10 +34,12 @@ jobs:
 
             - name: Deploy docs to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3
+              env:
+                DEPLOYMENT_BRANCH: ${{ github.event.deployment.ref }}
               with:
                   allow_empty_commits: false
                   github_token: ${{ secrets.GITHUB_TOKEN }}
-                  publish_branch: gh-pages
+                  publish_branch: gh-pages-${DEPLOYMENT_BRANCH}
                   publish_dir: .gh-deploy
   
             - name: Report deploy success

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -3,7 +3,7 @@ name: Request Production Deployment
 on:
     push:
       branches:
-        master
+        preview-deploys
 
 jobs:
     request-production-deployment:

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -1,0 +1,28 @@
+name: Request Production Deployment
+
+on:
+    push:
+      branches:
+        master
+
+jobs:
+    request-production-deployment:
+        name: Request production deployment
+        runs-on: ubuntu-latest
+
+        steps:
+          - name: Create new production deployment
+            uses: octokit/request-action@v2.x
+            if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+            env:
+                GITHUB_TOKEN: ${{ secrets.EMPLUMS_STAGING_DEPLOYMENT_TOKEN }}
+            with:
+                route: POST /repos/:owner/:repo/deployments
+                mediaType: '{"previews": ["ant-man"]}'
+                owner: primer
+                repo: components
+                ref: 'refs/heads/master'
+                environment: production
+                auto_merge: false
+                required_contexts: '[]'
+                description: Deployment of Primer Components Docs

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -3,7 +3,7 @@ name: Request Production Deployment
 on:
     push:
       branches:
-        preview-deploy
+        preview-deploys
 
 jobs:
     request-production-deployment:

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -3,7 +3,7 @@ name: Request Production Deployment
 on:
     push:
       branches:
-        master
+        preview-deploy
 
 jobs:
     request-production-deployment:
@@ -21,7 +21,7 @@ jobs:
                 mediaType: '{"previews": ["ant-man"]}'
                 owner: primer
                 repo: components
-                ref: 'refs/heads/master'
+                ref: 'refs/heads/preview-deploy'
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -21,6 +21,7 @@ jobs:
                 owner: primer
                 repo: components
                 ref: 'refs/heads/preview-deploys'
+                keep_files: true
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -20,7 +20,7 @@ jobs:
                 mediaType: '{"previews": ["ant-man"]}'
                 owner: primer
                 repo: components
-                ref: 'refs/heads/master'
+                ref: 'refs/heads/preview-deploys'
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -13,7 +13,7 @@ jobs:
         steps:
           - name: Create new production deployment
             uses: octokit/request-action@v2.x
-            if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
+            if: github.event_name == 'push' && github.event.ref == 'refs/heads/preview-deploys'
             env:
                 GITHUB_TOKEN: ${{ secrets.EMPLUMS_STAGING_DEPLOYMENT_TOKEN }}
             with:
@@ -21,7 +21,7 @@ jobs:
                 mediaType: '{"previews": ["ant-man"]}'
                 owner: primer
                 repo: components
-                ref: 'refs/heads/preview-deploy'
+                ref: 'refs/heads/preview-deploys'
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -21,7 +21,6 @@ jobs:
                 owner: primer
                 repo: components
                 ref: 'refs/heads/preview-deploys'
-                keep_files: true
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -13,7 +13,6 @@ jobs:
         steps:
           - name: Create new production deployment
             uses: octokit/request-action@v2.x
-            if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
             env:
                 GITHUB_TOKEN: ${{ secrets.EMPLUMS_STAGING_DEPLOYMENT_TOKEN }}
             with:

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -25,4 +25,4 @@ jobs:
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'
-                description: Deployment of Primer Components Docs
+                description: Deployment of Primer Components Docs!

--- a/.github/workflows/request-production-deployment.yml
+++ b/.github/workflows/request-production-deployment.yml
@@ -3,7 +3,7 @@ name: Request Production Deployment
 on:
     push:
       branches:
-        preview-deploys
+        master
 
 jobs:
     request-production-deployment:
@@ -13,7 +13,7 @@ jobs:
         steps:
           - name: Create new production deployment
             uses: octokit/request-action@v2.x
-            if: github.event_name == 'push' && github.event.ref == 'refs/heads/preview-deploys'
+            if: github.event_name == 'push' && github.event.ref == 'refs/heads/master'
             env:
                 GITHUB_TOKEN: ${{ secrets.EMPLUMS_STAGING_DEPLOYMENT_TOKEN }}
             with:
@@ -21,7 +21,7 @@ jobs:
                 mediaType: '{"previews": ["ant-man"]}'
                 owner: primer
                 repo: components
-                ref: 'refs/heads/preview-deploys'
+                ref: 'refs/heads/master'
                 environment: production
                 auto_merge: false
                 required_contexts: '[]'

--- a/.github/workflows/request-staging-deployment.yml
+++ b/.github/workflows/request-staging-deployment.yml
@@ -1,9 +1,7 @@
 name: Request Staging Deployment
 
 on:
-    push:
-      branches-ignore:
-        master
+    pull_request:
 
 jobs:
     request-staging-deployment:

--- a/.github/workflows/request-staging-deployment.yml
+++ b/.github/workflows/request-staging-deployment.yml
@@ -4,7 +4,6 @@ on:
     push:
       branches-ignore:
         master
-    pull_request:
 
 jobs:
     request-staging-deployment:

--- a/.github/workflows/request-staging-deployment.yml
+++ b/.github/workflows/request-staging-deployment.yml
@@ -1,7 +1,10 @@
 name: Request Staging Deployment
 
 on:
-    [push, pull_request]
+    push:
+      branches-ignore:
+        master
+    pull_request:
 
 jobs:
     request-staging-deployment:

--- a/.github/workflows/request-staging-deployment.yml
+++ b/.github/workflows/request-staging-deployment.yml
@@ -1,0 +1,27 @@
+name: Request Staging Deployment
+
+on:
+    [push, pull_request]
+
+jobs:
+    request-staging-deployment:
+        name: Request staging deployment
+        runs-on: ubuntu-latest
+
+        steps:
+          - name: Create new staging deployment
+            uses: octokit/request-action@v2.x
+            if: github.event_name == 'pull_request'
+            env:
+                GITHUB_TOKEN: ${{ secrets.EMPLUMS_STAGING_DEPLOYMENT_TOKEN }}
+            with:
+                route: POST /repos/:owner/:repo/deployments
+                mediaType: '{"previews": ["ant-man"]}'
+                owner: primer
+                repo: components
+                ref: 'refs/heads/${{ github.event.pull_request.head.ref }}'
+                environment: staging
+                transient_environment: true
+                auto_merge: false
+                required_contexts: '[]'
+                description: Automated staging deployment of Primer Components Docs

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -51,21 +51,7 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 The `sx` prop also allows for declaring styles based on media queries, psueudo-classes, and pseudo-elements. This example, though contrived, demonstrates the ability:
 
 ```jsx live
-<Box sx={{
-  '> *': {
-    borderWidth: 1,
-    borderColor: 'border.gray',
-    borderStyle: 'solid',
-    borderBottomWidth: 0,
-    padding: 2,
-    ':last-child': {
-      borderBottomWidth: 1
-    },
-    ':hover': {
-      bg: 'gray.1'
-    }
-  }
-}}>
+<Box>
   <Box>First</Box>
   <Box>Second</Box>
   <Box>Third</Box>

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -51,7 +51,21 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 The `sx` prop also allows for declaring styles based on media queries, psueudo-classes, and pseudo-elements. This example, though contrived, demonstrates the ability:
 
 ```jsx live
-<Box>
+<Box sx={{
+    '> *': {	
+    borderWidth: 1,	
+    borderColor: 'border.gray',	
+    borderStyle: 'solid',	
+    borderBottomWidth: 0,	
+    padding: 2,	
+    ':last-child': {	
+      borderBottomWidth: 1	
+    },	
+    ':hover': {	
+      bg: 'gray.1'	
+    }	
+  }	
+}}>
   <Box>First</Box>
   <Box>Second</Box>
   <Box>Third</Box>

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -24,5 +24,5 @@ module.exports = {
       }
     }
   ],
-  pathPrefix: '/components'
+  pathPrefix: `/components${process.env.STAGING_PATH_PREFIX || ''}`
 }


### PR DESCRIPTION
## Description
This PR moves our preview deploys from Now/vercel to GH Pages via an amazing action that I copypasta'd from @lerebear 's work! 🙌 🎉  Huge shoutout to Lere for coming up with these workflows!

I've also built an action for deploying our docs to the production url (https://primer.github.com/components). I tested it by changing the action to run on pushes to this branch and it worked smoothly and deployed here: https://primer.github.io/components (note that contributor data doesn't show up, but i fixed that in a later commit)

## Notes
I needed to use a personal access token in the `request_deployment` workflows because jobs using the `GITHUB_TOKEN` are prevented from triggering other workflows as Lere pointed out in his original PR

## Rollout Plan
- [ ] Merge this PR and make sure deploys on pushes to master works
- [ ] Test that a [path alias in primer.style](https://github.com/primer/primer.style/blob/master/now.json#L13) pointing to a non-vercel deploy works okay. I don't see anything in the vercel docs that says otherwise so I think it should be fine, but to test carefully we could set up a route like this:
`{"src": "/test-components(/.*)?", "dest": "https://primer.github.com/components"},`
- [ ] Remove the vercel integration on this repository
- [ ] Migrate over other repositories. See migration for other repos below

## To do:
- [x] URLs off the root are not resolving correctly
- [x] Animation in hero is not displaying
- [x] Add seperate job for deploying to production
- [x] ~Contributions isn't working - I noticed in the [deploy to production action](https://github.com/primer/components/runs/719015448?check_suite_focus=true) that the script output this `error Non-deploy build and no GITHUB_TOKEN environment variable set; skipping GitHub API calls`. the `GITHUB_TOKEN` environment variable should be set so I need to see if there's some way that this script classifies something as a deploy/non-deploy build~ fixed this just for production builds so we don't have to wait for all the API calls for each deploy preview. need to double check that it worked after merging to master

## Migration Plan for Other Repos
- [ ] Add a personal staging deployment token to repo
- [ ] Copy over workflow files
- [ ] Update `name`, `repo`, `environment_url` in `deploy-to-gh-pages.yml`
- [ ] Update `name`,  `environment_url`, and `repo` in `deploy-to-staging.yml`
- [ ] Update `repo` and `description` in `request-staging-deployment.yml`
- [ ] Update `pathPrefix` in `gatsby-config.yml`

## Possible Improvements
- Might be able to clean up the code a bit and have one file for requesting deploys & one file for doing deployments and separate steps with `if` parameters for each environment?