### PR TITLE
Add hoverColor to Link's type

### DIFF
--- a/docs/content/Link.md
+++ b/docs/content/Link.md
@@ -28,3 +28,4 @@ Link components get `COMMON` and `TYPOGRAPHY` system props. Read our [System Pro
 | muted     | Boolean |  false  | Uses light gray for Link color, and blue on hover |
 | underline | Boolean |  false  | Adds underline to the Link                        |
 | as        | String  |   'a'   | Can be 'a', 'button', 'input', or 'summary'       |
+| hoverColor        | String  |    | Color used when hovering over link      |

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,6 +238,7 @@ declare module '@primer/components' {
       Omit<React.AnchorHTMLAttributes<HTMLAnchorElement>, 'color'> {
     muted?: boolean
     underline?: boolean
+    hoverColor?: string
   }
 
   export const Link: React.FunctionComponent<LinkProps>

--- a/src/Link.js
+++ b/src/Link.js
@@ -43,6 +43,7 @@ Link.defaultProps = {
 
 Link.propTypes = {
   as: PropTypes.elementType,
+  hoverColor: PropTypes.string,
   href: PropTypes.string,
   muted: PropTypes.bool,
   theme: PropTypes.object,


### PR DESCRIPTION
While looking into #918 I realized we have the `hoverColor` prop that allows folks to change hover color - except it's not documented and wasn't part of the exported TS type 😬 This PR fixes that.

Ideally, this component would use `variants` for the `muted` `gray` `dark-gray` variations of Links, but since Link is used pretty extensively in other projects I would rather avoid the breaking change and make the `hoverColor` prop a little more obvious.

Closes #918 

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
