### PR TITLE
Primer Components -> Primer React Components

### DIFF
--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -13,8 +13,8 @@ Several additional components exist to provide even more functionality: `SelectM
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
     </SelectMenu.List>
@@ -97,8 +97,8 @@ Use the `align='right'` prop to align the modal to the right. Note that this onl
     <SelectMenu.Modal align="right">
       <SelectMenu.Header>Projects</SelectMenu.Header>
       <SelectMenu.List>
-        <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-        <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+        <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+        <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
         <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
         <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       </SelectMenu.List>
@@ -168,8 +168,8 @@ Use a `SelectMenu.Filter` to add a filter UI to your select menu. Users are expe
     <SelectMenu.Header>Filter by Project</SelectMenu.Header>
     <SelectMenu.Filter placeholder="Filter projects" value="" aria-label="Filter Projects"/>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Divider>More Options</SelectMenu.Divider>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
@@ -211,8 +211,8 @@ If you need access to the selected tab state, you can find it in the MenuContext
       <SelectMenu.Tab index={1} tabName="Organization"/>
     </SelectMenu.Tabs>
     <SelectMenu.TabPanel tabName="Repository">
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
     </SelectMenu.TabPanel>
@@ -279,8 +279,8 @@ Use a `SelectMenu.Divider` to add information between items in a `SelectMenu.Lis
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Divider>More Options</SelectMenu.Divider>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
@@ -305,8 +305,8 @@ Use a `SelectMenu.Footer` to add content to the bottom of the select menu.
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       <SelectMenu.Footer>Use ⌥ + click/return to exclude labels.</SelectMenu.Footer>
@@ -331,8 +331,8 @@ Use a `SelectMenu.Header` to add a header to the top of the select menu content.
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       <SelectMenu.Footer>Use ⌥ + click/return to exclude labels.</SelectMenu.Footer>

--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -13,8 +13,8 @@ Several additional components exist to provide even more functionality: `SelectM
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
     </SelectMenu.List>
@@ -97,8 +97,8 @@ Use the `align='right'` prop to align the modal to the right. Note that this onl
     <SelectMenu.Modal align="right">
       <SelectMenu.Header>Projects</SelectMenu.Header>
       <SelectMenu.List>
-        <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-        <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+        <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+        <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
         <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
         <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       </SelectMenu.List>
@@ -168,8 +168,8 @@ Use a `SelectMenu.Filter` to add a filter UI to your select menu. Users are expe
     <SelectMenu.Header>Filter by Project</SelectMenu.Header>
     <SelectMenu.Filter placeholder="Filter projects" value="" aria-label="Filter Projects"/>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Divider>More Options</SelectMenu.Divider>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
@@ -211,8 +211,8 @@ If you need access to the selected tab state, you can find it in the MenuContext
       <SelectMenu.Tab index={1} tabName="Organization"/>
     </SelectMenu.Tabs>
     <SelectMenu.TabPanel tabName="Repository">
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
     </SelectMenu.TabPanel>
@@ -279,8 +279,8 @@ Use a `SelectMenu.Divider` to add information between items in a `SelectMenu.Lis
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Divider>More Options</SelectMenu.Divider>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
@@ -305,8 +305,8 @@ Use a `SelectMenu.Footer` to add content to the bottom of the select menu.
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       <SelectMenu.Footer>Use ⌥ + click/return to exclude labels.</SelectMenu.Footer>
@@ -331,8 +331,8 @@ Use a `SelectMenu.Header` to add a header to the top of the select menu content.
   <SelectMenu.Modal>
     <SelectMenu.Header>Projects</SelectMenu.Header>
     <SelectMenu.List>
-      <SelectMenu.Item href="#">Primer React Components bugs</SelectMenu.Item>
-      <SelectMenu.Item href="#">Primer React Components roadmap</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React bugs</SelectMenu.Item>
+      <SelectMenu.Item href="#">Primer React roadmap</SelectMenu.Item>
       <SelectMenu.Item href="#"> Project 3</SelectMenu.Item>
       <SelectMenu.Item href="#">Project 4</SelectMenu.Item>
       <SelectMenu.Footer>Use ⌥ + click/return to exclude labels.</SelectMenu.Footer>

