### PR TITLE
Update Label font weight

### DIFF
--- a/src/Label.js
+++ b/src/Label.js
@@ -44,7 +44,7 @@ const sizeVariant = variant({
 
 const Label = styled('span')`
   display: inline-block;
-  font-weight: ${get('fontWeights.normal')};
+  font-weight: ${get('fontWeights.semibold')};
   color: ${get('colors.white')};
   border-radius: ${get('radii.3')};
   &:hover {

--- a/src/__tests__/__snapshots__/Label.js.snap
+++ b/src/__tests__/__snapshots__/Label.js.snap
@@ -3,7 +3,7 @@
 exports[`Label renders consistently 1`] = `
 .c0 {
   display: inline-block;
-  font-weight: 400;
+  font-weight: 500;
   color: #fff;
   border-radius: 100px;
   font-size: 12px;
@@ -25,7 +25,7 @@ exports[`Label renders consistently 1`] = `
 exports[`Label respects the "outline" prop 1`] = `
 .c0 {
   display: inline-block;
-  font-weight: 400;
+  font-weight: 500;
   color: #fff;
   border-radius: 100px;
   font-size: 12px;
@@ -54,7 +54,7 @@ exports[`Label respects the "outline" prop 1`] = `
 exports[`Label respects the "variant" prop 1`] = `
 .c0 {
   display: inline-block;
-  font-weight: 400;
+  font-weight: 500;
   color: #fff;
   border-radius: 100px;
   font-size: 14px;


### PR DESCRIPTION
This PR updates the Label font weight to `semibold` (500), to match the font weight in Primer CSS.

Closes #885 

### Screenshots
![image](https://user-images.githubusercontent.com/8960591/96042541-67ea0900-0e22-11eb-8b81-b1498bd6058b.png)


### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
