### PR TITLE
[WIP] Update type definitions of components created with styled-components

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -10,3 +10,8 @@ export type ComponentProps<T> = T extends React.ComponentType<infer Props>
     ? Props
     : never
   : never
+
+export type StyledComponentProps = {
+  as?: React.ElementType
+  theme?: any
+}


### PR DESCRIPTION
### Problem

### Solution

```ts
type StyledComponentProps = {
  as?: React.ElementType
  theme?: any
}
```

```diff
import styled from 'styled-components'
import sx, {SxProp} from './sx'
import {COMMON, SystemCommonProps} from './constants'
import theme from './theme'
- import {ComponentProps} from ‘./utils/types’
+ import {StyledComponentProps} from ‘./utils/types’

- type StyledBoxProps =
+ export type BoxProps =
  SystemCommonProps &
  SxProp &
+  StyledComponentProps

- const Box = styled.h2<StyledBoxProps>`
+ const Box = styled.h2<BoxProps>`
  ${COMMON};
  ${sx};
`

Box.defaultProps = {theme}

- export type BoxProps = ComponentProps<typeof Box>
export default Box

```