### PR TITLE
Add contrast prop to TextInput

### DIFF
--- a/.changeset/fuzzy-dodos-applaud.md
+++ b/.changeset/fuzzy-dodos-applaud.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': minor
+---
+
+Adds a `contrast` prop to TextInput

--- a/docs/content/TextInput.md
+++ b/docs/content/TextInput.md
@@ -2,13 +2,15 @@
 title: TextInput
 ---
 
-TextInput is a form component to add default styling to the native text input. 
+TextInput is a form component to add default styling to the native text input.
 
 **Note:** Don't forget to set `aria-label` to make the TextInput accessible to screen reader users.
 ## Default example
 
 ```jsx live
 <TextInput aria-label="Zipcode" name="zipcode" placeholder="Zipcode" autoComplete="postal-code" />
+
+<TextInput  ml={4} aria-label="City" name="city" placeholder="City" contrast />
 
 <TextInput ml={4} icon={SearchIcon} aria-label="Zipcode" name="zipcode" placeholder="Find user" autoComplete="postal-code" />
 ```
@@ -25,8 +27,9 @@ Native `<input>` attributes are forwarded to the underlying React `input` compon
 | :- | :- | :-: | :- |
 | aria-label | String | | Required. Allows input to be accessible. |
 | block | Boolean | | Adds `display: block` to element |
+| contrast | Boolean | | Changes background color to a higher contrast color |
 | variant | String | | Can be either `small` or `large`. Creates a smaller or larger input than the default.
 | width | String or Number | | Set the width of the input |
 | maxWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the maximum width of the input |
 | minWidth | String or Number or [Array](https://styled-system.com/guides/array-props) | | Set the minimum width of the input |
-| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the left edge. | 
+| icon | Node (pass Octicon react component) | | Icon to be used inside of input. Positioned on the left edge. |

--- a/index.d.ts
+++ b/index.d.ts
@@ -446,6 +446,7 @@ declare module '@primer/components' {
       StyledSystem.MinWidthProps,
       Omit<React.InputHTMLAttributes<HTMLInputElement>, 'color' | 'size' | 'width'> {
     block?: boolean
+    contrast?: boolean
     icon?: ReactComponentLike
     variant?: 'small' | 'large'
     ref?: React.RefObject<HTMLInputElement> | null

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -44,6 +44,7 @@ type StyledWrapperProps = {
   disabled?: boolean
   hasIcon?: boolean
   block?: boolean
+  contrast?: boolean
   variant?: 'small' | 'large'
 } & SystemCommonProps &
   WidthProps &
@@ -91,6 +92,14 @@ const Wrapper = styled.span<StyledWrapperProps>`
   }
 
   ${props =>
+    props.contrast &&
+    css`
+     background-color: ${get('colors.gray.0')};
+    }
+  `}
+
+
+  ${props =>
     props.disabled &&
     css`
      background-color: ${get('colors.bg.disabled')};
@@ -122,7 +131,7 @@ type TextInputInternalProps = {icon?: React.ComponentType<{className?: string}>}
 
 // using forwardRef is important so that other components (ex. SelectMenu) can autofocus the input
 const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
-  ({icon: IconComponent, className, block, disabled, sx, ...rest}, ref) => {
+  ({icon: IconComponent, contrast, className, block, disabled, sx, ...rest}, ref) => {
     // this class is necessary to style FilterSearch, plz no touchy!
     const wrapperClasses = classnames(className, 'TextInput-wrapper')
     const wrapperProps = pick(rest)
@@ -134,6 +143,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
         block={block}
         theme={theme}
         disabled={disabled}
+        contrast={contrast}
         sx={sx}
         {...wrapperProps}
       >

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -95,7 +95,6 @@ const Wrapper = styled.span<StyledWrapperProps>`
     props.contrast &&
     css`
      background-color: ${get('colors.gray.0')};
-    }
   `}
 
 
@@ -103,8 +102,7 @@ const Wrapper = styled.span<StyledWrapperProps>`
     props.disabled &&
     css`
      background-color: ${get('colors.bg.disabled')};
-     box-shadow: ${get('shadows.formControlDisabled')}
-    }
+     box-shadow: ${get('shadows.formControlDisabled')};
   `}
 
   ${props =>


### PR DESCRIPTION
This PR is a quick addition to the TextInput as requested in #1081 



Closes #1081

### Screenshots
Please provide before/after screenshots for any visual changes
<img width="723" alt="image" src="https://user-images.githubusercontent.com/8960591/109189252-adabcc00-7748-11eb-9146-eae7ea6e925a.png">


### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
