### PR TITLE
Allow forwarding refs on SelectMenu

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     initialTab?: string
-    ref?: HTMLDetailsElement
+    ref?: React.RefObject<HTMLElement>
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
@@ -414,7 +414,7 @@ declare module '@primer/components' {
     block?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
-    ref?: HTMLSpanElement
+    ref?: React.RefObject<HTMLElement>
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -307,7 +307,8 @@ declare module '@primer/components' {
   export const Fixed: React.FunctionComponent<PositionComponentProps>
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
-    initialTab?: string
+    initialTab?: string,
+    ref?: HTMLDetailsElement
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     initialTab?: string
-    ref?: React.RefObject<HTMLElement> | null
+    ref?: React.RefObject<HTMLDetailsElement>
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
@@ -414,7 +414,7 @@ declare module '@primer/components' {
     block?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
-    ref?: React.RefObject<HTMLElement> | null
+    ref?: React.RefObject<HTMLInputElement>
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     initialTab?: string
-    ref?: React.RefObject<HTMLDetailsElement>
+    ref?: React.RefObject<HTMLDetailsElement> | null
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
@@ -414,7 +414,7 @@ declare module '@primer/components' {
     block?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
-    ref?: React.RefObject<HTMLInputElement>
+    ref?: React.RefObject<HTMLInputElement> | null
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -307,7 +307,7 @@ declare module '@primer/components' {
   export const Fixed: React.FunctionComponent<PositionComponentProps>
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
-    initialTab?: string,
+    initialTab?: string
     ref?: HTMLDetailsElement
   }
 
@@ -414,6 +414,7 @@ declare module '@primer/components' {
     block?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
+    ref?: HTMLSpanElement
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -308,7 +308,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuProps extends Omit<CommonProps, 'as'>, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     initialTab?: string
-    ref?: React.RefObject<HTMLElement>
+    ref?: React.RefObject<HTMLElement> | null
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
@@ -414,7 +414,7 @@ declare module '@primer/components' {
     block?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
-    ref?: React.RefObject<HTMLElement>
+    ref?: React.RefObject<HTMLElement> | null
   }
 
   export const TextInput: React.FunctionComponent<TextInputProps>

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -51,8 +51,8 @@ const StyledSelectMenu = styled.details`
 `
 
 // 'as' is spread out because we don't want users to be able to change the tag.
-const SelectMenu = ({children, initialTab, as, ...rest}) => {
-  const ref = useRef(null)
+const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef) => {
+  const ref = forwardedRef || useRef(null)
   const [selectedTab, setSelectedTab] = useState(initialTab)
   const [open, setOpen] = useState(false)
   const menuProviderValues = {

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -51,8 +51,7 @@ const StyledSelectMenu = styled.details`
 `
 
 // 'as' is spread out because we don't want users to be able to change the tag.
-const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef) => {
-  const ref = forwardedRef || useRef(null)
+const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, ref) => {
   const [selectedTab, setSelectedTab] = useState(initialTab)
   const [open, setOpen] = useState(false)
   const menuProviderValues = {

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -79,6 +79,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
   )
 })
 
+SelectMenu.displayName = "SelectMenu"
 SelectMenu.MenuContext = MenuContext
 SelectMenu.List = SelectMenuList
 SelectMenu.Divider = SelectMenuDivider

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react'
+import React, {useState} from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import sx from '../sx'

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -51,7 +51,7 @@ const StyledSelectMenu = styled.details`
 `
 
 // 'as' is spread out because we don't want users to be able to change the tag.
-const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef)) => {
+const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef) => {
   const ref = forwardedRef || useRef(null)
   const [selectedTab, setSelectedTab] = useState(initialTab)
   const [open, setOpen] = useState(false)
@@ -76,7 +76,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
       </StyledSelectMenu>
     </MenuContext.Provider>
   )
-}
+})
 
 SelectMenu.MenuContext = MenuContext
 SelectMenu.List = SelectMenuList

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, {useRef, useState} from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import sx from '../sx'
@@ -51,7 +51,9 @@ const StyledSelectMenu = styled.details`
 `
 
 // 'as' is spread out because we don't want users to be able to change the tag.
-const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, ref) => {
+const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef) => {
+  const backupRef = useRef()
+  const ref = forwardedRef ?? backupRef
   const [selectedTab, setSelectedTab] = useState(initialTab)
   const [open, setOpen] = useState(false)
   const menuProviderValues = {

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -51,7 +51,7 @@ const StyledSelectMenu = styled.details`
 `
 
 // 'as' is spread out because we don't want users to be able to change the tag.
-const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef) => {
+const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwardedRef)) => {
   const ref = forwardedRef || useRef(null)
   const [selectedTab, setSelectedTab] = useState(initialTab)
   const [open, setOpen] = useState(false)

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -79,7 +79,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
   )
 })
 
-SelectMenu.displayName = "SelectMenu"
+SelectMenu.displayName = 'SelectMenu'
 SelectMenu.MenuContext = MenuContext
 SelectMenu.List = SelectMenuList
 SelectMenu.Divider = SelectMenuDivider

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -29,14 +29,14 @@ const modalStyles = css`
   animation: ${animateModal} 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
 
   @media (min-width: ${get('breakpoints.0')}) {
-    width: '300px';
+    width: 300px;
     height: auto;
     max-height: 350px;
     margin: ${get('space.1')} 0 ${get('space.3')} 0;
     font-size: ${get('fontSizes.0')};
     border: ${get('borderWidths.1')} solid ${get('colors.border.grayDark')};
     border-radius: ${get('radii.2')};
-    box-shadow: 0 1px 5px ${get('colors.blackfade15')} !default;
+    box-shadow: 0 1px 5px ${get('colors.blackfade15')};
   }
 `
 

--- a/src/__tests__/__snapshots__/SelectMenu.js.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.js.snap
@@ -295,14 +295,14 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 
 @media (min-width:544px) {
   .c3 {
-    width: '300px';
+    width: 300px;
     height: auto;
     max-height: 350px;
     margin: 4px 0 16px 0;
     font-size: 12px;
     border: 1px solid #d1d5da;
     border-radius: 6px;
-    box-shadow: 0 1px 5px rgba(27,31,35,0.15) !default;
+    box-shadow: 0 1px 5px rgba(27,31,35,0.15);
   }
 }
 


### PR DESCRIPTION
This PR updates `SelectMenu` to forward refs. I used the `useProvidedRefOrCreate` approach suggested by @smockle ✨ 

Closes: https://github.com/github/design-systems/issues/857