### PR TITLE
Remove unnecessary as="summary" prop in SelectMenu

### DIFF
--- a/docs/content/SelectMenu.md
+++ b/docs/content/SelectMenu.md
@@ -61,7 +61,7 @@ import React, {useContext} from 'react'
 
 const MyMenu = () => {
   <SelectMenu>
-    <MyButton as="summary" />
+    <MyButton />
     <SelectMenu.Modal>
       content
     </SelectMenu.Modal>


### PR DESCRIPTION
The documentation for the SelectMenu with context provides `as="summary"` as a prop to a custom component which does nothing with it (and for those using TypeScript, it results in an error).

The code for `MyButton` already includes `as="summary"` (line 76), so I think this might've been accidental duplication.

### Screenshots
N/A, this just affects the documentation

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
