### PR TITLE
Protect against a ref that hasn't been initialized

### DIFF
--- a/src/SelectMenu/SelectMenu.js
+++ b/src/SelectMenu/SelectMenu.js
@@ -55,7 +55,7 @@ const SelectMenu = React.forwardRef(({children, initialTab, as, ...rest}, forwar
 
   const onClickOutside = useCallback(
     (event) => {
-      if (!ref.current.contains(event.target)) {
+      if (ref.current && !ref.current.contains(event.target)) {
         if (!event.defaultPrevented) {
           setOpen(false)
         }


### PR DESCRIPTION
This fixes a console error that I noticed while using the SelectMenu in another project. I think for `clickOutside` behaviour we can safely ignore a missing ref.

### Screenshots
Please provide before/after screenshots for any visual changes

<img width="489" alt="Screen Shot 2021-01-15 at 12 25 28 AM" src="https://user-images.githubusercontent.com/776168/104699896-3ce4af00-56c8-11eb-9081-19d1e40f6fb8.png">

### Merge checklist
- [ ] ~Added or updated TypeScript definitions (`index.d.ts`) if necessary~
- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