--- a/docs/content/core-concepts.md
+++ b/docs/content/core-concepts.md
@@ -2,7 +2,7 @@
 title: Core Concepts
 ---
 
-This document aims to discuss some of the core concepts of building with Primer Components.
+This document aims to discuss some of the core concepts of building with Primer React Components.
 
 ## Responsive props
 It's really easy to set different values for most of our component props based on screen size! We take advantage of [styled-system](https://github.com/styled-system/styled-system)'s responsive props API in our components.
@@ -17,7 +17,7 @@ or
 
 ## Providing your own theme
 
-You can provide your own theme to Primer Components! There are a few ways of doing this to varying degrees, checkout the [theme docs](https://primer.style/components/primer-theme) for more information.
+You can provide your own theme to Primer React Components! There are a few ways of doing this to varying degrees, checkout the [theme docs](https://primer.style/components/primer-theme) for more information.
 
 ## The `css` prop
 When push comes to shove and you just _really_ need to add a custom CSS rule, you can do that with the `css` prop. Please don't abuse this :)
@@ -31,7 +31,7 @@ Please note that you will need to have the **[styled-components babel plugin](ht
 
 ## Types of components
 
-We categorize our components into 3 general types. Building block components, pattern components, and helper components. Understanding how these types of components interact with each other can help you better understand how to get the most out of Primer Components.
+We categorize our components into 3 general types. Building block components, pattern components, and helper components. Understanding how these types of components interact with each other can help you better understand how to get the most out of Primer React Components.
 
 - Building Blocks
 

--- a/docs/content/core-concepts.md
+++ b/docs/content/core-concepts.md
@@ -2,7 +2,7 @@
 title: Core Concepts
 ---
 
-This document aims to discuss some of the core concepts of building with Primer React Components.
+This document aims to discuss some of the core concepts of building with Primer React.
 
 ## Responsive props
 It's really easy to set different values for most of our component props based on screen size! We take advantage of [styled-system](https://github.com/styled-system/styled-system)'s responsive props API in our components.
@@ -17,7 +17,7 @@ or
 
 ## Providing your own theme
 
-You can provide your own theme to Primer React Components! There are a few ways of doing this to varying degrees, checkout the [theme docs](https://primer.style/components/primer-theme) for more information.
+You can provide your own theme to Primer React! There are a few ways of doing this to varying degrees, checkout the [theme docs](https://primer.style/components/primer-theme) for more information.
 
 ## The `css` prop
 When push comes to shove and you just _really_ need to add a custom CSS rule, you can do that with the `css` prop. Please don't abuse this :)
@@ -31,7 +31,7 @@ Please note that you will need to have the **[styled-components babel plugin](ht
 
 ## Types of components
 
-We categorize our components into 3 general types. Building block components, pattern components, and helper components. Understanding how these types of components interact with each other can help you better understand how to get the most out of Primer React Components.
+We categorize our components into 3 general types. Building block components, pattern components, and helper components. Understanding how these types of components interact with each other can help you better understand how to get the most out of Primer React.
 
 - Building Blocks
 

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -4,7 +4,7 @@ title: Getting Started
 
 ## Installation
 
-To get started using Primer React Components, install the package and its peer dependencies with your package manager of choice:
+To get started using Primer React, install the package and its peer dependencies with your package manager of choice:
 
 ```bash
 # with npm
@@ -14,7 +14,7 @@ npm install @primer/components react react-dom styled-components
 yarn add @primer/components react react-dom styled-components
 ```
 
-You can now import Primer React Components from the main package module:
+You can now import Primer React from the main package module:
 
 ```javascript
 // using import syntax
@@ -26,7 +26,7 @@ const {Box, Flex} = require('@primer/components')
 
 ### Minimizing bundle size
 
-Module bundlers that use ECMAScript modules (ESM) will automatically tree-shake Primer React Components, ensuring that no unused code is included in your final bundle. However, if you're not using ESM, you may be able to drastically reduce the size of your final bundle by importing components individually from the `lib` subfolder:
+Module bundlers that use ECMAScript modules (ESM) will automatically tree-shake Primer React, ensuring that no unused code is included in your final bundle. However, if you're not using ESM, you may be able to drastically reduce the size of your final bundle by importing components individually from the `lib` subfolder:
 
 ```javascript
 // using import syntax
@@ -42,9 +42,9 @@ Note that the modules in the `lib` folder are CommonJS-style modules; if you're 
 
 ### Peer dependencies
 
-Primer React Components ships with a few libraries labeled as peer dependencies. These libraries are separated because they are commonly already installed in the host project and having multiple versions can introduce errors.
+Primer React ships with a few libraries labeled as peer dependencies. These libraries are separated because they are commonly already installed in the host project and having multiple versions can introduce errors.
 
-Primer React Components requires the following libraries to be installed along with it:
+Primer React requires the following libraries to be installed along with it:
 
 - `styled-components` at version 4.0.0 or higher
 - `react` at versions 16.8.0 or higher
@@ -122,7 +122,7 @@ If you're rendering React components both server- and client-side, we suggest fo
 
 ## TypeScript
 
-Primer React Components includes TypeScript support and ships with its own typings. You will need still need to to install type typings for the peer dependencies if you import those in your own application code.
+Primer React includes TypeScript support and ships with its own typings. You will need still need to to install type typings for the peer dependencies if you import those in your own application code.
 
 Once installed, you can import components and their prop type interfaces from the `@primer/components` package:
 
@@ -152,4 +152,4 @@ Of course, customize the array based on the `@types/` packages you have installe
 
 ## Silencing warnings
 
-Like React, Primer React Components emits warnings to the JavaScript console under certain conditions, like using deprecated components or props. Similar to React, you can silence these warnings by setting the `NODE_ENV` environment variable to `production` during bundling.
+Like React, Primer React emits warnings to the JavaScript console under certain conditions, like using deprecated components or props. Similar to React, you can silence these warnings by setting the `NODE_ENV` environment variable to `production` during bundling.

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -4,7 +4,7 @@ title: Getting Started
 
 ## Installation
 
-To get started using Primer Components, install the package and its peer dependencies with your package manager of choice:
+To get started using Primer React Components, install the package and its peer dependencies with your package manager of choice:
 
 ```bash
 # with npm
@@ -14,7 +14,7 @@ npm install @primer/components react react-dom styled-components
 yarn add @primer/components react react-dom styled-components
 ```
 
-You can now import Primer Components from the main package module:
+You can now import Primer React Components from the main package module:
 
 ```javascript
 // using import syntax
@@ -26,7 +26,7 @@ const {Box, Flex} = require('@primer/components')
 
 ### Minimizing bundle size
 
-Module bundlers that use ECMAScript modules (ESM) will automatically tree-shake Primer Components, ensuring that no unused code is included in your final bundle. However, if you're not using ESM, you may be able to drastically reduce the size of your final bundle by importing components individually from the `lib` subfolder:
+Module bundlers that use ECMAScript modules (ESM) will automatically tree-shake Primer React Components, ensuring that no unused code is included in your final bundle. However, if you're not using ESM, you may be able to drastically reduce the size of your final bundle by importing components individually from the `lib` subfolder:
 
 ```javascript
 // using import syntax
@@ -42,9 +42,9 @@ Note that the modules in the `lib` folder are CommonJS-style modules; if you're 
 
 ### Peer dependencies
 
-Primer Components ships with a few libraries labeled as peer dependencies. These libraries are separated because they are commonly already installed in the host project and having multiple versions can introduce errors.
+Primer React Components ships with a few libraries labeled as peer dependencies. These libraries are separated because they are commonly already installed in the host project and having multiple versions can introduce errors.
 
-Primer Components requires the following libraries to be installed along with it:
+Primer React Components requires the following libraries to be installed along with it:
 
 - `styled-components` at version 4.0.0 or higher
 - `react` at versions 16.8.0 or higher
@@ -122,7 +122,7 @@ If you're rendering React components both server- and client-side, we suggest fo
 
 ## TypeScript
 
-Primer Components includes TypeScript support and ships with its own typings. You will need still need to to install type typings for the peer dependencies if you import those in your own application code.
+Primer React Components includes TypeScript support and ships with its own typings. You will need still need to to install type typings for the peer dependencies if you import those in your own application code.
 
 Once installed, you can import components and their prop type interfaces from the `@primer/components` package:
 
@@ -152,4 +152,4 @@ Of course, customize the array based on the `@types/` packages you have installe
 
 ## Silencing warnings
 
-Like React, Primer Components emits warnings to the JavaScript console under certain conditions, like using deprecated components or props. Similar to React, you can silence these warnings by setting the `NODE_ENV` environment variable to `production` during bundling.
+Like React, Primer React Components emits warnings to the JavaScript console under certain conditions, like using deprecated components or props. Similar to React, you can silence these warnings by setting the `NODE_ENV` environment variable to `production` during bundling.

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -5,9 +5,9 @@ title: Getting Started
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 export default HeroLayout
 
-## Primer Components
+## Primer React Components
 
-Primer Components is a React implementation of GitHub's [Primer Design System](https://primer.style/) 🎉
+Primer React Components is a React implementation of GitHub's [Primer Design System](https://primer.style/) 🎉
 
 ## Principles
 
@@ -20,7 +20,7 @@ Primer Components is a React implementation of GitHub's [Primer Design System](h
 
 ## Getting started
 
-Check out [our getting started guide](/getting-started) for everything you need to know about installing and using Primer Components.
+Check out [our getting started guide](/getting-started) for everything you need to know about installing and using Primer React Components.
 
 ## Local development
 

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -5,9 +5,9 @@ title: Getting Started
 import {HeroLayout} from '@primer/gatsby-theme-doctocat'
 export default HeroLayout
 
-## Primer React Components
+## Primer React
 
-Primer React Components is a React implementation of GitHub's [Primer Design System](https://primer.style/) 🎉
+Primer React is a React implementation of GitHub's [Primer Design System](https://primer.style/) 🎉
 
 ## Principles
 
@@ -20,7 +20,7 @@ Primer React Components is a React implementation of GitHub's [Primer Design Sys
 
 ## Getting started
 
-Check out [our getting started guide](/getting-started) for everything you need to know about installing and using Primer React Components.
+Check out [our getting started guide](/getting-started) for everything you need to know about installing and using Primer React.
 
 ## Local development
 

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -2,9 +2,9 @@
 title: Overriding styles with the sx prop
 ---
 
-Our goal with Primer Components is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't *quite* flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
+Our goal with Primer React Components is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't *quite* flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
 
-The `sx` prop allows ad-hoc styling that is still theme aware. Declare the styles you want to apply in camel-cased object notation, and try to use theme values in appropriate CSS properties when possible. If you've passed a custom theme using `ThemeProvider` or a `theme` prop, the `sx` prop will honor the custom theme. For more information on theming in Primer Components, check out [the Primer Theme documentation](/primer-theme).
+The `sx` prop allows ad-hoc styling that is still theme aware. Declare the styles you want to apply in camel-cased object notation, and try to use theme values in appropriate CSS properties when possible. If you've passed a custom theme using `ThemeProvider` or a `theme` prop, the `sx` prop will honor the custom theme. For more information on theming in Primer React Components, check out [the Primer Theme documentation](/primer-theme).
 
 ## When to use the `sx` prop
 

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -2,9 +2,9 @@
 title: Overriding styles with the sx prop
 ---
 
-Our goal with Primer React Components is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't *quite* flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
+Our goal with Primer React is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't *quite* flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
 
-The `sx` prop allows ad-hoc styling that is still theme aware. Declare the styles you want to apply in camel-cased object notation, and try to use theme values in appropriate CSS properties when possible. If you've passed a custom theme using `ThemeProvider` or a `theme` prop, the `sx` prop will honor the custom theme. For more information on theming in Primer React Components, check out [the Primer Theme documentation](/primer-theme).
+The `sx` prop allows ad-hoc styling that is still theme aware. Declare the styles you want to apply in camel-cased object notation, and try to use theme values in appropriate CSS properties when possible. If you've passed a custom theme using `ThemeProvider` or a `theme` prop, the `sx` prop will honor the custom theme. For more information on theming in Primer React, check out [the Primer Theme documentation](/primer-theme).
 
 ## When to use the `sx` prop
 

--- a/docs/content/philosophy.md
+++ b/docs/content/philosophy.md
@@ -1,12 +1,12 @@
 ---
-title: Primer React Components Philosophy
+title: Primer React Philosophy
 ---
 
 ## Presentational Components
- We are focusing primarily on presentational components that help standardize common design patterns. Primer React Components don't handle fetching and submitting data to/from APIs. If you would like to handle data in a Primer Component, feel free to create a wrapper around the Primer Component to do so.
+ We are focusing primarily on presentational components that help standardize common design patterns. Primer React components don't handle fetching and submitting data to/from APIs. If you would like to handle data in a Primer Component, feel free to create a wrapper around the Primer Component to do so.
 
 ## Assume that people will break the rules, provide safe ways for them to do so
-While we aim to standardize design in Primer React Components, we also provide some flexibility with constraint-based props. We offer system props via [styled-system](https://github.com/styled-system/styled-system) to allow users of the components to make small customizations, such as color and spacing, using values from the theme. Users also have the option to override the theme with a theme of their own.
+While we aim to standardize design in Primer React, we also provide some flexibility with constraint-based props. We offer system props via [styled-system](https://github.com/styled-system/styled-system) to allow users of the components to make small customizations, such as color and spacing, using values from the theme. Users also have the option to override the theme with a theme of their own.
 
 
 ## Pattern Components vs Helper Components

--- a/docs/content/philosophy.md
+++ b/docs/content/philosophy.md
@@ -1,12 +1,12 @@
 ---
-title: Primer Components Philosophy
+title: Primer React Components Philosophy
 ---
 
 ## Presentational Components
- We are focusing primarily on presentational components that help standardize common design patterns. Primer Components don't handle fetching and submitting data to/from APIs. If you would like to handle data in a Primer Component, feel free to create a wrapper around the Primer Component to do so.
+ We are focusing primarily on presentational components that help standardize common design patterns. Primer React Components don't handle fetching and submitting data to/from APIs. If you would like to handle data in a Primer Component, feel free to create a wrapper around the Primer Component to do so.
 
 ## Assume that people will break the rules, provide safe ways for them to do so
-While we aim to standardize design in Primer Components, we also provide some flexibility with constraint-based props. We offer system props via [styled-system](https://github.com/styled-system/styled-system) to allow users of the components to make small customizations, such as color and spacing, using values from the theme. Users also have the option to override the theme with a theme of their own.
+While we aim to standardize design in Primer React Components, we also provide some flexibility with constraint-based props. We offer system props via [styled-system](https://github.com/styled-system/styled-system) to allow users of the components to make small customizations, such as color and spacing, using values from the theme. Users also have the option to override the theme with a theme of their own.
 
 
 ## Pattern Components vs Helper Components

--- a/docs/content/primer-theme.md
+++ b/docs/content/primer-theme.md
@@ -4,7 +4,7 @@ title: Primer Theme
 
 import {theme} from '@primer/components'
 
-Primer React Components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
+Primer React components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
 
 Many of our theme keys correspond to system props on our components. For example, if you'd like to set the max width on a `<Box>` set the `maxWidth` prop to `medium`: `<Box maxWidth='medium'>`
 

--- a/docs/content/primer-theme.md
+++ b/docs/content/primer-theme.md
@@ -4,7 +4,7 @@ title: Primer Theme
 
 import {theme} from '@primer/components'
 
-Primer Components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
+Primer React Components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/master/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
 
 Many of our theme keys correspond to system props on our components. For example, if you'd like to set the max width on a `<Box>` set the `maxWidth` prop to `medium`: `<Box maxWidth='medium'>`
 

--- a/docs/content/system-props.mdx
+++ b/docs/content/system-props.mdx
@@ -4,12 +4,12 @@ title: System Props
 
 import {PropsList, COMMON, LAYOUT, BORDER, TYPOGRAPHY, FLEX, POSITION, GRID} from '../components'
 
-Primer React Components utilize what we call "system props" to apply a standard set of props to each component. Using [styled-system](https://github.com/jxnblk/styled-system), groups of props are automatically applied to each component. Most components get the `COMMON` set of props which give the component access to color and space props (margin, padding, color and background color). These groups correspond to the `color` and `space` functions from `styled-system` which can be referenced in the styled system [table of style functions](https://github.com/jxnblk/styled-system/blob/master/docs/table.md#core).
+Primer React components utilize what we call "system props" to apply a standard set of props to each component. Using [styled-system](https://github.com/jxnblk/styled-system), groups of props are automatically applied to each component. Most components get the `COMMON` set of props which give the component access to color and space props (margin, padding, color and background color). These groups correspond to the `color` and `space` functions from `styled-system` which can be referenced in the styled system [table of style functions](https://github.com/jxnblk/styled-system/blob/master/docs/table.md#core).
 
 To check which system props each component includes, check the documentation for that component.
 
 ### The `as` prop
-All Primer React Components have access to the `as` prop, provided by [styled-components](https://www.styled-components.com/docs/api#as-polymorphic-prop). We use the `as` prop to render a component with the styles of the passed component in `as`, but with the system props of the base component.
+All Primer React components have access to the `as` prop, provided by [styled-components](https://www.styled-components.com/docs/api#as-polymorphic-prop). We use the `as` prop to render a component with the styles of the passed component in `as`, but with the system props of the base component.
 
 For example, if you wanted to add some flex utilities to the `Text` component, you could do:
 

--- a/docs/content/system-props.mdx
+++ b/docs/content/system-props.mdx
@@ -4,12 +4,12 @@ title: System Props
 
 import {PropsList, COMMON, LAYOUT, BORDER, TYPOGRAPHY, FLEX, POSITION, GRID} from '../components'
 
-Primer Components utilize what we call "system props" to apply a standard set of props to each component. Using [styled-system](https://github.com/jxnblk/styled-system), groups of props are automatically applied to each component. Most components get the `COMMON` set of props which give the component access to color and space props (margin, padding, color and background color). These groups correspond to the `color` and `space` functions from `styled-system` which can be referenced in the styled system [table of style functions](https://github.com/jxnblk/styled-system/blob/master/docs/table.md#core).
+Primer React Components utilize what we call "system props" to apply a standard set of props to each component. Using [styled-system](https://github.com/jxnblk/styled-system), groups of props are automatically applied to each component. Most components get the `COMMON` set of props which give the component access to color and space props (margin, padding, color and background color). These groups correspond to the `color` and `space` functions from `styled-system` which can be referenced in the styled system [table of style functions](https://github.com/jxnblk/styled-system/blob/master/docs/table.md#core).
 
 To check which system props each component includes, check the documentation for that component.
 
 ### The `as` prop
-All Primer Components have access to the `as` prop, provided by [styled-components](https://www.styled-components.com/docs/api#as-polymorphic-prop). We use the `as` prop to render a component with the styles of the passed component in `as`, but with the system props of the base component.
+All Primer React Components have access to the `as` prop, provided by [styled-components](https://www.styled-components.com/docs/api#as-polymorphic-prop). We use the `as` prop to render a component with the styles of the passed component in `as`, but with the system props of the base component.
 
 For example, if you wanted to add some flex utilities to the `Text` component, you could do:
 

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -2,8 +2,8 @@ const path = require('path')
 
 module.exports = {
   siteMetadata: {
-    title: 'Primer React Components',
-    shortName: 'React Components',
+    title: 'Primer React',
+    shortName: 'React',
     description: 'React components for the Primer design system'
   },
   plugins: [

--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -2,8 +2,8 @@ const path = require('path')
 
 module.exports = {
   siteMetadata: {
-    title: 'Primer Components',
-    shortName: 'Components',
+    title: 'Primer React Components',
+    shortName: 'React Components',
     description: 'React components for the Primer design system'
   },
   plugins: [

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -14,8 +14,8 @@ exports.onCreateWebpackConfig = ({actions, plugins, loaders, getConfig}) => {
       ...loaders.js(),
       test: /\.jsx?$/,
       exclude: modulePath => /node_modules/.test(modulePath),
-      // ...except that we want to run Primer Components through webpack as well.
-      // By default, Gatsby won't use the define plugin we added above on Primer Components.
+      // ...except that we want to run Primer React Components through webpack as well.
+      // By default, Gatsby won't use the define plugin we added above on Primer React Components.
       include: modulePath => /@primer\/components/.test(modulePath)
     }
   ]

--- a/docs/gatsby-node.js
+++ b/docs/gatsby-node.js
@@ -14,8 +14,8 @@ exports.onCreateWebpackConfig = ({actions, plugins, loaders, getConfig}) => {
       ...loaders.js(),
       test: /\.jsx?$/,
       exclude: modulePath => /node_modules/.test(modulePath),
-      // ...except that we want to run Primer React Components through webpack as well.
-      // By default, Gatsby won't use the define plugin we added above on Primer React Components.
+      // ...except that we want to run Primer React through webpack as well.
+      // By default, Gatsby won't use the define plugin we added above on Primer React.
       include: modulePath => /@primer\/components/.test(modulePath)
     }
   ]

--- a/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -9,7 +9,7 @@ export default function Hero() {
     <Box bg="black" py={6}>
       <Container>
         <Heading color="blue.4" fontSize={7} lineHeight="condensed" pb={3} m={0}>
-          Primer Components
+          Primer React Components
         </Heading>
         <Text as="p" fontFamily="mono" mt={0} mb={2} color="blue.3" fontSize={2}>
           v{version}

--- a/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/hero.js
@@ -9,7 +9,7 @@ export default function Hero() {
     <Box bg="black" py={6}>
       <Container>
         <Heading color="blue.4" fontSize={7} lineHeight="condensed" pb={3} m={0}>
-          Primer React Components
+          Primer React
         </Heading>
         <Text as="p" fontFamily="mono" mt={0} mb={2} color="blue.3" fontSize={2}>
           v{version}


### PR DESCRIPTION
We're getting an increasing amount of questions about the difference between Primer Components vs Primer View Components vs Primer Figma Components vs Primer CSS Components. Everything is a component these days 😂. In an effort to clarify what this library is meant for, @yaili @joelhawksley and I discussed changing the documentation site to reference this library by "Primer React Components" instead of just "Primer Components"

This feels like a small change that's relatively low-effort we can make to try to clarify some of the confusion around which library does what. It's a little wordy to say "Primer React Components" (8 syllables!) but feels worth it to add more clarity for folks new to Primer.

We could take this a step further by renaming the package as well, but I think for now we should stick with the package name `@primer/components` and wait to see if there's a clear need to change the package name as well. My hunch is that the package name itself doesn't matter as much.

I think this is just *one* small change that should probably be part of a wider effort of changes (many of which we are already working on!) such as better DS onboarding for new hires and directory/landing page for all of our DS tools.

If everyone is cool with this change, I'll also update the Doctocat navigation to say "Primer React Components" instead of "Primer Components"

![image](https://user-images.githubusercontent.com/8960591/84822027-e77cde00-afd0-11ea-9a0b-15fa0c7d31bf.png)


🙌 