### PR TITLE
[typings] add supported htmlFor prop to FormGroupLabelProps definition

### DIFF
--- a/.changeset/mighty-pumpkins-behave.md
+++ b/.changeset/mighty-pumpkins-behave.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Add supported `htmlFor` prop to `FormGroupLabelProps` type definition

--- a/index.d.ts
+++ b/index.d.ts
@@ -238,7 +238,9 @@ declare module '@primer/components' {
 
   export interface FormGroupProps extends CommonProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {}
 
-  export interface FormGroupLabelProps extends CommonProps, TypographyProps, Omit<React.HTMLAttributes<HTMLLabelElement>, 'color'> {}
+  export interface FormGroupLabelProps extends CommonProps, TypographyProps, Omit<React.HTMLAttributes<HTMLLabelElement>, 'color'> {
+    htmlFor?: string
+  }
 
   export const FormGroup: React.FunctionComponent<FormGroupProps> & {
     Label: React.FunctionComponent<FormGroupLabelProps>


### PR DESCRIPTION
`FormGroup.Label` supports a `htmlFor` prop in the docs to associated the label with a text input: https://primer.style/components/FormGroup#formgrouplabel

<img width="900" src="https://user-images.githubusercontent.com/359239/105877633-94432300-5fd6-11eb-8822-4289321ff06d.png">

However the TS declarations do not indicate this is a supported prop:

<img width="711" src="https://user-images.githubusercontent.com/359239/105877808-bf2d7700-5fd6-11eb-9cf0-61684a352b1a.png">

Omitting this value causes axe to report accessibility violations, so I added in the missing value (optional, just to match the docs).

### Screenshots

N/A

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
