### PR TITLE
Dialog fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -521,7 +521,7 @@ declare module '@primer/components' {
   export const theme: {[key: string]: any}
   export const themeGet: (key: any) => any
 
-  export interface DialogProps extends CommonProps, LayoutProps {
+  export interface DialogProps extends CommonProps, LayoutProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
     isOpen: boolean
     onDismiss: () => unknown
   }

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -91,7 +91,7 @@ function DialogHeader({theme, children, ...rest}) {
 function Dialog({children, ...props}) {
   return (
     <>
-      <StyledDialog {...props} role="dialog">
+      <StyledDialog role="dialog" {...props}>
         <UnstyledButton onClick={props.onDismiss}>
           <StyledOcticon icon={XIcon} />
         </UnstyledButton>

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -91,7 +91,7 @@ function DialogHeader({theme, children, ...rest}) {
 function Dialog({children, ...props}) {
   return (
     <>
-      <StyledDialog {...props}>
+      <StyledDialog {...props} role="dialog">
         <UnstyledButton onClick={props.onDismiss}>
           <StyledOcticon icon={XIcon} />
         </UnstyledButton>


### PR DESCRIPTION
This PR sets a default `role="dialog"` and allows users to override it by adding the HTML attribute types to the Dialog exported type.
