### PR TITLE
Dialog tweaks

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -81,6 +81,7 @@ const Overlay = styled.span`
 
 const Dialog = forwardRef(({children, onDismiss, isOpen, initialFocusRef, returnFocusRef, ...props}, forwardedRef) => {
   const backupRef = useRef(null)
+  const overlayRef = useRef(null)
   const modalRef = forwardedRef ?? backupRef
   const closeButtonRef = useRef(null)
 
@@ -98,10 +99,11 @@ const Dialog = forwardRef(({children, onDismiss, isOpen, initialFocusRef, return
     initialFocusRef,
     closeButtonRef,
     returnFocusRef,
+    overlayRef,
   })
   return isOpen ? (
     <>
-      <Overlay />
+      <Overlay ref={overlayRef} />
       <StyledDialog tabIndex={-1} ref={modalRef} role="dialog" aria-modal="true" {...props} {...getDialogProps()}>
         <ButtonClose
           ref={closeButtonRef}

--- a/src/hooks/useDialog.js
+++ b/src/hooks/useDialog.js
@@ -8,14 +8,19 @@ function focusable(el) {
   return el.tabIndex >= 0 && !el.disabled && visible(el)
 }
 
-function useDialog({modalRef, isOpen, onDismiss, initialFocusRef, closeButtonRef} = {}) {
+function useDialog({modalRef, overlayRef, isOpen, onDismiss, initialFocusRef, closeButtonRef} = {}) {
   const onClickOutside = useCallback(
     (e) => {
-      if (modalRef.current && !modalRef.current.contains(e.target)) {
+      if (
+        modalRef.current &&
+        overlayRef.current &&
+        !modalRef.current.contains(e.target) &&
+        overlayRef.current.contains(e.target)
+      ) {
         onDismiss()
       }
     },
-    [onDismiss, modalRef]
+    [onDismiss, modalRef, overlayRef]
   )
 
   useEffect(() => {


### PR DESCRIPTION
This PR tweaks the useDialog hook a bit to check if a click happened on the overlay or not before closing it on outside click. This helps ensure that the initial click to open the Dialog is not counted as an outside click, since it is impossible for it to happen on the overlay.