### PR TITLE
Configure Dependabot to update Doctocat

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/docs" # Location of package manifests
+    schedule:
+      interval: "daily"
+    allow:
+      - dependency-name: "@primer/gatsby-theme-doctocat"

--- a/now.json
+++ b/now.json
@@ -2,7 +2,6 @@
   "name": "primer-components",
   "version": 2,
   "alias": "primer-components.now.sh",
-  "files": ["babel.config.js", "yarn.lock", "docs", "rollup.config.js", "src", "static"],
   "routes": [
     {"src": "/playroom(/.*)?", "dest": "$1"},
     {"src": "/components(/.*)?", "dest": "/docs$1"},


### PR DESCRIPTION
## Problem

Every time we release a new version of [Doctocat](https://primer.style/doctocat), we have to manually update the Primer React components docs site.

## Solution

This PR configures dependabot to automatically update Doctocat every time a new version is released.