### PR TITLE
Allow custom width for SelectMenu.Modal

### DIFF
--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -116,6 +116,7 @@ SelectMenu.Modal components get `COMMON` system props. Read our [System Props](/
 | Prop name | Type   | Default | Description                                       |
 | :-------- | :----- | :------ | ------------------------------------------------- |
 | align     | String | 'left'  | Use `right` to align the select menu to the right |
+| width    | String or Number | 300px | Sets the modal width |
 
 
 ## SelectMenu.List
@@ -138,9 +139,9 @@ SelectMenu.List components do not get any additional props besides system props.
 
 ## SelectMenu.Item
 
-Individual items in a select menu. SelectMenu.Item renders an anchor tag by default, you'll need to make sure to provide the appropriate `href`. 
+Individual items in a select menu. SelectMenu.Item renders an anchor tag by default, you'll need to make sure to provide the appropriate `href`.
 
-You can use a `button` tag instead by utilizing the [`as` prop](/core-concepts#the-as-prop). Be sure to consider [which HTML element is the right choice](https://marcysutton.com/links-vs-buttons-in-modern-web-applications) for your usage of the component. 
+You can use a `button` tag instead by utilizing the [`as` prop](/core-concepts#the-as-prop). Be sure to consider [which HTML element is the right choice](https://marcysutton.com/links-vs-buttons-in-modern-web-applications) for your usage of the component.
 
 ```jsx
 <SelectMenu.Item href="/link/to/thing" selected={true}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -311,9 +311,8 @@ declare module '@primer/components' {
     ref?: React.RefObject<HTMLDetailsElement> | null
   }
 
-  export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
-    align?: 'left' | 'right',
-    width?: StyledSystem.WidthProps
+  export interface SelectMenuModalProps extends CommonProps, StyledSystem.WidthProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
+    align?: 'left' | 'right'
   }
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}

--- a/index.d.ts
+++ b/index.d.ts
@@ -312,7 +312,8 @@ declare module '@primer/components' {
   }
 
   export interface SelectMenuModalProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
-    align?: 'left' | 'right'
+    align?: 'left' | 'right',
+    width?: StyledSystem.WidthProps
   }
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "20.1.0",
+  "version": "20.2.0",
   "description": "Primer react components",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -91,7 +91,9 @@ const ModalWrapper = styled.div`
 const SelectMenuModal = ({children, theme, width, ...rest}) => {
   return (
     <ModalWrapper theme={theme} {...rest} role="menu">
-      <Modal theme={theme} width={width}>{children}</Modal>
+      <Modal theme={theme} width={width}>
+        {children}
+      </Modal>
     </ModalWrapper>
   )
 }
@@ -105,7 +107,7 @@ SelectMenuModal.defaultProps = {
 SelectMenuModal.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   theme: PropTypes.object,
-  width: PropTypes.oneOfType['string', 'number'],
+  width: PropTypes.oneOfType[('string', 'number')],
   ...COMMON.propTypes,
   ...sx.propTypes
 }

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled, {keyframes, css} from 'styled-components'
 import {COMMON, get} from '../constants'
+import {width} from 'styled-system'
 import theme from '../theme'
 import sx from '../sx'
 
@@ -29,7 +30,6 @@ const modalStyles = css`
   animation: ${animateModal} 0.12s cubic-bezier(0, 0.1, 0.1, 1) backwards;
 
   @media (min-width: ${get('breakpoints.0')}) {
-    width: 300px;
     height: auto;
     max-height: 350px;
     margin: ${get('space.1')} 0 ${get('space.3')} 0;
@@ -79,6 +79,7 @@ const modalWrapperStyles = css`
 
 const Modal = styled.div`
   ${modalStyles}
+  ${width}
 `
 
 const ModalWrapper = styled.div`
@@ -87,18 +88,20 @@ const ModalWrapper = styled.div`
   ${sx};
 `
 
-const SelectMenuModal = ({children, theme, ...rest}) => {
+const SelectMenuModal = ({children, theme, width, ...rest}) => {
   return (
     <ModalWrapper theme={theme} {...rest} role="menu">
-      <Modal theme={theme}>{children}</Modal>
+      <Modal theme={theme} width={width}>{children}</Modal>
     </ModalWrapper>
   )
 }
 
 SelectMenuModal.defaultProps = {
   align: 'left',
-  theme
+  theme,
+  width: '300px'
 }
+
 SelectMenuModal.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   theme: PropTypes.object,

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -105,6 +105,7 @@ SelectMenuModal.defaultProps = {
 SelectMenuModal.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   theme: PropTypes.object,
+  width: PropTypes.oneOfType['string', 'number'],
   ...COMMON.propTypes,
   ...sx.propTypes
 }

--- a/src/__tests__/__snapshots__/SelectMenu.js.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.js.snap
@@ -188,6 +188,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   box-shadow: 0 1px 5px rgba(27,31,35,0.15);
   -webkit-animation: lejQAW 0.12s cubic-bezier(0,0.1,0.1,1) backwards;
   animation: lejQAW 0.12s cubic-bezier(0,0.1,0.1,1) backwards;
+  width: 300px;
 }
 
 .c2 {
@@ -295,7 +296,6 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 
 @media (min-width:544px) {
   .c3 {
-    width: 300px;
     height: auto;
     max-height: 350px;
     margin: 4px 0 16px 0;
@@ -340,6 +340,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   >
     <div
       className="c3"
+      width="300px"
     >
       <div
         className="c4"


### PR DESCRIPTION
This PR updates `SelectMenu.Modal` to allow users to pass in a custom width for their SelectMenu modal & bumps the version to 20.2.0 ✨ 