### PR TITLE
bug fix: select menu click handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "22.0.2",
+  "version": "22.0.3",
   "description": "Primer react components",
   "main": "lib/index.js",
   "module": "lib-esm/index.js",

--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -55,7 +55,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
 
   const onClickOutside = useCallback(
     (event) => {
-      if (event.target.closest('details') !== ref.current) {
+      if (!ref.current.contains(event.target)) {
         if (!event.defaultPrevented) {
           setOpen(false)
         }


### PR DESCRIPTION
This PR changes the `onClickOutside` handling of the SelectMenu to work even if the component is not wrapped inside of a `details` and instead checks against the `ref` - this would allow the click handling to work when the SelectMenu.Modal is rendered in a Portal.

I'd like to ship this as a patch release

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
