### PR TITLE
Auto-bump: @primer/gatsby-theme-doctocat@0.24.0

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "node": ">= 10.x"
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "0.0.0-0eaacfc",
+    "@primer/gatsby-theme-doctocat": "0.24.0",
     "@primer/octicons-react": "^10.0.0",
     "@styled-system/prop-types": "^5.1.0",
     "@styled-system/theme-get": "^5.1.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1325,10 +1325,10 @@
     style-value-types "^3.1.7"
     tslib "^1.10.0"
 
-"@primer/components@0.0.0-e1ba9f0":
-  version "0.0.0-e1ba9f0"
-  resolved "https://registry.yarnpkg.com/@primer/components/-/components-0.0.0-e1ba9f0.tgz#4c18fa20ba0a91b2f7e277c300f2a06b688739ef"
-  integrity sha512-SWdosZIKM1fxP2uC23gBPxSPgzsFvrIK/zudh/7DFpNkue/S4Os0+R6RUHhKOOZHqmgHpYbugmFeKHRi409KTQ==
+"@primer/components@^20.0.0":
+  version "20.0.0"
+  resolved "https://registry.yarnpkg.com/@primer/components/-/components-20.0.0.tgz#643bd7d719af28d6cdf446909255ee04e9f47014"
+  integrity sha512-OpnBJDB+7Rw8NK7p/UlJx3B6uGjRSVKtbEUAE+BjTYAD5wrjSnWKTgBqnorTzPcmstDAxC6GNtmsukyyk3lMHA==
   dependencies:
     "@babel/helpers" "7.9.2"
     "@babel/runtime" "7.9.2"
@@ -1352,16 +1352,16 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@0.0.0-0eaacfc":
-  version "0.0.0-0eaacfc"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.0.0-0eaacfc.tgz#41242ef9e767bb3fb24ffeaa62bbb72e63294ca3"
-  integrity sha512-qjSd8RPJPvnE1KKR918+EY6FhFtKxMSpab00TpdE7fA8DkmmZIPrOJBIvNxx4qlezsTkQp1KptNEJRe12Bj56w==
+"@primer/gatsby-theme-doctocat@0.24.0":
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.24.0.tgz#615f6cec7b5b46020836f4c57ead4f6b0087d250"
+  integrity sha512-1RGeBG3H+DrlMOJ7MAMiop+Q09/PKGt+wtR7qx1AsbGZOdxU+PkzVf21ZK+BlOHsUXt00iGvtBkHDaXkxKpr1A==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"
     "@mdx-js/mdx" "^1.0.21"
     "@mdx-js/react" "^1.0.21"
-    "@primer/components" "0.0.0-e1ba9f0"
+    "@primer/components" "^20.0.0"
     "@styled-system/theme-get" "^5.0.12"
     "@testing-library/jest-dom" "^4.1.0"
     "@testing-library/react" "^9.1.3"


### PR DESCRIPTION
Auto-upgrade of `@primer/gatsby-theme-doctocat` to `0.24.0` via multibump.