### PR TITLE
Set up ref forwarding in SelectMenuModal

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -313,6 +313,7 @@ declare module '@primer/components' {
 
   export interface SelectMenuModalProps extends CommonProps, StyledSystem.WidthProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     align?: 'left' | 'right'
+    ref?: React.RefObject<HTMLDivElement> | null
   }
 
   export interface SelectMenuListProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -106,7 +106,7 @@ SelectMenuModal.defaultProps = {
 SelectMenuModal.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   theme: PropTypes.object,
-  width: PropTypes.oneOfType[('string', 'number')],
+  width: PropTypes.oneOfType[(PropTypes.string, PropTypes.number)],
   ...COMMON.propTypes,
   ...sx.propTypes
 }

--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -87,16 +87,15 @@ const ModalWrapper = styled.div`
   ${COMMON}
   ${sx};
 `
-
-const SelectMenuModal = ({children, theme, width, ...rest}) => {
+const SelectMenuModal = React.forwardRef(({children, theme, width, ...rest}, forwardedRef) => {
   return (
-    <ModalWrapper theme={theme} {...rest} role="menu">
+    <ModalWrapper theme={theme} {...rest} role="menu" ref={forwardedRef}>
       <Modal theme={theme} width={width}>
         {children}
       </Modal>
     </ModalWrapper>
   )
-}
+})
 
 SelectMenuModal.defaultProps = {
   align: 'left',


### PR DESCRIPTION
This PR adds ref forwarding to the SelectMenu.Modal component for added flexibility ✨ 

I also went ahead and closed #906 - a typo in the prop type object for the modal.

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
