### PR TITLE
Fix prop passing in BaseStyles

### DIFF
--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -35,12 +35,12 @@ const Base = styled.div<SystemTypographyProps & SystemCommonProps>`
 export type BaseStylesProps = ComponentProps<typeof Base>
 
 function BaseStyles(props: BaseStylesProps) {
-  const {color, lineHeight, fontFamily, theme, ...rest} = props
+  const {children, ...rest} = props
   useMouseIntent()
   return (
     <Base {...rest}>
       <GlobalStyle />
-      {props.children}
+      {children}
     </Base>
   )
 }


### PR DESCRIPTION
## Problem

https://github.com/primer/components/pull/982 broke the `BaseStyles` by preventing system props from being applied correctly. 

## Solution

This PR makes sure that the system props are passed to the correct styled component.
