### PR TITLE
[Docs] Broken link to theme file

### DIFF
--- a/docs/content/primer-theme.md
+++ b/docs/content/primer-theme.md
@@ -4,7 +4,7 @@ title: Primer Theme
 
 import {theme} from '@primer/components'
 
-Primer React components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/main/src/theme-preval.js) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
+Primer React components come with built-in access to our Primer theme. The [theme file](https://github.com/primer/components/blob/main/src/theme-preval.ts) contains an object which holds values for common variables such as color, fonts, box shadows, and more. Our theme file pulls many of its color and typography values from [primer-primitives](https://github.com/primer/primer-primitives).
 
 Many of our theme keys correspond to system props on our components. For example, if you'd like to set the max width on a `<Box>` set the `maxWidth` prop to `medium`: `<Box maxWidth='medium'>`
 


### PR DESCRIPTION
[primer-theme.md](https://github.com/primer/components/blob/main/docs/content/primer-theme.md) contains broken link to the theme file.

Changed the link to https://github.com/primer/components/blob/main/src/theme-preval.ts

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge