### PR TITLE
Fix Flex display name + SubNav fixes

### DIFF
--- a/docs/content/SubNav.md
+++ b/docs/content/SubNav.md
@@ -46,7 +46,8 @@ This ensures that the NavLink gets `activeClassName='selected'`
 ```jsx live
 <SubNav aria-label="Main">
   <FilteredSearch>
-    <Dropdown title="Filter">
+    <Dropdown>
+      <Dropdown.Button>Filter</Dropdown.Button>
       <Dropdown.Menu direction="sw">
         <Dropdown.Item>
           <a href="#">Item 1</a>

--- a/src/SubNav.js
+++ b/src/SubNav.js
@@ -54,11 +54,11 @@ SubNav.Link = styled.a.attrs(props => ({
 }))`
   padding-left: ${get('space.3')};
   padding-right: ${get('space.3')};
-  min-height: 34px; // copied from TextInput, but should be a variable.
-  font-weight: ${get('fontWeights.bold')};
+  min-height: 34px;
+  font-weight: ${get('fontWeights.semibold')};
   font-size: ${get('fontSizes.1')};
-  line-height: ${get('lineHeights.default')};
-  color: ${get('colors.gray.6')};
+  line-height: 20px;
+  color: ${get('colors.gray.9')};
   text-align: center;
   text-decoration: none;
   border-top: 1px solid ${get('colors.gray.2')};

--- a/src/SubNav.js
+++ b/src/SubNav.js
@@ -54,10 +54,10 @@ SubNav.Link = styled.a.attrs(props => ({
 }))`
   padding-left: ${get('space.3')};
   padding-right: ${get('space.3')};
-  min-height: 34px;
   font-weight: ${get('fontWeights.semibold')};
   font-size: ${get('fontSizes.1')};
-  line-height: 20px;
+  line-height: 20px; //custom value for SubNav
+  min-height: 34px; //custom value for SubNav
   color: ${get('colors.gray.9')};
   text-align: center;
   text-decoration: none;

--- a/src/SubNav.js
+++ b/src/SubNav.js
@@ -46,7 +46,7 @@ const SubNav = styled(SubNavBase)`
   ${sx};
 `
 
-SubNav.Links = Flex
+SubNav.Links = props => <Flex {...props} />
 
 SubNav.Link = styled.a.attrs(props => ({
   activeClassName: typeof props.to === 'string' ? 'selected' : '',

--- a/src/__tests__/__snapshots__/SubNavLink.js.snap
+++ b/src/__tests__/__snapshots__/SubNavLink.js.snap
@@ -4,11 +4,11 @@ exports[`SubNav.Link renders consistently 1`] = `
 .c0 {
   padding-left: 16px;
   padding-right: 16px;
-  min-height: 34px;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
-  line-height: 1.5;
-  color: #586069;
+  line-height: 20px;
+  min-height: 34px;
+  color: #24292e;
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;
@@ -69,11 +69,11 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
 .c0 {
   padding-left: 16px;
   padding-right: 16px;
-  min-height: 34px;
-  font-weight: 600;
+  font-weight: 500;
   font-size: 14px;
-  line-height: 1.5;
-  color: #586069;
+  line-height: 20px;
+  min-height: 34px;
+  color: #24292e;
   text-align: center;
   -webkit-text-decoration: none;
   text-decoration: none;


### PR DESCRIPTION
I originally started this branch to fix an issue where all `Flex` components were showing up in React DevTools as `SubNav.Links` 😬 but noticed a few other inconsistencies  (text color, line height, font weight) between the SubNav in Primer Components and the one in Primer CSS, and a few docs bugs so I went ahead and fixed those as well :) 

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/8960591/99720406-8e731380-2a62-11eb-97be-17663b19dad9.png)


#### After
![image](https://user-images.githubusercontent.com/8960591/99720376-861ad880-2a62-11eb-821a-129290c0c27b.png)


### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
