### PR TITLE
Add ButtonInvisible focus styles

### DIFF
--- a/.changeset/five-islands-dance.md
+++ b/.changeset/five-islands-dance.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix border radius on ButtonClose

--- a/.changeset/orange-ties-marry.md
+++ b/.changeset/orange-ties-marry.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Add ButtonInvisible focus styles

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -15,6 +15,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   background: transparent;
   outline: none;
   cursor: pointer;
+  border-radius: ${get('radii.2')};
 
   &:focus {
     box-shadow: ${get('buttons.close.shadow.focus')};

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -9,12 +9,18 @@ const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps &
   color: ${get('colors.blue.5')};
   background-color: transparent;
   border: 0;
-  border-radius: 0;
+  border-radius: ${get('radii.2')};
   box-shadow: none;
 
   &:disabled {
     color: ${get('buttons.default.color.disabled')};
   }
+
+  &:focus {
+    border-color: rgba(27, 31, 35, 0.15);
+    box-shadow: ${get('buttons.default.shadow.focus')};
+  }
+
 
   ${buttonSystemProps};
   ${sx}

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -17,7 +17,6 @@ const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps &
   }
 
   &:focus {
-    border-color: rgba(27, 31, 35, 0.15);
     box-shadow: ${get('buttons.default.shadow.focus')};
   }
 

--- a/src/__tests__/__snapshots__/Button.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.tsx.snap
@@ -455,7 +455,7 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   color: #0366d6;
   background-color: transparent;
   border: 0;
-  border-radius: 0;
+  border-radius: 6px;
   box-shadow: none;
 }
 
@@ -478,6 +478,11 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
 
 .c0:disabled {
   color: #959da5;
+}
+
+.c0:focus {
+  border-color: rgba(27,31,35,0.15);
+  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 
 <button

--- a/src/__tests__/__snapshots__/Button.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.tsx.snap
@@ -481,7 +481,6 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
 }
 
 .c0:focus {
-  border-color: rgba(27,31,35,0.15);
   box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
 }
 

--- a/src/__tests__/__snapshots__/Dialog.js.snap
+++ b/src/__tests__/__snapshots__/Dialog.js.snap
@@ -73,6 +73,7 @@ Array [
   background: transparent;
   outline: none;
   cursor: pointer;
+  border-radius: 6px;
   position: absolute;
   top: 16px;
   right: 16px;

--- a/src/__tests__/__snapshots__/TextInput.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.tsx.snap
@@ -4,6 +4,7 @@ exports[`TextInput renders 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;
@@ -74,6 +75,7 @@ exports[`TextInput renders block 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;
@@ -146,6 +148,7 @@ exports[`TextInput renders consistently 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;
@@ -215,6 +218,7 @@ exports[`TextInput renders large 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;
@@ -290,6 +294,7 @@ exports[`TextInput renders small 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;
@@ -367,6 +372,7 @@ exports[`TextInput should render a password input 1`] = `
 .c1 {
   border: 0;
   font-size: inherit;
+  font-family: inherit;
   background-color: transparent;
   -webkit-appearance: none;
   color: inherit;


### PR DESCRIPTION
This PR adds focus styles to `ButtonInvisible`. I've also gone ahead and fixed the border radius on the focus style for ButtonClose. And I've updated all snapshots, including one for `TextInput` that was in need of updating from #1049 (opened from outside contributor so tests didn't run).

Closes #1052 

### Screenshots
Before:
<img width="55" alt="image" src="https://user-images.githubusercontent.com/8960591/108125942-0a7af880-705e-11eb-8758-ae76574359eb.png">

After:
<img width="222" alt="image" src="https://user-images.githubusercontent.com/8960591/108125888-f9ca8280-705d-11eb-865e-784bbd35a13d.png">
<img width="133" alt="image" src="https://user-images.githubusercontent.com/8960591/108125907-ff27cd00-705d-11eb-8a8d-7ee9ad232218.png">


### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
