### PR TITLE
Typo in SelectMenu.Modal prop type

### DIFF
--- a/src/SelectMenu/SelectMenuModal.js
+++ b/src/SelectMenu/SelectMenuModal.js
@@ -106,7 +106,7 @@ SelectMenuModal.defaultProps = {
 SelectMenuModal.propTypes = {
   align: PropTypes.oneOf(['left', 'right']),
   theme: PropTypes.object,
-  width: PropTypes.oneOfType[(PropTypes.string, PropTypes.number)],
+  width: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   ...COMMON.propTypes,
   ...sx.propTypes
 }


### PR DESCRIPTION
There's been a type in the SelectMenu.Modal prop types declaration for a while that's been causing a console error, this PR fixes that!