### PR TITLE
Remove details element polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/styled-components": "^4.4.0",
     "@types/styled-system": "5.1.2",
     "classnames": "^2.2.5",
-    "details-element-polyfill": "2.4.0",
     "polished": "3.5.2",
     "react": "^16.10.2",
     "react-is": "16.10.2",

--- a/src/Details.js
+++ b/src/Details.js
@@ -5,14 +5,6 @@ import {COMMON} from './constants'
 import theme from './theme'
 import sx from './sx'
 
-// The <details> element is not yet supported in Edge so we have to use a polyfill.
-// We have to check if window is defined before importing the polyfill
-// so the code doesn’t run while pages build
-// uses require because of primer/components issue #638
-if (typeof window !== 'undefined') {
-  require('details-element-polyfill')
-}
-
 const StyledDetails = styled('details')`
   & > summary {
     list-style: none;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4630,11 +4630,6 @@ destroy@~1.0.4:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.0.4.tgz#978857442c44749e4206613e37946205826abd80"
   integrity sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=
 
-details-element-polyfill@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/details-element-polyfill/-/details-element-polyfill-2.4.0.tgz#e0622adef7902662faf27b4ab8acba5dc4e3a6e6"
-  integrity sha512-jnZ/m0+b1gz3EcooitqL7oDEkKHEro659dt8bWB/T/HjiILucoQhHvvi5MEOAIFJXxxO+rIYJ/t3qCgfUOSU5g==
-
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"


### PR DESCRIPTION
After we set the browser support policy in #899 we can drop the details element polyfill since all the browsers in our support matrix implement the details element.

Applications that consume primer components can include this polyfill in their own bundles if they wish.