### PR TITLE
Remove default theme prop

### DIFF
--- a/.changeset/tricky-humans-appear.md
+++ b/.changeset/tricky-humans-appear.md
@@ -1,0 +1,20 @@
+---
+"@primer/components": major
+---
+
+Components no longer have a default `theme` prop. To ensure components still render correctly, you'll need pass the Primer theme to a [styled-components](https://styled-components.com/) `<ThemeProvider>` at the root of your application:
+
+```jsx
+import {ThemeProvider} from 'styled-components'
+import {theme} from '@primer/components'
+
+funciton App(props) {
+  return (
+    <div>
+      <ThemeProvider theme={theme}>
+        <div>your app here</div>
+      </ThemeProvider>
+    </div>
+  )
+}
+```

--- a/contributor-docs/CONTRIBUTING.md
+++ b/contributor-docs/CONTRIBUTING.md
@@ -6,7 +6,6 @@
 4. [Developing Components](#developing-components)
    - [Tools we use](#tools-we-use)
    - [Component patterns](#component-patterns)
-   - [Adding default theme](#adding-default-theme)
    - [Adding system props](#adding-system-props)
    - [Adding the sx prop](#adding-the-sx-prop)
    - [Linting](#linting)
@@ -72,7 +71,7 @@ With a couple of exceptions, all components should be created with the `styled` 
 
 Default values for system props can be set in `Component.defaultProps`.
 
-⚠️ **Make sure to always set the default `theme` prop to our [theme](https://github.com/primer/components/blob/main/src/theme-preval.js)! This allows consumers of our components to access our theme values without a ThemeProvider.**
+⚠️ **Do not set the default `theme` prop! This can sometimes override the theme provided by the ThemeProvider and cause unexpected theming issues.**
 
 Additionally, every component should support [the `sx` prop](https://primer.style/components/overriding-styles); remember to add `${sx}` to the style literal.
 
@@ -80,7 +79,6 @@ Here's an example of a basic component written in the style of Primer Components
 
 ```jsx
 import {TYPOGRAPHY, COMMON} from './constants'
-import theme from './theme'
 import sx from './sx
 
 const Component = styled.div`
@@ -92,26 +90,11 @@ const Component = styled.div`
 `
 
 Component.defaultProps = {
-  theme, // make sure to always set the default theme!
   m: 0,
   fontSize: 5,
 }
 
 export default Component
-```
-
-### Adding default theme
-
-Each component needs access to our default Primer Theme, so that users of the component can access theme values easily in their consuming applications.
-
-To add the default theme to a component, import the theme and assign it to the component's defaultProps object:
-
-```jsx
-import theme from './theme'
-
-Component.defaultProps = {
-  theme // make sure to always set the default theme!
-}
 ```
 
 ### Adding system props
@@ -223,7 +206,6 @@ After opening a pull request, a member of the design systems team will add the a
 - If it's a new component, does the component make sense to add to Primer Components? (Ideally this is discussed before the pull request stage, please reach out to a DS member if you aren't sure if a component should be added to Primer Components!)
 - Does the component follow our [Primer Components code style](#component-patterns)?
 - Does the component use theme values for most CSS values?
-- Does the component have access to the [default theme](#adding-default-theme)?
 - Does the component have the [correct system props implemented](#adding-system-props)?
 - Is the component API intuitive?
 - Does the component have the appropriate [type definitions in `index.d.ts`](#typescript-support)?

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -100,7 +100,6 @@ If you'd like to fully replace the Primer [theme](https://github.com/primer/comp
 
 ```jsx
 import {ThemeProvider} from 'styled-components'
-import {theme} from '@primer/components'
 const theme = { ... }
 
 const App = (props) => {

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -79,11 +79,28 @@ This will apply the same `color`, `font-family`, and `line-height` styles to the
 
 ## Theming
 
-Components are styled using Primer's [theme](https://github.com/primer/components/blob/main/src/theme-preval.js) by default, but you can provide your own theme by using [styled-component's](https://styled-components.com/) `<ThemeProvider>`. If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/main/src/theme-preval.js) with your custom theme, pass your theme to the `<ThemeProvider>` in the root of your application like so:
+For Primer Components to render correcly, you must pass the Primer theme to a [styled-components](<(https://styled-components.com/)>) `<ThemeProvider>` at the root of your application:
 
 ```jsx
 import {ThemeProvider} from 'styled-components'
+import {theme} from '@primer/components'
 
+const App = props => {
+  return (
+    <div>
+      <ThemeProvider theme={theme}>
+        <div>your app here</div>
+      </ThemeProvider>
+    </div>
+  )
+}
+```
+
+If you'd like to fully replace the Primer [theme](https://github.com/primer/components/blob/main/src/theme-preval.js) with your custom theme, pass your theme to the `<ThemeProvider>` instead:
+
+```jsx
+import {ThemeProvider} from 'styled-components'
+import {theme} from '@primer/components'
 const theme = { ... }
 
 const App = (props) => {

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "rollup-plugin-terser": "5.3.0",
     "rollup-plugin-visualizer": "4.0.4",
     "semver": "7.3.2",
-    "styled-components": "4.4.0",
+    "styled-components": "4.4.1",
     "typescript": "4.1.3"
   },
   "peerDependencies": {

--- a/src/Avatar.tsx
+++ b/src/Avatar.tsx
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledAvatarProps = {
@@ -33,7 +32,6 @@ const Avatar = styled.img.attrs<StyledAvatarProps>(props => ({
 `
 
 Avatar.defaultProps = {
-  theme,
   size: 20,
   alt: '',
   square: false
@@ -43,8 +41,7 @@ Avatar.propTypes = {
   ...COMMON.propTypes,
   size: PropTypes.number,
   square: PropTypes.bool,
-  ...sx.propTypes,
-  theme: PropTypes.object
+  ...sx.propTypes
 }
 
 export type AvatarProps = ComponentProps<typeof Avatar>

--- a/src/AvatarPair.tsx
+++ b/src/AvatarPair.tsx
@@ -1,10 +1,8 @@
-import PropTypes from 'prop-types'
 import React from 'react'
 import styled from 'styled-components'
 import Avatar from './Avatar'
 import {get} from './constants'
 import {Relative, RelativeProps} from './Position'
-import theme from './theme'
 
 const ChildAvatar = styled(Avatar)`
   position: absolute;
@@ -30,10 +28,8 @@ const AvatarPair = ({children, ...rest}: AvatarPairProps) => {
 // styled() changes this
 AvatarPair.displayName = 'AvatarPair'
 
-AvatarPair.defaultProps = {theme}
 AvatarPair.propTypes = {
-  ...Relative.propTypes,
-  theme: PropTypes.object
+  ...Relative.propTypes
 }
 
 export default AvatarPair

--- a/src/AvatarStack.tsx
+++ b/src/AvatarStack.tsx
@@ -1,11 +1,10 @@
-import React from 'react'
 import classnames from 'classnames'
 import PropTypes from 'prop-types'
+import React from 'react'
 import styled from 'styled-components'
-import sx, {SxProp} from './sx'
-import {get, COMMON, SystemCommonProps} from './constants'
-import theme from './theme'
+import {COMMON, get, SystemCommonProps} from './constants'
 import {Absolute} from './Position'
+import sx, {SxProp} from './sx'
 import {ComponentProps} from './utils/types'
 
 type StyledAvatarStackWrapperProps = {
@@ -158,10 +157,6 @@ const AvatarStack = ({children, alignRight, ...rest}: AvatarStackProps) => {
       </Absolute>
     </AvatarStackWrapper>
   )
-}
-
-AvatarStack.defaultProps = {
-  theme
 }
 
 AvatarStack.propTypes = {

--- a/src/AvatarStack.tsx
+++ b/src/AvatarStack.tsx
@@ -1,17 +1,9 @@
 import classnames from 'classnames'
-<<<<<<< HEAD
-import PropTypes from 'prop-types'
-=======
->>>>>>> origin/main
 import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import {Absolute} from './Position'
 import sx, {SxProp} from './sx'
-<<<<<<< HEAD
-=======
-import theme from './theme'
->>>>>>> origin/main
 import {ComponentProps} from './utils/types'
 
 type StyledAvatarStackWrapperProps = {

--- a/src/BaseStyles.tsx
+++ b/src/BaseStyles.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled, {createGlobalStyle} from 'styled-components'
 import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import useMouseIntent from './hooks/useMouseIntent'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const GlobalStyle = createGlobalStyle`
@@ -47,8 +46,7 @@ function BaseStyles(props: BaseStylesProps) {
 BaseStyles.defaultProps = {
   color: 'text.primary',
   fontFamily: 'normal',
-  lineHeight: 'default',
-  theme
+  lineHeight: 'default'
 }
 
 export default BaseStyles

--- a/src/BorderBox.tsx
+++ b/src/BorderBox.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import Box from './Box'
 import {BORDER, SystemBorderProps} from './constants'
 import sx from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const BorderBox = styled(Box)<SystemBorderProps>`
@@ -11,7 +10,6 @@ const BorderBox = styled(Box)<SystemBorderProps>`
 `
 
 BorderBox.defaultProps = {
-  theme,
   borderWidth: '1px',
   borderStyle: 'solid',
   borderColor: 'border.primary',

--- a/src/Box.tsx
+++ b/src/Box.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, FLEX, LAYOUT, SystemCommonProps, SystemFlexProps, SystemLayoutProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Box = styled.div<SystemCommonProps & SystemFlexProps & SystemLayoutProps & SxProp>`
@@ -10,8 +9,6 @@ const Box = styled.div<SystemCommonProps & SystemFlexProps & SystemLayoutProps &
   ${LAYOUT}
   ${sx};
 `
-
-Box.defaultProps = {theme}
 
 export type BoxProps = ComponentProps<typeof Box>
 export default Box

--- a/src/BranchName.tsx
+++ b/src/BranchName.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const BranchName = styled.a<SystemCommonProps & SxProp>`
@@ -15,10 +14,6 @@ const BranchName = styled.a<SystemCommonProps & SxProp>`
   ${COMMON};
   ${sx};
 `
-
-BranchName.defaultProps = {
-  theme
-}
 
 export type BranchNameProps = ComponentProps<typeof BranchName>
 export default BranchName

--- a/src/Breadcrumb.tsx
+++ b/src/Breadcrumb.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import Box from './Box'
 import {COMMON, FLEX, get, SystemCommonProps, SystemFlexProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const SELECTED_CLASS = 'selected'
@@ -79,15 +78,7 @@ const BreadcrumbItem = styled.a.attrs<StyledBreadcrumbItemProps>(props => ({
   ${sx};
 `
 
-Breadcrumb.defaultProps = {
-  theme
-}
-
 Breadcrumb.displayName = 'Breadcrumb'
-
-BreadcrumbItem.defaultProps = {
-  theme
-}
 
 BreadcrumbItem.displayName = 'Breadcrumb.Item'
 

--- a/src/Button/Button.tsx
+++ b/src/Button/Button.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components'
-import sx, {SxProp} from '../sx'
 import {get} from '../constants'
-import theme from '../theme'
-import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
+import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
+import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
 const Button = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   color: ${get('buttons.default.color.default')};
@@ -38,8 +37,6 @@ const Button = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   ${buttonSystemProps};
   ${sx};
 `
-
-Button.defaultProps = {theme}
 
 export type ButtonProps = ComponentProps<typeof Button>
 export default Button

--- a/src/Button/ButtonBase.tsx
+++ b/src/Button/ButtonBase.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {compose, fontSize, FontSizeProps, variant} from 'styled-system'
 import {COMMON, LAYOUT, SystemCommonProps, SystemLayoutProps} from '../constants'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import buttonBaseStyles from './ButtonStyles'
 
@@ -37,7 +36,6 @@ const ButtonBase = styled.button.attrs<StyledButtonBaseProps>(({disabled, onClic
 `
 
 ButtonBase.defaultProps = {
-  theme,
   variant: 'medium'
 }
 

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -27,9 +27,9 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${sx};
 `
 
-const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>(({theme, ...props}, ref) => {
+const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>(props, ref) => {
   return (
-    <StyledButton ref={ref} aria-label="Close" {...{theme, ...props}}>
+    <StyledButton ref={ref} aria-label="Close" {...props}>
       <XIcon />
     </StyledButton>
   )

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -27,7 +27,7 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${sx};
 `
 
-const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>(props, ref) => {
+const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>((props, ref) => {
   return (
     <StyledButton ref={ref} aria-label="Close" {...props}>
       <XIcon />

--- a/src/Button/ButtonClose.tsx
+++ b/src/Button/ButtonClose.tsx
@@ -3,7 +3,6 @@ import React, {forwardRef} from 'react'
 import styled from 'styled-components'
 import {COMMON, get, LAYOUT, SystemCommonProps, SystemLayoutProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import defaultTheme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 type StyledButtonProps = SystemCommonProps & SystemLayoutProps & SxProp
@@ -28,15 +27,13 @@ const StyledButton = styled.button<StyledButtonProps>`
   ${sx};
 `
 
-const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>(
-  ({theme = defaultTheme, ...props}, ref) => {
-    return (
-      <StyledButton ref={ref} aria-label="Close" {...{theme, ...props}}>
-        <XIcon />
-      </StyledButton>
-    )
-  }
-)
+const ButtonClose = forwardRef<HTMLButtonElement, ComponentProps<typeof StyledButton>>(({theme, ...props}, ref) => {
+  return (
+    <StyledButton ref={ref} aria-label="Close" {...{theme, ...props}}>
+      <XIcon />
+    </StyledButton>
+  )
+})
 
 export type ButtonCloseProps = ComponentProps<typeof ButtonClose>
 export default ButtonClose

--- a/src/Button/ButtonDanger.tsx
+++ b/src/Button/ButtonDanger.tsx
@@ -1,9 +1,8 @@
 import styled from 'styled-components'
-import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 import {get} from '../constants'
-import theme from '../theme'
 import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
+import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
 const ButtonDanger = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & SxProp>`
   color: ${get('buttons.danger.color.default')};
@@ -39,10 +38,6 @@ const ButtonDanger = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & Sx
   ${buttonSystemProps};
   ${sx};
 `
-
-ButtonDanger.defaultProps = {
-  theme
-}
 
 export type ButtonDangerProps = ComponentProps<typeof ButtonDanger>
 export default ButtonDanger

--- a/src/Button/ButtonGroup.tsx
+++ b/src/Button/ButtonGroup.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import Box from '../Box'
 import {get} from '../constants'
 import sx from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 const ButtonGroup = styled(Box)`
@@ -49,8 +48,7 @@ const ButtonGroup = styled(Box)`
 `
 
 ButtonGroup.defaultProps = {
-  display: 'inline-block',
-  theme
+  display: 'inline-block'
 }
 
 export type ButtonGroupProps = ComponentProps<typeof ButtonGroup>

--- a/src/Button/ButtonInvisible.tsx
+++ b/src/Button/ButtonInvisible.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
@@ -23,10 +22,6 @@ const ButtonInvisible = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps &
   ${buttonSystemProps};
   ${sx}
 `
-
-ButtonInvisible.defaultProps = {
-  theme
-}
 
 export type ButtonInvisibleProps = ComponentProps<typeof ButtonInvisible>
 export default ButtonInvisible

--- a/src/Button/ButtonOutline.tsx
+++ b/src/Button/ButtonOutline.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
@@ -39,10 +38,6 @@ const ButtonOutline = styled(ButtonBase)<ButtonBaseProps & ButtonSystemProps & S
   ${buttonSystemProps};
   ${sx};
 `
-
-ButtonOutline.defaultProps = {
-  theme
-}
 
 export type ButtonOutlineProps = ComponentProps<typeof ButtonOutline>
 export default ButtonOutline

--- a/src/Button/ButtonPrimary.tsx
+++ b/src/Button/ButtonPrimary.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import ButtonBase, {ButtonBaseProps, ButtonSystemProps, buttonSystemProps} from './ButtonBase'
 
@@ -37,10 +36,6 @@ export const ButtonPrimary = styled(ButtonBase)<ButtonBaseProps & ButtonSystemPr
   ${buttonSystemProps};
   ${sx};
 `
-
-ButtonPrimary.defaultProps = {
-  theme
-}
 
 export type ButtonPrimaryProps = ComponentProps<typeof ButtonPrimary>
 export default ButtonPrimary

--- a/src/Button/ButtonTableList.tsx
+++ b/src/Button/ButtonTableList.tsx
@@ -9,7 +9,6 @@ import {
   TYPOGRAPHY
 } from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 type StyledButtonTableListProps = SystemCommonProps & SystemTypographyProps & SystemLayoutProps & SxProp
@@ -54,8 +53,6 @@ const ButtonTableList = styled.summary<StyledButtonTableListProps>`
   ${LAYOUT}
   ${sx};
 `
-
-ButtonTableList.defaultProps = {theme}
 
 export type ButtonTableListProps = ComponentProps<typeof ButtonTableList>
 export default ButtonTableList

--- a/src/Caret.tsx
+++ b/src/Caret.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import {style} from 'styled-system'
-import theme from './theme'
 
 type Location =
   | 'top'
@@ -123,8 +122,7 @@ Caret.locations = [
 Caret.defaultProps = {
   bg: 'bg.canvas',
   borderColor: 'border.primary',
-  borderWidth: 1,
-  theme
+  borderWidth: 1
 }
 
 export default Caret

--- a/src/Caret.tsx
+++ b/src/Caret.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {ThemeContext} from 'styled-components'
 import {style} from 'styled-system'
 
 type Location =
@@ -55,12 +56,15 @@ export type CaretProps = {
   borderWidth?: string | number
   size?: number
   location?: Location
+  theme?: any
 }
 
 function Caret(props: CaretProps) {
-  const {bg} = getBg(props)
-  const {borderColor} = getBorderColor(props)
-  const {borderWidth} = getBorderWidth(props)
+  const theme = React.useContext(ThemeContext)
+  const propsWithTheme = {...props, theme: props.theme ?? theme}
+  const {bg} = getBg(propsWithTheme)
+  const {borderColor} = getBorderColor(propsWithTheme)
+  const {borderWidth} = getBorderWidth(propsWithTheme)
   const {size = 8, location = 'bottom'} = props
   const [edge, align] = getEdgeAlign(location)
   const perp = perpendicularEdge[edge]

--- a/src/CircleBadge.tsx
+++ b/src/CircleBadge.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import StyledOcticon from './StyledOcticon'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import isNumeric from './utils/isNumeric'
 import {ComponentProps} from './utils/types'
 
@@ -46,12 +45,7 @@ const CircleBadgeIcon = styled(StyledOcticon)`
 `
 
 CircleBadge.defaultProps = {
-  inline: false,
-  theme
-}
-
-CircleBadgeIcon.defaultProps = {
-  theme
+  inline: false
 }
 
 CircleBadgeIcon.displayName = 'CircleBadge.Icon'

--- a/src/CircleOcticon.tsx
+++ b/src/CircleOcticon.tsx
@@ -2,7 +2,6 @@ import {IconProps} from '@primer/octicons-react'
 import React from 'react'
 import BorderBox from './BorderBox'
 import Flex, {FlexProps} from './Flex'
-import theme from './theme'
 
 export type CircleOcticonProps = {
   as?: React.ElementType
@@ -23,7 +22,6 @@ function CircleOcticon(props: CircleOcticonProps) {
 }
 
 CircleOcticon.defaultProps = {
-  theme,
   ...Flex.defaultProps,
   size: 32
 }

--- a/src/CounterLabel.tsx
+++ b/src/CounterLabel.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledCounterLabelProps = {
@@ -48,10 +47,6 @@ const CounterLabel = styled.span<StyledCounterLabelProps>`
 
   ${sx};
 `
-
-CounterLabel.defaultProps = {
-  theme
-}
 
 export type CounterLabelProps = ComponentProps<typeof CounterLabel>
 export default CounterLabel

--- a/src/Details.tsx
+++ b/src/Details.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledDetailsProps = SystemCommonProps & SxProp
@@ -19,10 +18,6 @@ const Details = styled.details<StyledDetailsProps>`
 `
 
 Details.displayName = 'Details'
-
-Details.defaultProps = {
-  theme
-}
 
 export type DetailsProps = ComponentProps<typeof Details>
 export default Details

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -6,7 +6,6 @@ import Flex from './Flex'
 import useDialog from './hooks/useDialog'
 import sx, {SxProp} from './sx'
 import Text from './Text'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const noop = () => null
@@ -139,11 +138,8 @@ const Dialog = forwardRef<HTMLElement, InternalDialogProps>(
   }
 )
 
-Dialog.defaultProps = {theme}
-
 DialogHeader.defaultProps = {
-  backgroundColor: 'gray.1',
-  theme
+  backgroundColor: 'gray.1'
 }
 
 DialogHeader.displayName = 'Dialog.Header'

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -140,12 +140,12 @@ DropdownMenu.displayName = 'Dropdown.Menu'
 
 DropdownItem.displayName = 'Dropdown.Item'
 
-DropdownButton.defaultProps = {...Button.defaultProps}
+DropdownButton.defaultProps = Button.defaultProps
 DropdownButton.displayName = 'Dropdown.Button'
 
 DropdownCaret.displayName = 'Dropdown.Caret'
 
-Dropdown.defaultProps = {...Details.defaultProps}
+Dropdown.defaultProps = Details.defaultProps
 
 export type DropdownCaretProps = ComponentProps<typeof DropdownCaret>
 export type DropdownMenuProps = ComponentProps<typeof DropdownMenu>

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -6,7 +6,6 @@ import Details, {DetailsProps} from './Details'
 import getDirectionStyles from './DropdownStyles'
 import useDetails from './hooks/useDetails'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const StyledDetails = styled(Details)`
@@ -136,22 +135,17 @@ const DropdownItem = styled.li`
   ${sx};
 `
 
-DropdownMenu.defaultProps = {
-  direction: 'sw',
-  theme
-}
+DropdownMenu.defaultProps = {direction: 'sw'}
 DropdownMenu.displayName = 'Dropdown.Menu'
 
-DropdownItem.defaultProps = {theme}
 DropdownItem.displayName = 'Dropdown.Item'
 
-DropdownButton.defaultProps = {theme, ...Button.defaultProps}
+DropdownButton.defaultProps = {...Button.defaultProps}
 DropdownButton.displayName = 'Dropdown.Button'
 
-DropdownCaret.defaultProps = {theme}
 DropdownCaret.displayName = 'Dropdown.Caret'
 
-Dropdown.defaultProps = {theme, ...Details.defaultProps}
+Dropdown.defaultProps = {...Details.defaultProps}
 
 export type DropdownCaretProps = ComponentProps<typeof DropdownCaret>
 export type DropdownMenuProps = ComponentProps<typeof DropdownMenu>

--- a/src/FilterList.tsx
+++ b/src/FilterList.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const FilterListBase = styled.ul<SystemCommonProps & SxProp>`
@@ -73,13 +72,8 @@ function FilterListItem({children, count, ...rest}: React.PropsWithChildren<Filt
 }
 
 FilterList.defaultProps = {
-  theme,
   m: 0,
   p: 0
-}
-
-FilterListItem.defaultProps = {
-  theme
 }
 
 FilterListItem.displayName = 'FilterList.Item'

--- a/src/FilteredSearch.tsx
+++ b/src/FilteredSearch.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const FilteredSearch = styled.div<SystemCommonProps & SxProp>`
@@ -24,10 +23,6 @@ const FilteredSearch = styled.div<SystemCommonProps & SxProp>`
 
   ${sx}
 `
-
-FilteredSearch.defaultProps = {
-  theme
-}
 
 export type FilteredSearchProps = ComponentProps<typeof FilteredSearch>
 export default FilteredSearch

--- a/src/Flash.tsx
+++ b/src/Flash.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import {variant} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 
 const variants = variant({
   scale: 'flash'
@@ -38,7 +37,6 @@ const Flash = styled.div<
 `
 
 Flash.defaultProps = {
-  theme,
   variant: 'default'
 }
 

--- a/src/Flex.tsx
+++ b/src/Flex.tsx
@@ -1,12 +1,10 @@
 import styled from 'styled-components'
 import Box from './Box'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Flex = styled(Box)``
 
 Flex.defaultProps = {
-  theme,
   display: 'flex'
 }
 

--- a/src/FormGroup.tsx
+++ b/src/FormGroup.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const FormGroup = styled.div<SystemCommonProps & SxProp>`
@@ -10,8 +9,6 @@ const FormGroup = styled.div<SystemCommonProps & SxProp>`
   ${COMMON};
   ${sx};
 `
-
-FormGroup.defaultProps = {theme}
 
 const FormGroupLabel = styled.label<SystemTypographyProps & SystemCommonProps & SxProp>`
   display: block;
@@ -24,10 +21,6 @@ const FormGroupLabel = styled.label<SystemTypographyProps & SystemCommonProps & 
 `
 
 FormGroupLabel.displayName = 'FormGroup.Label'
-
-FormGroupLabel.defaultProps = {
-  theme
-}
 
 export type FormGroupProps = ComponentProps<typeof FormGroup>
 export type FormGroupLabelProps = ComponentProps<typeof FormGroupLabel>

--- a/src/Grid.tsx
+++ b/src/Grid.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import Box from './Box'
 import {GRID, SystemGridProps} from './constants'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Grid = styled(Box)<SystemGridProps>`
@@ -9,7 +8,6 @@ const Grid = styled(Box)<SystemGridProps>`
 `
 
 Grid.defaultProps = {
-  theme,
   display: 'grid'
 }
 

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -2,7 +2,6 @@ import * as History from 'history'
 import styled, {css} from 'styled-components'
 import {BORDER, COMMON, get, SystemBorderProps, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledHeaderItemProps = {full?: boolean} & SystemCommonProps & SxProp
@@ -77,12 +76,6 @@ const HeaderLink = styled.a.attrs<StyledHeaderLinkProps>(({to}) => {
 `
 
 HeaderLink.displayName = 'Header.Link'
-
-Header.defaultProps = {theme}
-
-HeaderItem.defaultProps = {theme}
-
-HeaderLink.defaultProps = {theme}
 
 export type HeaderProps = ComponentProps<typeof Header>
 export type HeaderLinkProps = ComponentProps<typeof HeaderLink>

--- a/src/Label.tsx
+++ b/src/Label.tsx
@@ -2,7 +2,6 @@ import styled, {css} from 'styled-components'
 import {borderColor, BorderColorProps, variant} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const outlineStyles = css`
@@ -68,7 +67,6 @@ const Label = styled.span<
 `
 
 Label.defaultProps = {
-  theme,
   bg: 'gray.5',
   variant: 'medium'
 }

--- a/src/LabelGroup.tsx
+++ b/src/LabelGroup.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const LabelGroup = styled.span<SystemCommonProps & SxProp>`
@@ -14,10 +13,6 @@ const LabelGroup = styled.span<SystemCommonProps & SxProp>`
   }
   ${sx};
 `
-
-LabelGroup.defaultProps = {
-  theme
-}
 
 export type LabelGroupProps = ComponentProps<typeof LabelGroup>
 export default LabelGroup

--- a/src/Link.tsx
+++ b/src/Link.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import {system} from 'styled-system'
 import {COMMON, get, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledLinkProps = {
@@ -54,10 +53,6 @@ const Link = styled.a<StyledLinkProps>`
   ${COMMON};
   ${sx};
 `
-
-Link.defaultProps = {
-  theme
-}
 
 export type LinkProps = ComponentProps<typeof Link>
 export default Link

--- a/src/Pagehead.tsx
+++ b/src/Pagehead.tsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Pagehead = styled.div<SystemCommonProps & SxProp>`
@@ -13,8 +12,6 @@ const Pagehead = styled.div<SystemCommonProps & SxProp>`
   ${COMMON};
   ${sx};
 `
-
-Pagehead.defaultProps = {theme}
 
 export type PageheadProps = ComponentProps<typeof Pagehead>
 export default Pagehead

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import Box from '../Box'
 import {COMMON, get} from '../constants'
 import sx from '../sx'
-import theme from '../theme'
 import {buildComponentData, buildPaginationModel} from './model'
 
 const Page = styled.a`
@@ -208,8 +207,7 @@ Pagination.defaultProps = {
   marginPageCount: 1,
   onPageChange: noop,
   showPages: true,
-  surroundingPageCount: 2,
-  theme
+  surroundingPageCount: 2
 }
 
 export default Pagination

--- a/src/Pagination/Pagination.tsx
+++ b/src/Pagination/Pagination.tsx
@@ -156,7 +156,7 @@ const PaginationContainer = styled.nav`
 `
 
 export type PaginationProps = {
-  theme: object
+  theme?: object
   pageCount: number
   currentPage: number
   onPageChange?: (e: React.MouseEvent, n: number) => void

--- a/src/PointerBox.tsx
+++ b/src/PointerBox.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {ThemeContext} from 'styled-components'
 import BorderBox, {BorderBoxProps} from './BorderBox'
 import Caret, {CaretProps} from './Caret'
 
@@ -10,10 +11,17 @@ export type PointerBoxProps = {
 } & BorderBoxProps
 
 function PointerBox(props: PointerBoxProps) {
+  const themeContext = React.useContext(ThemeContext)
   // don't destructure these, just grab them
-  const {bg, border, borderColor} = props
+  const {bg, border, borderColor, theme} = props
   const {caret, children, ...boxProps} = props
-  const caretProps = {bg, borderColor, borderWidth: border, location: caret}
+  const caretProps = {
+    bg,
+    borderColor,
+    borderWidth: border,
+    location: caret,
+    theme: theme ?? themeContext
+  }
   return (
     <BorderBox sx={{position: 'relative'}} {...boxProps}>
       {children}

--- a/src/PointerBox.tsx
+++ b/src/PointerBox.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import BorderBox, {BorderBoxProps} from './BorderBox'
 import Caret, {CaretProps} from './Caret'
-import theme from './theme'
 
 export type PointerBoxProps = {
   caret?: CaretProps['location']
@@ -22,7 +21,5 @@ function PointerBox(props: PointerBoxProps) {
     </BorderBox>
   )
 }
-
-PointerBox.defaultProps = {theme}
 
 export default PointerBox

--- a/src/PointerBox.tsx
+++ b/src/PointerBox.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {ThemeContext} from 'styled-components'
 import BorderBox, {BorderBoxProps} from './BorderBox'
 import Caret, {CaretProps} from './Caret'
 
@@ -11,7 +10,6 @@ export type PointerBoxProps = {
 } & BorderBoxProps
 
 function PointerBox(props: PointerBoxProps) {
-  const themeContext = React.useContext(ThemeContext)
   // don't destructure these, just grab them
   const {bg, border, borderColor, theme} = props
   const {caret, children, ...boxProps} = props
@@ -20,7 +18,7 @@ function PointerBox(props: PointerBoxProps) {
     borderColor,
     borderWidth: border,
     location: caret,
-    theme: theme ?? themeContext
+    theme
   }
   return (
     <BorderBox sx={{position: 'relative'}} {...boxProps}>

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import BorderBox from './BorderBox'
 import {COMMON, get, LAYOUT, POSITION, SystemCommonProps, SystemLayoutProps, SystemPositionProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type CaretPosition =
@@ -225,12 +224,7 @@ const PopoverContent = styled(BorderBox)`
 `
 
 Popover.defaultProps = {
-  caret: 'top',
-  theme
-}
-
-PopoverContent.defaultProps = {
-  theme
+  caret: 'top'
 }
 
 PopoverContent.displayName = 'Popover.Content'

--- a/src/Position.tsx
+++ b/src/Position.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import Box from './Box'
 import {POSITION, SystemPositionProps} from './constants'
 import sx from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledPositionProps = {as?: React.ElementType} & SystemPositionProps
@@ -13,8 +12,6 @@ const Position = styled(Box)<StyledPositionProps>`
   ${sx};
 `
 
-Position.defaultProps = {theme}
-
 export type PositionProps = ComponentProps<typeof Position>
 export default Position
 
@@ -23,25 +20,22 @@ export type AbsoluteProps = Omit<PositionProps, 'position'>
 export function Absolute(props: AbsoluteProps) {
   return <Position {...props} position="absolute" />
 }
-Absolute.defaultProps = Position.defaultProps
 
 // Fixed
 export type FixedProps = Omit<PositionProps, 'position'>
 export function Fixed(props: AbsoluteProps) {
   return <Position {...props} position="fixed" />
 }
-Fixed.defaultProps = Position.defaultProps
 
 // Relative
 export type RelativeProps = Omit<PositionProps, 'position'>
 export function Relative(props: RelativeProps) {
   return <Position {...props} position="relative" />
 }
-Relative.defaultProps = Position.defaultProps
 
 // Sticky
 export type StickyProps = Omit<PositionProps, 'position'>
 export function Sticky(props: StickyProps) {
   return <Position {...props} position="sticky" />
 }
-Sticky.defaultProps = {...Position.defaultProps, top: 0, zIndex: 1}
+Sticky.defaultProps = {top: 0, zIndex: 1}

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import {width, WidthProps} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Bar = styled.span<{progress?: string | number} & SystemCommonProps>`
@@ -45,11 +44,9 @@ function ProgressBar({progress, bg, theme, ...rest}: ProgressBarProps) {
   )
 }
 
-
 ProgressBar.defaultProps = {
   bg: 'state.success',
-  barSize: 'default',
-  theme
+  barSize: 'default'
 }
 
 export default ProgressBar

--- a/src/SelectMenu/SelectMenu.tsx
+++ b/src/SelectMenu/SelectMenu.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useEffect, useRef, useState} from 'react'
 import styled from 'styled-components'
 import {COMMON, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import useKeyboardNav from './hooks/useKeyboardNav'
 import {MenuContext} from './SelectMenuContext'
@@ -98,7 +97,6 @@ const SelectMenu = React.forwardRef<HTMLElement, SelectMenuInternalProps>(
 
 SelectMenu.displayName = 'SelectMenu'
 
-SelectMenu.defaultProps = {theme}
 
 export type SelectMenuProps = ComponentProps<typeof SelectMenu>
 export type { SelectMenuDividerProps } from './SelectMenuDivider'

--- a/src/SelectMenu/SelectMenuDivider.tsx
+++ b/src/SelectMenu/SelectMenuDivider.tsx
@@ -1,5 +1,4 @@
 import styled, {css} from 'styled-components'
-import theme from '../theme'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
@@ -19,8 +18,6 @@ const SelectMenuDivider = styled.div<SystemCommonProps & SxProp>`
   ${COMMON}
   ${sx};
 `
-
-SelectMenuDivider.defaultProps = {theme}
 
 SelectMenuDivider.displayName = 'SelectMenu.Divider'
 

--- a/src/SelectMenu/SelectMenuFilter.tsx
+++ b/src/SelectMenu/SelectMenuFilter.tsx
@@ -3,7 +3,6 @@ import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
 import TextInput, {TextInputProps} from '../TextInput'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import {MenuContext} from './SelectMenuContext'
 
@@ -46,9 +45,6 @@ const SelectMenuFilter = forwardRef<HTMLInputElement, SelectMenuFilterInternalPr
   }
 )
 
-SelectMenuFilter.defaultProps = {
-  theme
-}
 SelectMenuFilter.displayName = 'SelectMenu.Filter'
 
 export type SelectMenuFilterProps = ComponentProps<typeof SelectMenuFilter>

--- a/src/SelectMenu/SelectMenuFooter.tsx
+++ b/src/SelectMenu/SelectMenuFooter.tsx
@@ -1,6 +1,5 @@
 import styled, {css} from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
-import theme from '../theme'
 import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
 
@@ -22,8 +21,6 @@ const SelectMenuFooter = styled.footer<SystemCommonProps & SxProp>`
   ${COMMON}
   ${sx};
 `
-
-SelectMenuFooter.defaultProps = {theme}
 
 SelectMenuFooter.displayName = 'SelectMenu.Footer'
 

--- a/src/SelectMenu/SelectMenuHeader.tsx
+++ b/src/SelectMenu/SelectMenuHeader.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 // SelectMenu.Header is intentionally not exported, it's an internal component used in
@@ -44,8 +43,6 @@ const SelectMenuHeader = ({children, theme, ...rest}: SelectMenuHeaderProps) => 
     </StyledHeader>
   )
 }
-
-SelectMenuHeader.defaultProps = {theme}
 
 SelectMenuHeader.displayName = 'SelectMenu.Header'
 

--- a/src/SelectMenu/SelectMenuItem.tsx
+++ b/src/SelectMenu/SelectMenuItem.tsx
@@ -4,7 +4,6 @@ import styled, {css} from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import StyledOcticon from '../StyledOcticon'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import {MenuContext} from './SelectMenuContext'
 
@@ -130,7 +129,6 @@ const SelectMenuItem = forwardRef<HTMLAnchorElement, SelectMenuItemInteralProps>
 )
 
 SelectMenuItem.defaultProps = {
-  theme,
   selected: false
 }
 

--- a/src/SelectMenu/SelectMenuList.tsx
+++ b/src/SelectMenu/SelectMenuList.tsx
@@ -1,7 +1,6 @@
 import styled, {css} from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 const listStyles = css`
@@ -36,7 +35,6 @@ const SelectMenuList = styled.div<SystemCommonProps & SxProp>`
   ${COMMON}
   ${sx};
 `
-SelectMenuList.defaultProps = {theme}
 
 SelectMenuList.displayName = 'SelectMenu.List'
 

--- a/src/SelectMenu/SelectMenuModal.tsx
+++ b/src/SelectMenu/SelectMenuModal.tsx
@@ -3,7 +3,6 @@ import styled, {css, keyframes} from 'styled-components'
 import {width, WidthProps} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 
 type StyledModalProps = {
@@ -113,7 +112,6 @@ const SelectMenuModal = React.forwardRef<HTMLDivElement, SelectMenuModalInternal
 
 SelectMenuModal.defaultProps = {
   align: 'left',
-  theme,
   width: '300px'
 }
 

--- a/src/SelectMenu/SelectMenuTab.tsx
+++ b/src/SelectMenu/SelectMenuTab.tsx
@@ -3,7 +3,6 @@ import React, {useContext, useEffect} from 'react'
 import styled, {css} from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import {MenuContext} from './SelectMenuContext'
 
@@ -83,10 +82,6 @@ const SelectMenuTab = ({tabName = '', index, className, onClick, ...rest}: Selec
       {tabName}
     </StyledTab>
   )
-}
-
-SelectMenuTab.defaultProps = {
-  theme
 }
 
 SelectMenuTab.displayName = 'SelectMenu.Tab'

--- a/src/SelectMenu/SelectMenuTabPanel.tsx
+++ b/src/SelectMenu/SelectMenuTabPanel.tsx
@@ -2,7 +2,6 @@ import React, {useContext} from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
 import sx, {SxProp} from '../sx'
-import theme from '../theme'
 import {ComponentProps} from '../utils/types'
 import {MenuContext} from './SelectMenuContext'
 import SelectMenuList from './SelectMenuList'
@@ -24,10 +23,6 @@ const TabPanel = ({tabName, className, children, ...rest}: SelectMenuTabPanelPro
       <SelectMenuList>{children}</SelectMenuList>
     </TabPanelBase>
   )
-}
-
-TabPanel.defaultProps = {
-  theme
 }
 
 TabPanel.displayName = 'SelectMenu.TabPanel'

--- a/src/SelectMenu/SelectMenuTabs.tsx
+++ b/src/SelectMenu/SelectMenuTabs.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import styled, {css} from 'styled-components'
 import {COMMON, get, SystemCommonProps} from '../constants'
-import theme from '../theme'
 import sx, {SxProp} from '../sx'
 import {ComponentProps} from '../utils/types'
 
@@ -39,8 +38,6 @@ const SelectMenuTabs = ({children, ...rest}: SelectMenuTabsProps) => {
     </SelectMenuTabsBase>
   )
 }
-
-SelectMenuTabs.defaultProps = {theme}
 
 SelectMenuTabs.displayName = 'SelectMenu.Tabs'
 

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -6,7 +6,6 @@ import BorderBox from './BorderBox'
 import {COMMON, get} from './constants'
 import Link from './Link'
 import sx from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type SideNavBaseProps = {
@@ -153,12 +152,10 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
 `
 
 SideNav.defaultProps = {
-  theme,
   variant: 'normal'
 }
 
 SideNavLink.defaultProps = {
-  theme,
   variant: 'normal'
 }
 

--- a/src/StateLabel.tsx
+++ b/src/StateLabel.tsx
@@ -5,7 +5,6 @@ import {variant} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from './constants'
 import StyledOcticon from './StyledOcticon'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const octiconMap = {
@@ -60,7 +59,6 @@ function StateLabel({children, status, variant, ...rest}: StateLabelProps) {
 }
 
 StateLabel.defaultProps = {
-  theme,
   variant: 'normal'
 }
 

--- a/src/StyledOcticon.tsx
+++ b/src/StyledOcticon.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type OcticonProps = {icon: React.ElementType} & IconProps
@@ -18,7 +17,6 @@ const StyledOcticon = styled(Octicon)<SystemCommonProps & SxProp>`
 `
 
 StyledOcticon.defaultProps = {
-  theme,
   size: 16
 }
 

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import {COMMON, FLEX, get, SystemBorderProps, SystemCommonProps, SystemFlexProps} from './constants'
 import Flex, {FlexProps} from './Flex'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const ITEM_CLASS = 'SubNav-item'
@@ -120,10 +119,6 @@ const SubNavLink = styled.a.attrs<StyledSubNavLinkProps>(props => ({
   ${COMMON};
   ${sx};
 `
-
-SubNav.defaultProps = {theme}
-
-SubNavLink.defaultProps = {theme}
 
 SubNavLink.displayName = 'SubNav.Link'
 

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps, SystemTypographyProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const ITEM_CLASS = 'TabNav-item'
@@ -70,10 +69,6 @@ const TabNavLink = styled.a.attrs<StyledTabNavLinkProps>(props => ({
   ${COMMON};
   ${sx};
 `
-
-TabNav.defaultProps = {theme}
-
-TabNavLink.defaultProps = {theme}
 
 TabNavLink.displayName = 'TabNav.Link'
 

--- a/src/Text.tsx
+++ b/src/Text.tsx
@@ -1,17 +1,12 @@
 import styled from 'styled-components'
 import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 
 const Text = styled.span<SystemTypographyProps & SystemCommonProps & SxProp>`
   ${TYPOGRAPHY};
   ${COMMON};
   ${sx};
 `
-
-Text.defaultProps = {
-  theme
-}
 
 export type TextProps = React.ComponentProps<typeof Text>
 export default Text

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -5,7 +5,6 @@ import styled, {css} from 'styled-components'
 import {maxWidth, MaxWidthProps, minWidth, MinWidthProps, variant, width, WidthProps} from 'styled-system'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const sizeVariants = variant({
@@ -128,7 +127,7 @@ type TextInputInternalProps = {icon?: React.ComponentType<{className?: string}>}
 
 // using forwardRef is important so that other components (ex. SelectMenu) can autofocus the input
 const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
-  ({icon: IconComponent, contrast, className, block, disabled, sx, ...rest}, ref) => {
+  ({icon: IconComponent, contrast, className, block, disabled, theme, sx, ...rest}, ref) => {
     // this class is necessary to style FilterSearch, plz no touchy!
     const wrapperClasses = classnames(className, 'TextInput-wrapper')
     const wrapperProps = pick(rest)
@@ -152,7 +151,6 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
 )
 
 TextInput.defaultProps = {
-  theme,
   type: 'text'
 }
 

--- a/src/Timeline.tsx
+++ b/src/Timeline.tsx
@@ -6,7 +6,6 @@ import {COMMON, get} from './constants'
 import Flex, {FlexProps} from './Flex'
 import {Relative} from './Position'
 import sx from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const Timeline = styled(Flex)<{clipSidebar?: boolean}>`
@@ -120,18 +119,12 @@ const TimelineBreak = styled(Relative)`
   ${sx};
 `
 
-Timeline.defaultProps = {theme}
-
-TimelineItem.defaultProps = {theme}
 TimelineItem.displayName = 'Timeline.Item'
 
-TimelineBadge.defaultProps = {theme}
 TimelineBadge.displayName = 'Timeline.Badge'
 
-TimelineBody.defaultProps = {theme}
 TimelineBody.displayName = 'Timeline.Body'
 
-TimelineBreak.defaultProps = {theme}
 TimelineBreak.displayName = 'Timeline.Break'
 
 export type TimelineProps = ComponentProps<typeof Timeline>

--- a/src/Tooltip.tsx
+++ b/src/Tooltip.tsx
@@ -3,7 +3,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const TooltipBase = styled.span<SystemCommonProps & SxProp>`
@@ -256,10 +255,9 @@ function Tooltip({direction = 'n', children, className, text, noDelay, align, wr
     </TooltipBase>
   )
 }
+
 Tooltip.alignments = ['left', 'right']
 
 Tooltip.directions = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw']
-
-Tooltip.defaultProps = {theme}
 
 export default Tooltip

--- a/src/Truncate.tsx
+++ b/src/Truncate.tsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import {maxWidth, MaxWidthProps} from 'styled-system'
 import {COMMON, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 type StyledTruncateProps = {
@@ -30,8 +29,7 @@ const Truncate = styled.div<StyledTruncateProps>`
 Truncate.defaultProps = {
   expandable: false,
   inline: false,
-  maxWidth: 125,
-  theme
+  maxWidth: 125
 }
 
 export type TruncateProps = ComponentProps<typeof Truncate>

--- a/src/UnderlineNav.tsx
+++ b/src/UnderlineNav.tsx
@@ -4,7 +4,6 @@ import React from 'react'
 import styled from 'styled-components'
 import {COMMON, get, SystemCommonProps} from './constants'
 import sx, {SxProp} from './sx'
-import theme from './theme'
 import {ComponentProps} from './utils/types'
 
 const ITEM_CLASS = 'UnderlineNav-item'
@@ -103,10 +102,6 @@ const UnderlineNavLink = styled.a.attrs<StyledUnderlineNavLinkProps>(props => ({
   ${COMMON};
   ${sx};
 `
-
-UnderlineNav.defaultProps = {theme}
-
-UnderlineNavLink.defaultProps = {theme}
 
 UnderlineNavLink.displayName = 'UnderlineNav.Link'
 

--- a/src/__tests__/Caret.tsx
+++ b/src/__tests__/Caret.tsx
@@ -25,13 +25,13 @@ describe('Caret', () => {
 
   it('renders cardinal directions', () => {
     for (const location of ['top', 'right', 'bottom', 'left']) {
-      expect(render(<Caret location={location as CaretProps['location']} theme={theme} />)).toMatchSnapshot()
+      expect(render(<Caret location={location as CaretProps['location']} />)).toMatchSnapshot()
     }
     for (const location of ['top-left', 'top-right', 'bottom-left', 'bottom-right']) {
-      expect(render(<Caret location={location as CaretProps['location']} theme={theme} />)).toMatchSnapshot()
+      expect(render(<Caret location={location as CaretProps['location']} />)).toMatchSnapshot()
     }
     for (const location of ['left-top', 'left-bottom', 'right-top', 'right-bottom']) {
-      expect(render(<Caret location={location as CaretProps['location']} theme={theme} />)).toMatchSnapshot()
+      expect(render(<Caret location={location as CaretProps['location']} />)).toMatchSnapshot()
     }
   })
 })

--- a/src/__tests__/Position.tsx
+++ b/src/__tests__/Position.tsx
@@ -30,10 +30,6 @@ describe('position components', () => {
       expect(render(<Absolute />)).toHaveStyleRule('position', 'absolute')
     })
 
-    it('cannot override position', () => {
-      expect(render(<Absolute position="relative" />)).toHaveStyleRule('position', 'absolute')
-    })
-
     it('can render other components with the as prop', () => {
       const result = render(<Absolute as={BorderBox} />)
       expect(result).toHaveStyleRule('position', 'absolute')
@@ -60,10 +56,6 @@ describe('position components', () => {
       expect(render(<Fixed />)).toHaveStyleRule('position', 'fixed')
     })
 
-    it('cannot override position', () => {
-      expect(render(<Fixed position="relative" />)).toHaveStyleRule('position', 'fixed')
-    })
-
     it('can render other components with the as prop', () => {
       const result = render(<Fixed as={BorderBox} />)
       expect(result).toHaveStyleRule('position', 'fixed')
@@ -86,10 +78,6 @@ describe('position components', () => {
       expect(render(<Relative />)).toHaveStyleRule('position', 'relative')
     })
 
-    it('cannot override position', () => {
-      expect(render(<Relative position="absolute" />)).toHaveStyleRule('position', 'relative')
-    })
-
     it('can render other components with the as prop', () => {
       const result = render(<Relative as={BorderBox} />)
       expect(result).toHaveStyleRule('position', 'relative')
@@ -110,10 +98,6 @@ describe('position components', () => {
 
     it('sets position: sticky', () => {
       expect(render(<Sticky />)).toHaveStyleRule('position', 'sticky')
-    })
-
-    it('cannot override position', () => {
-      expect(render(<Sticky position="absolute" />)).toHaveStyleRule('position', 'sticky')
     })
 
     it('can render other components with the as prop', () => {

--- a/src/__tests__/SelectMenu.tsx
+++ b/src/__tests__/SelectMenu.tsx
@@ -98,10 +98,6 @@ describe('SelectMenu', () => {
     expect(SelectMenu).toImplementSystemProps(COMMON)
   })
 
-  it('has default theme', () => {
-    expect(SelectMenu).toSetDefaultTheme()
-  })
-
   it('does not allow the "as" prop on SelectMenu', () => {
     const component = mount(<BasicSelectMenu as="span" />)
     expect(component.find('details').length).toEqual(1)

--- a/src/__tests__/__snapshots__/Popover.tsx.snap
+++ b/src/__tests__/__snapshots__/Popover.tsx.snap
@@ -615,6 +615,161 @@ exports[`Popover renders correctly for a caret position of bottom 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--bottom"
   open={true}
@@ -821,6 +976,161 @@ exports[`Popover renders correctly for a caret position of bottom-left 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 
@@ -1033,6 +1343,161 @@ exports[`Popover renders correctly for a caret position of bottom-right 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--bottom-right"
   open={true}
@@ -1239,6 +1704,161 @@ exports[`Popover renders correctly for a caret position of left 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 
@@ -1451,6 +2071,161 @@ exports[`Popover renders correctly for a caret position of left-bottom 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--left-bottom"
   open={true}
@@ -1657,6 +2432,161 @@ exports[`Popover renders correctly for a caret position of left-top 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 
@@ -1869,6 +2799,161 @@ exports[`Popover renders correctly for a caret position of right 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--right"
   open={true}
@@ -2075,6 +3160,161 @@ exports[`Popover renders correctly for a caret position of right-bottom 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 
@@ -2287,6 +3527,161 @@ exports[`Popover renders correctly for a caret position of right-top 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--right-top"
   open={true}
@@ -2493,6 +3888,161 @@ exports[`Popover renders correctly for a caret position of top 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 
@@ -2705,6 +4255,161 @@ exports[`Popover renders correctly for a caret position of top-left 1`] = `
   bottom: calc(16px + 1px);
 }
 
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  bottom: calc(16px + 1px);
+}
+
 <div
   className="c0 c1 caret-pos--top-left"
   open={true}
@@ -2911,6 +4616,161 @@ exports[`Popover renders correctly for a caret position of top-right 1`] = `
 
 .c0.caret-pos--right-bottom .c2::after,
 .c0.caret-pos--left-bottom .c2::after {
+  bottom: calc(16px + 1px);
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  top: auto;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--bottom .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--bottom-left .c3::before {
+  bottom: -16px;
+  border-top-color: #e1e4e8;
+}
+
+.c0.caret-pos--bottom .c3::after,
+.c0.caret-pos--bottom-right .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  bottom: -14px;
+  border-top-color: #ffffff;
+}
+
+.c0.caret-pos--top-right .c3,
+.c0.caret-pos--bottom-right .c3 {
+  right: -9px;
+  margin-right: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before,
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  left: auto;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-right .c3::before,
+.c0.caret-pos--bottom-right .c3::before {
+  right: 20px;
+}
+
+.c0.caret-pos--top-right .c3::after,
+.c0.caret-pos--bottom-right .c3::after {
+  right: 21px;
+}
+
+.c0.caret-pos--top-left .c3,
+.c0.caret-pos--bottom-left .c3 {
+  left: -9px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::before,
+.c0.caret-pos--bottom-left .c3::before,
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: 24px;
+  margin-left: 0;
+}
+
+.c0.caret-pos--top-left .c3::after,
+.c0.caret-pos--bottom-left .c3::after {
+  left: calc(24px + 1px);
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: 50%;
+  left: auto;
+  margin-left: 0;
+  border-bottom-color: transparent;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  margin-top: calc((8px + 1px) * -1);
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  margin-top: -8px;
+}
+
+.c0.caret-pos--right .c3::before,
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--right-bottom .c3::before {
+  right: -16px;
+  border-left-color: #e1e4e8;
+}
+
+.c0.caret-pos--right .c3::after,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--right-bottom .c3::after {
+  right: -14px;
+  border-left-color: #ffffff;
+}
+
+.c0.caret-pos--left .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  left: -16px;
+  border-right-color: #e1e4e8;
+}
+
+.c0.caret-pos--left .c3::after,
+.c0.caret-pos--left-top .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  left: -14px;
+  border-right-color: #ffffff;
+}
+
+.c0.caret-pos--right-top .c3::before,
+.c0.caret-pos--left-top .c3::before,
+.c0.caret-pos--right-top .c3::after,
+.c0.caret-pos--left-top .c3::after {
+  top: 24px;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before,
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
+  top: auto;
+}
+
+.c0.caret-pos--right-bottom .c3::before,
+.c0.caret-pos--left-bottom .c3::before {
+  bottom: 16px;
+}
+
+.c0.caret-pos--right-bottom .c3::after,
+.c0.caret-pos--left-bottom .c3::after {
   bottom: calc(16px + 1px);
 }
 

--- a/src/utils/test-matchers.tsx
+++ b/src/utils/test-matchers.tsx
@@ -1,10 +1,9 @@
-import React from 'react'
+import {Nullish} from '@testing-library/react'
 import 'jest-styled-components'
 import {styleSheetSerializer} from 'jest-styled-components/serializer'
-import theme from '../theme'
+import React from 'react'
 import {ReactTestRendererJSON, ReactTestRendererNode} from 'react-test-renderer'
-import {getClasses, mount, getComputedStyles, render} from './testing'
-import {Nullish} from '@testing-library/react'
+import {getClasses, getComputedStyles, render} from './testing'
 
 expect.addSnapshotSerializer(styleSheetSerializer)
 
@@ -89,21 +88,6 @@ expect.extend({
     return {
       pass: checkStylesDeep(rendered),
       message: () => 'sx prop values did not change styles of component nor of any sub-components'
-    }
-  },
-
-  toSetDefaultTheme(Component) {
-    let comp
-    if (Component.type) {
-      comp = Component
-    } else {
-      comp = <Component />
-    }
-    const wrapper = mount(comp)
-    const pass = this.equals(wrapper.prop('theme'), theme)
-    return {
-      pass,
-      message: () => 'default theme is not set'
     }
   },
 

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -38,8 +38,10 @@ declare global {
  * expect(render(<Foo />)).toEqual(render(<div foo='bar' />))
  * ```
  */
-export function render(component: React.ReactElement) {
-  return renderer.create(component).toJSON() as renderer.ReactTestRendererJSON
+export function render(component: React.ReactElement, theme = defaultTheme) {
+  return renderer
+    .create(<ThemeProvider theme={theme}>{component}</ThemeProvider>)
+    .toJSON() as renderer.ReactTestRendererJSON
 }
 
 /**
@@ -72,10 +74,6 @@ export function renderClasses(component: React.ReactElement): string {
  */
 export function rendersClass(node: React.ReactElement, klass: string): boolean {
   return renderClasses(node).includes(klass)
-}
-
-export function renderWithTheme(node: React.ReactElement, theme = defaultTheme): renderer.ReactTestRendererJSON {
-  return render(<ThemeProvider theme={theme}>{node}</ThemeProvider>)
 }
 
 export function px(value: number | string): string {

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -24,7 +24,6 @@ declare global {
       toImplementSystemProps: (systemProps: any) => boolean
       toImplementSxProp: () => boolean
       toImplementSxBehavior: () => boolean
-      toSetDefaultTheme: () => boolean
       toSetExports: (exports: Record<string, string>) => boolean
     }
   }
@@ -237,10 +236,6 @@ export function behavesAsComponent({Component, systemPropArray, toRender, option
 
   it('sets a valid displayName', () => {
     expect(Component.displayName).toMatch(COMPONENT_DISPLAY_NAME_REGEX)
-  })
-
-  it('sets the default theme', () => {
-    expect(getElement()).toSetDefaultTheme()
   })
 
   it('renders consistently', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13648,10 +13648,10 @@ style-to-object@0.3.0, style-to-object@^0.3.0:
   dependencies:
     inline-style-parser "0.1.1"
 
-styled-components@4.4.0:
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.0.tgz#4e381e2dab831d0e6ea431c2840a96323e84e21b"
-  integrity sha512-xQ6vTI/0zNjZ1BBDRxyjvBddrxhQ3DxjeCdaLM1lSn5FDnkTOQgRkmWvcUiTajqc5nJqKVl+7sUioMqktD0+Zw==
+styled-components@4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
+  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
     "@babel/traverse" "^7.0.0"


### PR DESCRIPTION
## Problem

We currently set the default `theme` prop of every component to our Primer theme. We did this to allow consumers to use components in their app without needing to wrap everything in a ThemeProvider. However, setting the default `theme` prop of components can sometimes override the theme provided by the `ThemeProvider` and cause unexpected theming issues which will prevent us from implementing color modes. 

## Solution

This PR removes the default `theme` prop from every component.

Consumers will now need to wrap their app in a `ThemeProvider` component and use the Primer theme:

```jsx
import {ThemeProvider} from 'styled-components'
import {theme} from '@primer/components'
const App = props => {
  return (
    <div>
      <ThemeProvider theme={theme}>
        <div>your app here</div>
      </ThemeProvider>
    </div>
  )
}
```

## TODO
- [x] Remove default `theme` prop from every component
- [x] Update tests
- [x] Update docs
- [x] Add changeset
- [x] Write PR description