### PR TITLE
Pass aria-label down to correct element

### DIFF
--- a/.changeset/spicy-garlics-worry.md
+++ b/.changeset/spicy-garlics-worry.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Forwards aria-label to correct component

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -25,10 +25,10 @@ const TabNavBody = styled.nav`
 
 export type TabNavProps = ComponentProps<typeof TabNavBase>
 
-function TabNav({children, ...rest}: TabNavProps) {
+function TabNav({children, "aria-label": ariaLabel, ...rest}: TabNavProps) {
   return (
     <TabNavBase {...rest}>
-      <TabNavBody>{children}</TabNavBody>
+      <TabNavBody aria-label={ariaLabel}>{children}</TabNavBody>
     </TabNavBase>
   )
 }

--- a/src/__tests__/TabNav.tsx
+++ b/src/__tests__/TabNav.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {TabNav} from '..'
-import {mount, render, rendersClass, behavesAsComponent, checkExports} from '../utils/testing'
+import {render, behavesAsComponent, checkExports} from '../utils/testing'
 import {COMMON} from '../constants'
 import {render as HTMLRender, cleanup} from '@testing-library/react'
 import {axe, toHaveNoViolations} from 'jest-axe'
@@ -19,13 +19,15 @@ describe('TabNav', () => {
   })
 
   it('should have no axe violations', async () => {
-    const {container} = HTMLRender(<TabNav />)
+    const {container} = HTMLRender(<TabNav aria-label="main" />)
     const results = await axe(container)
     expect(results).toHaveNoViolations()
     cleanup()
   })
 
   it('sets aria-label appropriately', () => {
-    expect(render(<TabNav aria-label="foo" />).props['aria-label']).toEqual('foo')
+    const {getByLabelText} = HTMLRender(<TabNav aria-label="stuff"/>)
+    expect(getByLabelText("stuff")).toBeTruthy();
+    expect(getByLabelText("stuff").tagName).toEqual("NAV")
   })
 })


### PR DESCRIPTION
This PR patches a bug introduced in my last TabNav PR. I refactored the components so that the `nav` component is the inner component (as it should be & to match implementation in .com), but I forgot to forward `aria-label` down to the `nav` which was throwing axe errors in Memex.

This PR fixes that and updates the tests to be more specific, making sure the aria-label gets applied to the `nav` and not the wrapping element ☮️ 


### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
