### PR TITLE
Type check test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@testing-library/react": "11.2.2",
     "@testing-library/user-event": "12.6.0",
     "@types/jest": "26.0.20",
+    "@types/jest-axe": "3.5.1",
     "@wojtekmaj/enzyme-adapter-react-17": "0.3.2",
     "babel-core": "7.0.0-bridge.0",
     "babel-plugin-add-react-displayname": "0.0.5",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,5 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["**/__tests__/**"]
+  "include": ["src/**/*.js", "src/**/*.ts", "src/**/*.tsx"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1645,7 +1645,15 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
-"@types/jest@26.0.20":
+"@types/jest-axe@3.5.1":
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-axe/-/jest-axe-3.5.1.tgz#122c3864e361c8d699e60814a6a7f6851101d263"
+  integrity sha512-yelGgELc6iJEPShJ3/XEu6uUr5rCGi/Md0QzMuoo53y0WpR2lyFM3mjdpo8Q+PPd3onHOpIw6BBzEAIU65ZFSA==
+  dependencies:
+    "@types/jest" "*"
+    axe-core "^3.5.5"
+
+"@types/jest@*", "@types/jest@26.0.20":
   version "26.0.20"
   resolved "https://registry.yarnpkg.com/@types/jest/-/jest-26.0.20.tgz#cd2f2702ecf69e86b586e1f5223a60e454056307"
   integrity sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
@@ -2482,6 +2490,11 @@ aws4@^1.8.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
   integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
+
+axe-core@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
+  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
 axe-core@^4.0.1:
   version "4.1.1"


### PR DESCRIPTION
## Problem

As part of the [TypeScript refactor](https://github.com/primer/components/issues/970), we're rewriting component test files in TypeScript. However, we never type check these test files during CI. So test files with type errors could still pass CI and be merged into the `main` branch, causing errors in consuming applications.

For example, if the type definition for the `Box` component is incorrect, we might not know about the error until a consuming application uses `Box` and encounters the error. If we type check the `Box` test file during CI, we'd surface the error before merging the PR.

## Solution

This PR updates `tsconfig.json` to include test files when type checking and generating type definition files.

## Impact

If any test files contain type errors, CI will fail. Since our tests (should) [resemble the way components are used](https://testing-library.com/docs/guiding-principles), we can catch type errors before they reach consumers.
