### PR TITLE
Fix typo in heading

### DIFF
--- a/src/Heading.js
+++ b/src/Heading.js
@@ -8,7 +8,8 @@ const Heading = styled.h2`
   font-weight: ${get('fontWeights.bold')};
   font-size: ${get('fontSizes.5')};
   margin: 0;
-  ${TYPOGRAPHY} ${COMMON};
+  ${TYPOGRAPHY};
+  ${COMMON};
   ${sx};
 `
 


### PR DESCRIPTION
I noticed there was a missing semi-colon in the `Heading` implementation so I fixed it!