### PR TITLE
Remove duplicate padding on Dropdown links

### DIFF
--- a/src/Dropdown.js
+++ b/src/Dropdown.js
@@ -101,7 +101,6 @@ Dropdown.Item = styled.li`
     color: ${get('colors.gray.9')};
     text-decoration: none;
     display: block;
-    padding: ${get('space.1')} 10px ${get('space.1')} 15px;
     overflow: hidden;
     color: ${get('colors.gray.9')};
     text-overflow: ellipsis;

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -147,7 +147,6 @@ exports[`Dropdown.Item renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   display: block;
-  padding: 4px 10px 4px 15px;
   overflow: hidden;
   color: #24292e;
   text-overflow: ellipsis;


### PR DESCRIPTION
For some reason, we were applying some padding to any links in `Dropdown.Item`. I've removed that!

Closes #902 

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/8960591/99726935-190c4080-2a6c-11eb-8375-2f151b194199.png)


#### After
![image](https://user-images.githubusercontent.com/8960591/99726897-098cf780-2a6c-11eb-97e3-640eb78c41a3.png)


### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
