### PR TITLE
Make 'SelectMenu.Modal' forward 'ref'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -329,7 +329,7 @@ declare module '@primer/components' {
     Footer: React.FunctionComponent<SelectMenuFooterProps>
     List: React.FunctionComponent<SelectMenuListProps>
     Item: React.FunctionComponent<SelectMenuItemProps>
-    Modal: React.FunctionComponent<SelectMenuModalProps>
+    Modal: React.ForwardRefExoticComponent<SelectMenuModalProps>
     Tabs: React.FunctionComponent<SelectMenuTabsProps>
     Tab: React.FunctionComponent<SelectMenuTabProps>
     TabPanel: React.FunctionComponent<SelectMenuTabPanelProps>

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -87,13 +87,13 @@ const ModalWrapper = styled.div`
   ${sx};
 `
 
-const SelectMenuModal = ({children, theme, ...rest}) => {
+const SelectMenuModal = React.forwardRef(({children, theme, ...rest}, ref) => {
   return (
-    <ModalWrapper theme={theme} {...rest} role="menu">
+    <ModalWrapper theme={theme} {...rest} role="menu" ref={ref}>
       <Modal theme={theme}>{children}</Modal>
     </ModalWrapper>
   )
-}
+})
 
 SelectMenuModal.defaultProps = {
   align: 'left',


### PR DESCRIPTION
This change makes it possible to get a reference to non-nested DOM elements when the `SelectMenu.Modal` is rendered in a [`Portal`](https://reactjs.org/docs/portals.html) (e.g. to avoid overflow clipping).

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge