### PR TITLE
fix TabNav styles

### DIFF
--- a/.changeset/happy-carpets-sit.md
+++ b/.changeset/happy-carpets-sit.md
@@ -2,4 +2,4 @@
 "@primer/components": patch
 ---
 
-- fixes up styles in TabNav allowing for items positioned on the right end of TabNav
+Fix up styles in TabNav allowing for items positioned on the right end of TabNav

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -11,26 +11,26 @@ import * as History from 'history'
 const ITEM_CLASS = 'TabNav-item'
 const SELECTED_CLASS = 'selected'
 
-const TabNavBase = styled.nav<SystemCommonProps & SxProp>`
-  display: flex;
+const TabNavBase = styled.div<SystemCommonProps & SxProp>`
+  margin-bottom: 16px;
+  margin-top: 0;
   border-bottom: 1px solid ${get('colors.border.gray')};
-
-  .TabNav-body {
-    display: flex;
-    margin-bottom: -1px;
-  }
-
   ${COMMON}
   ${sx}
 `
 
+const TabNavBody = styled.nav`
+  display: flex;
+  margin-bottom: -1px;
+  overflow: auto;
+`
+
 export type TabNavProps = ComponentProps<typeof TabNavBase>
 
-function TabNav({className, children, ...rest}: TabNavProps) {
-  const classes = classnames(className, 'TabNav')
+function TabNav({children, ...rest}: TabNavProps) {
   return (
-    <TabNavBase className={classes} {...rest}>
-      <div className="TabNav-body">{children}</div>
+    <TabNavBase {...rest}>
+      <TabNavBody>{children}</TabNavBody>
     </TabNavBase>
   )
 }

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -12,7 +12,6 @@ const ITEM_CLASS = 'TabNav-item'
 const SELECTED_CLASS = 'selected'
 
 const TabNavBase = styled.div<SystemCommonProps & SxProp>`
-  margin-bottom: 16px;
   margin-top: 0;
   border-bottom: 1px solid ${get('colors.border.gray')};
   ${COMMON}

--- a/src/__tests__/TabNav.tsx
+++ b/src/__tests__/TabNav.tsx
@@ -25,11 +25,6 @@ describe('TabNav', () => {
     cleanup()
   })
 
-  it('renders a <nav>', () => {
-    expect(render(<TabNav />).type).toEqual('nav')
-  })
-
-
   it('sets aria-label appropriately', () => {
     expect(render(<TabNav aria-label="foo" />).props['aria-label']).toEqual('foo')
   })

--- a/src/__tests__/TabNav.tsx
+++ b/src/__tests__/TabNav.tsx
@@ -29,19 +29,8 @@ describe('TabNav', () => {
     expect(render(<TabNav />).type).toEqual('nav')
   })
 
-  it('adds the TabNav class', () => {
-    expect(rendersClass(<TabNav />, 'TabNav')).toEqual(true)
-  })
 
   it('sets aria-label appropriately', () => {
     expect(render(<TabNav aria-label="foo" />).props['aria-label']).toEqual('foo')
-  })
-
-  it('wraps its children in an "TabNav-body" div', () => {
-    const children = <b>children</b>
-    const wrapper = mount(<TabNav>{children}</TabNav>)
-    const body = wrapper.find('.TabNav-body')
-    expect(body.exists()).toEqual(true)
-    expect(body.childAt(0).type()).toEqual('b')
   })
 })

--- a/src/__tests__/__snapshots__/TabNav.tsx.snap
+++ b/src/__tests__/__snapshots__/TabNav.tsx.snap
@@ -35,26 +35,24 @@ exports[`TabNav TabNav.Link renders consistently 1`] = `
 
 exports[`TabNav renders consistently 1`] = `
 .c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  margin-top: 0;
   border-bottom: 1px solid #e1e4e8;
 }
 
-.c0 .TabNav-body {
+.c1 {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
   margin-bottom: -1px;
+  overflow: auto;
 }
 
-<nav
-  className="c0 TabNav"
+<div
+  className="c0"
 >
-  <div
-    className="TabNav-body"
+  <nav
+    className="c1"
   />
-</nav>
+</div>
 `;


### PR DESCRIPTION
@pmarsceill noticed that it's not possible to align content to the right of the `TabNav` box. I started doing some digging and realized there's a few places where the styles in TabNav are not in alignment with the styles TabNav has in Primer CSS, so cleaned that up a bit and fixed the flex issue.


### Screenshots
#### Before (with no extra item)
<img width="1017" alt="image" src="https://user-images.githubusercontent.com/8960591/109233808-5f65ef80-777f-11eb-8dcf-44c85f22b573.png">


#### Before (with a button on the end with ml="auto"):
<img width="1019" alt="image" src="https://user-images.githubusercontent.com/8960591/109233838-6c82de80-777f-11eb-808b-8eb798bc9536.png">

#### After (with no extra item)
<img width="982" alt="image" src="https://user-images.githubusercontent.com/8960591/109233874-7dcbeb00-777f-11eb-9ee0-8004121d38fb.png">

#### After (with a button on the end with ml="auto"):
<img width="1015" alt="image" src="https://user-images.githubusercontent.com/8960591/109233896-8de3ca80-777f-11eb-81b3-8df687e70758.png">



### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
