### PR TITLE
Handle hiding select menu modal with js instead of css

### DIFF
--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -1,4 +1,4 @@
-import React, {useRef, useState} from 'react'
+import React, {useRef, useState, useCallback, useEffect} from 'react'
 import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import sx from '../sx'
@@ -19,18 +19,6 @@ import SelectMenuLoadingAnimation from './SelectMenuLoadingAnimation'
 import useKeyboardNav from './hooks/useKeyboardNav'
 
 const wrapperStyles = `
-  &[open] > summary::before {
-    position: fixed;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    z-index: 80;
-    display: block;
-    cursor: default;
-    content: ' ';
-    background: transparent;
-  }
   // Remove marker added by the display: list-item browser default
   > summary {
     list-style: none;
@@ -64,6 +52,27 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
     open,
     initialTab
   }
+
+  const onClickOutsideInternal = useCallback(
+    event => {
+      if (event.target.closest('details') !== ref.current) {
+        if (!event.defaultPrevented) {
+          setOpen(false)
+        }
+      }
+    },
+    [ref, setOpen]
+  )
+
+  // handles the overlay behavior - closing the menu when clicking outside of it
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('click', onClickOutsideInternal)
+      return () => {
+        document.removeEventListener('click', onClickOutsideInternal)
+      }
+    }
+  }, [open, onClickOutsideInternal])
 
   function toggle(event) {
     setOpen(event.target.open)

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -53,7 +53,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
     initialTab
   }
 
-  const onClickOutsideInternal = useCallback(
+  const onClickOutside = useCallback(
     event => {
       if (event.target.closest('details') !== ref.current) {
         if (!event.defaultPrevented) {
@@ -67,12 +67,12 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
   // handles the overlay behavior - closing the menu when clicking outside of it
   useEffect(() => {
     if (open) {
-      document.addEventListener('click', onClickOutsideInternal)
+      document.addEventListener('click', onClickOutside)
       return () => {
-        document.removeEventListener('click', onClickOutsideInternal)
+        document.removeEventListener('click', onClickOutside)
       }
     }
-  }, [open, onClickOutsideInternal])
+  }, [open, onClickOutside])
 
   function toggle(event) {
     setOpen(event.target.open)

--- a/src/__tests__/__snapshots__/SelectMenu.js.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.js.snap
@@ -221,19 +221,6 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   background-color: rgba(27,31,35,0.5);
 }
 
-.c0[open] > summary::before {
-  position: fixed;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
-  z-index: 80;
-  display: block;
-  cursor: default;
-  content: ' ';
-  background: transparent;
-}
-
 .c0 > summary {
   list-style: none;
 }


### PR DESCRIPTION
This PR updates the `SelectMenu` to handle the hiding on outside click behavior using javascript instead of CSS - similar to how we handle it in the `Details` component. While a pure CSS approach is cool and feels nice, it's problematic if the SelectMenu is ever rendered with a parent or ancestor that's absolutely positioned - the overlay won't take up the whole page.

This PR shouldn't change the existing behavior of the select menu at all, will just work better in all layouts.


### Screenshots
https://share.getcloudapp.com/o0umW2ON

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
