### PR TITLE
Fix button focus border

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,8 @@ declare module '@primer/components' {
     setOpen: (open: boolean) => void
   }
 
+  export const useMouseIntent: () => void
+
   export interface ButtonProps
     extends BaseProps,
       CommonProps,
@@ -631,6 +633,11 @@ declare module '@primer/components/lib/Details' {
 declare module '@primer/components/lib/hooks/useDetails' {
   import {useDetails} from '@primer/components'
   export default useDetails
+}
+
+declare module '@primer/components/lib/hooks/useMouseIntent' {
+  import {useMouseIntent} from '@primer/components'
+  export default useMouseIntent
 }
 
 declare module '@primer/components/lib/BaseStyles' {

--- a/src/BaseStyles.js
+++ b/src/BaseStyles.js
@@ -2,6 +2,7 @@ import React from 'react'
 import styled, {createGlobalStyle} from 'styled-components'
 import PropTypes from 'prop-types'
 import {TYPOGRAPHY, COMMON} from './constants'
+import useMouseIntent from './hooks/useMouseIntent'
 import theme from './theme'
 
 const GlobalStyle = createGlobalStyle`
@@ -27,6 +28,7 @@ const GlobalStyle = createGlobalStyle`
 `
 const Base = props => {
   const {color, lineHeight, fontFamily, theme, ...rest} = props
+  useMouseIntent()
   return (
     <div {...rest}>
       <GlobalStyle />

--- a/src/BaseStyles.js
+++ b/src/BaseStyles.js
@@ -3,14 +3,32 @@ import styled, {createGlobalStyle} from 'styled-components'
 import PropTypes from 'prop-types'
 import {TYPOGRAPHY, COMMON} from './constants'
 import theme from './theme'
+import useMouseIntent from './hooks/useMouseIntent'
 
 const GlobalStyle = createGlobalStyle`
   * { box-sizing: border-box; }
   body { margin: 0; }
   table { border-collapse: collapse; }
+  body.intent-mouse {
+    [role="button"]:focus,
+    [role="tabpanel"][tabindex="0"]:focus,
+    button:focus,
+    summary:focus,
+    a:focus {
+      outline: none;
+      box-shadow: none;
+    }
+
+    [tabindex="0"]:focus,
+    details-dialog:focus {
+      outline: none;
+    }
+  }
+
 `
 const Base = props => {
   const {color, lineHeight, fontFamily, theme, ...rest} = props
+
   return (
     <div {...rest}>
       <GlobalStyle />

--- a/src/BaseStyles.js
+++ b/src/BaseStyles.js
@@ -3,7 +3,6 @@ import styled, {createGlobalStyle} from 'styled-components'
 import PropTypes from 'prop-types'
 import {TYPOGRAPHY, COMMON} from './constants'
 import theme from './theme'
-import useMouseIntent from './hooks/useMouseIntent'
 
 const GlobalStyle = createGlobalStyle`
   * { box-sizing: border-box; }
@@ -28,7 +27,6 @@ const GlobalStyle = createGlobalStyle`
 `
 const Base = props => {
   const {color, lineHeight, fontFamily, theme, ...rest} = props
-
   return (
     <div {...rest}>
       <GlobalStyle />

--- a/src/Button/Button.js
+++ b/src/Button/Button.js
@@ -18,7 +18,7 @@ const Button = styled(ButtonBase)`
 
   // focus must come before :active so that the active box shadow overrides
   &:focus {
-    border-color: transparent;
+    border-color: rgba(27, 31, 35, 0.15);
     box-shadow: ${get('buttons.default.shadow.focus')};
   }
 

--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -52,7 +52,7 @@ exports[`Button renders consistently 1`] = `
 }
 
 .c0:focus {
-  border-color: transparent;
+  border-color: rgba(27,31,35,0.15);
   box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
@@ -125,7 +125,7 @@ exports[`Button respects the "disabled" prop 1`] = `
 }
 
 .c0:focus {
-  border-color: transparent;
+  border-color: rgba(27,31,35,0.15);
   box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 

--- a/src/__tests__/__snapshots__/Dropdown.js.snap
+++ b/src/__tests__/__snapshots__/Dropdown.js.snap
@@ -73,7 +73,7 @@ exports[`Dropdown.Button renders consistently 1`] = `
 }
 
 .c0:focus {
-  border-color: transparent;
+  border-color: rgba(27,31,35,0.15);
   box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 

--- a/src/__tests__/__snapshots__/SelectMenu.js.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.js.snap
@@ -52,7 +52,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 }
 
 .c1:focus {
-  border-color: transparent;
+  border-color: rgba(27,31,35,0.15);
   box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 

--- a/src/hooks/useMouseIntent.js
+++ b/src/hooks/useMouseIntent.js
@@ -1,0 +1,37 @@
+/* adapted from: https://github.com/github/github/blob/a959c0d15c29b98c49b881f520c5947fe24eecb9/app/assets/modules/github/behaviors/button-outline.ts */
+import {useEffect} from 'react'
+
+function useMouseIntent() {
+  useEffect(() => {
+    let lastActiveElement = null
+    let currentInputIsMouse = false
+
+    function setClass() {
+      lastActiveElement = document.activeElement
+      if (document.body) {
+        document.body.classList.toggle('intent-mouse', currentInputIsMouse)
+      }
+    }
+    // Use mousedown event to make sure outline is remove for holding and dragging
+    document.addEventListener(
+      'mousedown',
+      function() {
+        currentInputIsMouse = true
+        if (lastActiveElement === document.activeElement) setClass()
+      },
+      {capture: true}
+    )
+
+    document.addEventListener(
+      'keydown',
+      function() {
+        currentInputIsMouse = false
+      },
+      {capture: true}
+    )
+
+    document.addEventListener('focusin', setClass, {capture: true})
+  })
+}
+
+export default useMouseIntent

--- a/src/hooks/useMouseIntent.js
+++ b/src/hooks/useMouseIntent.js
@@ -1,7 +1,7 @@
 /* adapted from: https://github.com/github/github/blob/a959c0d15c29b98c49b881f520c5947fe24eecb9/app/assets/modules/github/behaviors/button-outline.ts */
 import {useEffect} from 'react'
 
-function useMouseIntent() {
+const useMouseIntent = () => {
   useEffect(() => {
     let lastActiveElement = null
     let currentInputIsMouse = false

--- a/src/hooks/useMouseIntent.js
+++ b/src/hooks/useMouseIntent.js
@@ -12,26 +12,28 @@ function useMouseIntent() {
         document.body.classList.toggle('intent-mouse', currentInputIsMouse)
       }
     }
-    // Use mousedown event to make sure outline is remove for holding and dragging
-    document.addEventListener(
-      'mousedown',
-      function() {
-        currentInputIsMouse = true
-        if (lastActiveElement === document.activeElement) setClass()
-      },
-      {capture: true}
-    )
 
-    document.addEventListener(
-      'keydown',
-      function() {
-        currentInputIsMouse = false
-      },
-      {capture: true}
-    )
+    function onKeyDown() {
+      currentInputIsMouse = false
+    }
+
+    function onMouseDown() {
+      currentInputIsMouse = true
+      if (lastActiveElement === document.activeElement) setClass()
+    }
+    // Use mousedown event to make sure outline is remove for holding and dragging
+    document.addEventListener('mousedown', onMouseDown, {capture: true})
+
+    document.addEventListener('keydown', onKeyDown, {capture: true})
 
     document.addEventListener('focusin', setClass, {capture: true})
-  })
+
+    return () => {
+      document.removeEventListener('keydown', onKeyDown, {capture: true})
+      document.removeEventListener('focusin', setClass, {capture: true})
+      document.removeEventListener('mousedown', onMouseDown, {capture: true})
+    }
+  }, [])
 }
 
 export default useMouseIntent

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export {default as Position, Absolute, Fixed, Relative, Sticky} from './Position
 
 // Hooks
 export {default as useDetails} from './hooks/useDetails'
+export {default as useMouseIntent} from './hooks/useMouseIntent'
 
 // Components
 export {default as Avatar} from './Avatar'


### PR DESCRIPTION
This PR fixes the button component to show a light border when focused with either a keyboard or a mouse.

I've also added a `useMouseIntent` hook that is basically exactly the same code as [the mouse intent JS in .com](https://github.com/github/github/blob/3e69b57a46084adaf1594d81f8c34de1117a85cb/app/assets/modules/github/behaviors/button-outline.ts#L7-L8) repurposed as a reusable hook for React applications. And, I've added the appropriate `mouse-intent` styles to our `BaseStyles` component.

The only open question I have is - should we apply this hook automatically in `BaseStyles` or should we leave it up to users of the component library to apply the hook themselves? My hunch is that we should include it in `BaseStyles`,~~but I want to do some extra testing first to make sure it doesn't negatively interfere with the .com mouse intent JS that could be already loaded on the page.~~ Tested this release candidate in ✨ another project ✨ and it doesn't seem to interfere

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
