### PR TITLE
Update doctcat

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -11,6 +11,7 @@ module.exports = {
       resolve: '@primer/gatsby-theme-doctocat',
       options: {
         repoRootPath: '..',
+        defaultBranch: 'main'
       },
     },
     {

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "node": ">= 10.x"
   },
   "dependencies": {
-    "@primer/gatsby-theme-doctocat": "0.25.2",
+    "@primer/gatsby-theme-doctocat": "^0.25.3",
     "@primer/octicons-react": "^10.0.0",
     "@styled-system/prop-types": "^5.1.0",
     "@styled-system/theme-get": "^5.1.0",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1352,10 +1352,10 @@
     react-is "16.10.2"
     styled-system "5.1.2"
 
-"@primer/gatsby-theme-doctocat@0.25.2":
-  version "0.25.2"
-  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.25.2.tgz#f0d871ac204902b153e2c9a1926390e54aa2419b"
-  integrity sha512-Hihiz2yTT4tEOUurLBRr8SlHNP9jPupBoMXbc/IC7HoxwyNONKpl8wOojgJvswAiHx1Gd4knTEzD6ZbC3KGtyw==
+"@primer/gatsby-theme-doctocat@^0.25.3":
+  version "0.25.3"
+  resolved "https://registry.yarnpkg.com/@primer/gatsby-theme-doctocat/-/gatsby-theme-doctocat-0.25.3.tgz#9ca4003bc030a093f1d86c5ba46c3e3fc224332a"
+  integrity sha512-gbX/v7t/OyrNnt9mbiuyOYajJtEnNSJNOQUcRfLhzT0qxIQhM0X7uszxDQIEmACU/xBuDMghISnRxDC87Zxubw==
   dependencies:
     "@babel/preset-env" "^7.5.5"
     "@babel/preset-react" "^7.0.0"


### PR DESCRIPTION
Updates Doctocat to fix the `Edit on GitHub` link

Closes #876 
