### PR TITLE
Upgrade Octicons

### DIFF
--- a/.changeset/old-dingos-switch.md
+++ b/.changeset/old-dingos-switch.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Upgrade Octicons to 11.3.0

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "author": "GitHub, Inc.",
   "license": "MIT",
   "dependencies": {
-    "@primer/octicons-react": "^10.0.0",
+    "@primer/octicons-react": "^11.3.0",
     "@primer/primitives": "3.0.0",
     "@styled-system/css": "5.1.5",
     "@styled-system/prop-types": "5.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1526,10 +1526,10 @@
     "@nodelib/fs.scandir" "2.1.4"
     fastq "^1.6.0"
 
-"@primer/octicons-react@^10.0.0":
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-10.1.0.tgz#6d2b980582f6d917043dd8fd873039e71d8b7242"
-  integrity sha512-WjIaetTaf4x66xxaG/gxwsWRL2JYG33n8CfeR/L134YcX2zl9TPps9crLzI2f3rxjOdKZgVFBoUh94Cim4Fflw==
+"@primer/octicons-react@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@primer/octicons-react/-/octicons-react-11.3.0.tgz#794641d95ff5749a9438a2e0c201956b2a377b60"
+  integrity sha512-4sVhkrBKuj3h+PFw69yOyO/l3nQB/mm95V+Kz7LRSlIrbZr6hZarZD5Ft4ewdONPROkIHQM/6KSK90+OAimxsQ==
 
 "@primer/primitives@3.0.0":
   version "3.0.0"


### PR DESCRIPTION
This PR upgrades the version of @primer/octicons-react that we use to `^11.3.0.`
