### PR TITLE
Add tabIndex default 0 to select menu list

### DIFF
--- a/src/SelectMenu/SelectMenuList.js
+++ b/src/SelectMenu/SelectMenuList.js
@@ -37,6 +37,7 @@ const SelectMenuList = styled.div`
 `
 SelectMenuList.defaultProps = {
   theme,
+  tabIndex: 0,
 }
 
 SelectMenuList.propTypes = {

--- a/src/__tests__/SelectMenu.js
+++ b/src/__tests__/SelectMenu.js
@@ -70,12 +70,17 @@ describe('SelectMenu', () => {
     })
   }
 
+  it.only('List has a tabIndex of 0', () => {
+    expect(render(<SelectMenu.List />).props['tabIndex']).toEqual(0)
+  })
+
   it('should have no axe violations', async () => {
     const {container} = HTMLRender(<BasicSelectMenu />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
     cleanup()
   })
+
   it('implements system props', () => {
     expect(SelectMenu).toImplementSystemProps(COMMON)
   })

--- a/src/__tests__/SelectMenu.js
+++ b/src/__tests__/SelectMenu.js
@@ -70,7 +70,7 @@ describe('SelectMenu', () => {
     })
   }
 
-  it.only('List has a tabIndex of 0', () => {
+  it('List has a tabIndex of 0', () => {
     expect(render(<SelectMenu.List />).props['tabIndex']).toEqual(0)
   })
 


### PR DESCRIPTION
WIPWIPWIP

Describe your changes here.

Closes # (type the issue number after # if applicable; otherwise remove this line)

### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
