### PR TITLE
Migrate useMouseIntent to TypeScript

### DIFF
--- a/.changeset/heavy-files-rule.md
+++ b/.changeset/heavy-files-rule.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Migrate `useMouseIntent` to TypeScript

--- a/src/hooks/useMouseIntent.ts
+++ b/src/hooks/useMouseIntent.ts
@@ -3,7 +3,7 @@ import {useEffect} from 'react'
 
 const useMouseIntent = () => {
   useEffect(() => {
-    let lastActiveElement = null
+    let lastActiveElement: Element | null = null
     let currentInputIsMouse = false
 
     function setClass() {


### PR DESCRIPTION
This PR migrates the `useMouseIntent` component to TypeScript as part of the [TypeScript refactor](https://github.com/primer/components/issues/970).