### PR TITLE
fix: reintroduce commonjs module builds

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -14,7 +14,11 @@ module.exports = {
   env: {
     development: {
       presets: makePresets(process.env.BABEL_MODULE || false),
-      plugins: [...sharedPlugins, replacementPlugin('development')]
+      plugins: [
+        ...(process.env.BABEL_MODULE === 'commonjs' ? ['@babel/plugin-transform-modules-commonjs'] : []),
+        ...sharedPlugins,
+        replacementPlugin('development')
+      ]
     },
     production: {
       presets: makePresets(false),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "22.0.0",
+  "version": "22.0.1",
   "description": "Primer react components",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",


### PR DESCRIPTION
v22 broke commonjs builds with https://github.com/primer/components/pull/899 (sorry!)

This re-introduces commonjs builds by way of the commonjs babel plugin, rather than babel-env which was dropped in https://github.com/primer/components/pull/899