### PR TITLE
Revert Dialog style changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
     "jest-styled-components": "6.3.3",
     "jscodeshift": "0.6.4",
     "playroom": "0.15.1",
-    "raw.macro": "0.3.0",
     "react-dom": "^16.10.2",
     "react-test-renderer": "16.10.2",
     "rollup": "2.33.1",

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -1,38 +1,40 @@
 import React from 'react'
 import {Dialog as ReachDialog} from '@reach/dialog'
-import raw from 'raw.macro'
 import styled, {createGlobalStyle} from 'styled-components'
 import PropTypes from 'prop-types'
 import {XIcon} from '@primer/octicons-react'
 import StyledOcticon from './StyledOcticon'
-import {COMMON, LAYOUT} from './constants'
+import {COMMON, LAYOUT, get} from './constants'
 import theme from './theme'
 import sx from './sx'
 import Text from './Text'
 import Flex from './Flex'
 
-const reachStyles = raw('@reach/dialog/styles.css')
-
 const ReachGlobalStyle = createGlobalStyle`
-  ${reachStyles}
-
   [data-reach-dialog-overlay] {
+    background: hsla(0, 0%, 0%, 0.33);
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    overflow: auto;
     z-index: 1000002; /* Higher than the Dropdown and Tooltip */
   }
 `
 
-/* !important's below are needed to override reach styles */
-/* can be removed when we remove ReachDialog */
-
 const StyledDialog = styled(ReachDialog)`
   box-shadow: 0px 4px 32px rgba(0, 0, 0, 0.35);
-  border-radius: 4px;
-  padding: 0 !important;
+  border-radius: ${get('radii.2')};
   position: relative;
+  background-color: ${get('colors.white')};
+  width: 50vw;
+  margin: 10vh auto;
+  outline: none;
 
   @media screen and (max-width: 750px) {
-    width: 100vw !important;
-    margin: 0 !important;
+    width: 100vw;
+    margin: 0;
     border-radius: 0;
     height: 100vh;
   }

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -21,15 +21,18 @@ const ReachGlobalStyle = createGlobalStyle`
   }
 `
 
+/* !important's below are needed to override reach styles */
+/* can be removed when we remove ReachDialog */
+
 const StyledDialog = styled(ReachDialog)`
   box-shadow: 0px 4px 32px rgba(0, 0, 0, 0.35);
   border-radius: 4px;
-  padding: 0;
+  padding: 0 !important;
   position: relative;
 
   @media screen and (max-width: 750px) {
-    width: 100vw;
-    margin: 0;
+    width: 100vw !important;
+    margin: 0 !important;
     border-radius: 0;
     height: 100vh;
   }

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -11,6 +11,11 @@ import Text from './Text'
 import Flex from './Flex'
 
 const ReachGlobalStyle = createGlobalStyle`
+  // silences error regarding importing @reach/dialog styles
+  :root {
+    --reach-dialog: 1;
+  }
+
   [data-reach-dialog-overlay] {
     background: hsla(0, 0%, 0%, 0.33);
     position: fixed;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3357,7 +3357,7 @@ babel-plugin-jest-hoist@^25.0.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@2.8.0, babel-plugin-macros@^2.1.0, babel-plugin-macros@^2.8.0:
+babel-plugin-macros@2.8.0, babel-plugin-macros@^2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz#0f958a7cc6556b1e65344465d99111a1e5e10138"
   integrity sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==
@@ -9283,13 +9283,6 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
-
-raw.macro@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/raw.macro/-/raw.macro-0.3.0.tgz#b62391c5c7a77fd5673b688ac031ba0c5cbff1dc"
-  integrity sha512-VGX8RNUyZ7cZDa4dM8tvysaqryMSQRPbZqmTKKIur2uaGbpmG9Jj9CAY3ndpO8J3RMu0zf2K0JvIwbYMS29TOQ==
-  dependencies:
-    babel-plugin-macros "^2.1.0"
 
 re-resizable@^6.1.1:
   version "6.2.0"


### PR DESCRIPTION
In #909 I removed a few `!important`s from styles inside the Dialog component because when testing in the docs environment they were not needed - when testing 22.0.1 in another application, it looks like the @reach/dialog styles are applied in a different order than in our docs environment, so they were not being overridden with the `!important`s.

Instead of adding the `!important`s back in - I took a look at the imported CSS from `@reach/dialog` it's actually only 25 lines:

```
/* Used to detect in JavaScript if apps have loaded styles or not. */
:root {
  --reach-dialog: 1;
}

[data-reach-dialog-overlay] {
  background: hsla(0, 0%, 0%, 0.33);
  position: fixed;
  top: 0;
  right: 0;
  bottom: 0;
  left: 0;
  overflow: auto;
}

[data-reach-dialog-content] {
  width: 50vw;
  margin: 10vh auto;
  background: white;
  padding: 2rem;
  outline: none;
}
```

a handful of which are overridden. I also noticed in another application using Primer React Components that some of these styles are being loaded upwards of 9 times in the DOM:

![image](https://user-images.githubusercontent.com/8960591/100824686-85dbef00-340b-11eb-8e84-68588c2b2e47.png)


Since we're planning on removing @reach/dialog from the library soon, I decided to move these styles upstream instead of importing the CSS file.
