### PR TITLE
Update docs to use functional color variables

### DIFF
--- a/.changeset/fair-feet-know.md
+++ b/.changeset/fair-feet-know.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Update color variable used in ProgressBar (`state.success` → `bg.successInverse`)

--- a/docs/content/BorderBox.md
+++ b/docs/content/BorderBox.md
@@ -2,7 +2,6 @@
 title: BorderBox
 ---
 
-
 BorderBox is a Box component with a border. When no `borderColor` is present, the component defaults to a gray border.
 
 ## Default example
@@ -19,10 +18,10 @@ BorderBox components get `COMMON`, `LAYOUT`, `BORDER`, and `FLEX` system props. 
 
 ## Component props
 
-| Prop name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| borderWidth | String | '1px' | Sets the border, use theme values or provide your own. |
-| borderStyle | String | 'solid' | Sets the border style, use theme values or provide your own. |
-| borderColor | String | 'gray.2' (from theme) | Sets the border color, use theme values or provide your own. |
-| borderRadius | String or Number| 2 (from theme)| Sets the border radius, use theme values or provide your own. |
-| boxShadow | String | | Sets box shadow, use theme values or provide your own. |
+| Prop name    | Type             |            Default            | Description                                                   |
+| :----------- | :--------------- | :---------------------------: | :------------------------------------------------------------ |
+| borderWidth  | String           |             '1px'             | Sets the border, use theme values or provide your own.        |
+| borderStyle  | String           |            'solid'            | Sets the border style, use theme values or provide your own.  |
+| borderColor  | String           | 'border.primary' (from theme) | Sets the border color, use theme values or provide your own.  |
+| borderRadius | String or Number |        2 (from theme)         | Sets the border radius, use theme values or provide your own. |
+| boxShadow    | String           |                               | Sets box shadow, use theme values or provide your own.        |

--- a/docs/content/BorderBox.md
+++ b/docs/content/BorderBox.md
@@ -2,7 +2,7 @@
 title: BorderBox
 ---
 
-BorderBox is a Box component with a border. When no `borderColor` is present, the component defaults to a gray border.
+BorderBox is a Box component with a border. When no `borderColor` is present, the component defaults to a primary border.
 
 ## Default example
 

--- a/docs/content/Box.md
+++ b/docs/content/Box.md
@@ -9,15 +9,17 @@ The Box component serves as a wrapper component for most layout related needs. U
 ```jsx live live
 <Box>
   Box can be used to create both{' '}
-  <Box as="span" bg="bg.success">
+  <Box as="span" color="text.inverse" bg="bg.successInverse">
     inline
   </Box>{' '}
   and
-  <Box bg="bg.danger">block-level elements,</Box>
-  <Box bg="bg.warning" width={[1, 1, 1 / 2]}>
+  <Box color="text.inverse" bg="bg.dangerInverse">
+    block-level elements,
+  </Box>
+  <Box color="text.inverse" bg="bg.warningInverse" width={[1, 1, 1 / 2]}>
     elements with fixed or responsive width and height,
   </Box>
-  <Box bg="bg.info" p={4} mt={2}>
+  <Box color="text.inverse" bg="bg.infoInverse" p={4} mt={2}>
     and more!
   </Box>
 </Box>

--- a/docs/content/Box.md
+++ b/docs/content/Box.md
@@ -2,17 +2,24 @@
 title: Box
 ---
 
-
-The Box component serves as a wrapper component for most layout related needs. Use Box to set values such as `display`,  `width`, `height`, and more. See the LAYOUT section of our [System Props](/system-props) documentation for the full list of available props. In practice, this component is used frequently as a wrapper around other components to achieve Box Model related styling.
+The Box component serves as a wrapper component for most layout related needs. Use Box to set values such as `display`, `width`, `height`, and more. See the LAYOUT section of our [System Props](/system-props) documentation for the full list of available props. In practice, this component is used frequently as a wrapper around other components to achieve Box Model related styling.
 
 ## Default example
 
 ```jsx live live
 <Box>
- Box can be used to create both <Box as="span" bg="green.1">inline</Box> and
- <Box bg="blue.1">block-level elements,</Box>
- <Box bg="purple.1" width={[1, 1, 1/2]}>elements with fixed or responsive width and height,</Box>
- <Box bg="yellow.0" p={4} mt={2}>and more!</Box>
+  Box can be used to create both{' '}
+  <Box as="span" bg="bg.success">
+    inline
+  </Box>{' '}
+  and
+  <Box bg="bg.danger">block-level elements,</Box>
+  <Box bg="bg.warning" width={[1, 1, 1 / 2]}>
+    elements with fixed or responsive width and height,
+  </Box>
+  <Box bg="bg.info" p={4} mt={2}>
+    and more!
+  </Box>
 </Box>
 ```
 
@@ -22,6 +29,6 @@ Box components get the `COMMON`, `LAYOUT`, and `FLEX` categories of system props
 
 ## Component props
 
-| Prop name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| as | String | `div` | sets the HTML tag for the component|
+| Prop name | Type   | Default | Description                         |
+| :-------- | :----- | :-----: | :---------------------------------- |
+| as        | String |  `div`  | sets the HTML tag for the component |

--- a/docs/content/BranchName.md
+++ b/docs/content/BranchName.md
@@ -2,8 +2,7 @@
 title: BranchName
 ---
 
-
-BranchName is a label-type component rendered as an `<a>` tag by default with monospace font and blue background.
+BranchName is a label-type component rendered as an `<a>` tag by default with monospace font.
 
 ## Default example
 
@@ -17,7 +16,7 @@ BranchName components get `COMMON` system props. Read our [System Props](/system
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| as | String | `<a>` | sets the HTML tag for the component |
-| href | String | | a URL to link the component to |
+| Name | Type   | Default | Description                         |
+| :--- | :----- | :-----: | :---------------------------------- |
+| as   | String |  `<a>`  | sets the HTML tag for the component |
+| href | String |         | a URL to link the component to      |

--- a/docs/content/CircleOcticon.md
+++ b/docs/content/CircleOcticon.md
@@ -2,13 +2,12 @@
 title: CircleOcticon
 ---
 
-
 CircleOcticon renders any Octicon with a circle background. CircleOcticons are most commonly used to represent the status of a pull request in the comment timeline.
 
 ## Default example
 
 ```jsx live
-  <CircleOcticon icon={CheckIcon} size={32} bg="green.5" color="white"/>
+<CircleOcticon icon={CheckIcon} size={32} bg="icon.success" color="text.inverse" />
 ```
 
 ## System props
@@ -17,7 +16,7 @@ CircleOcticon components get `COMMON` system props. Read our [System Props](/sys
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| icon | Octicon | | Octicon component used in the component |
-| size | Number | 32 | used to set the width and height of the component |
+| Name | Type    | Default | Description                                       |
+| :--- | :------ | :-----: | :------------------------------------------------ |
+| icon | Octicon |         | Octicon component used in the component           |
+| size | Number  |   32    | used to set the width and height of the component |

--- a/docs/content/Flex.md
+++ b/docs/content/Flex.md
@@ -4,20 +4,20 @@ title: Flex
 
 The `Flex` component behaves the same as the `Box` component except that it has `display: flex` set by default.
 
-*Previously, a `Flex.Item` component was used for flex item specific properties; `Box` now contains all those properties and should be used in its place.*
+_Previously, a `Flex.Item` component was used for flex item specific properties; `Box` now contains all those properties and should be used in its place._
 
 ## Default example
 
 ```jsx live
 <BorderBox width={300} height={300} borderRadius={0}>
   <Flex flexWrap="nowrap">
-    <Box p={3} bg="blue.5">
+    <Box p={3} bg="bg.info">
       Item 1
     </Box>
-    <Box p={3} bg="green.5">
+    <Box p={3} bg="bg.warning">
       Item 2
     </Box>
-    <Box p={3} bg="yellow.5">
+    <Box p={3} bg="bg.danger">
       Item 3
     </Box>
   </Flex>

--- a/docs/content/Flex.md
+++ b/docs/content/Flex.md
@@ -11,13 +11,13 @@ _Previously, a `Flex.Item` component was used for flex item specific properties;
 ```jsx live
 <BorderBox width={300} height={300} borderRadius={0}>
   <Flex flexWrap="nowrap">
-    <Box p={3} bg="bg.info">
+    <Box p={3} color="text.inverse" bg="bg.infoInverse">
       Item 1
     </Box>
-    <Box p={3} bg="bg.warning">
+    <Box p={3} color="text.inverse" bg="bg.warningInverse">
       Item 2
     </Box>
-    <Box p={3} bg="bg.danger">
+    <Box p={3} color="text.inverse" bg="bg.dangerInverse">
       Item 3
     </Box>
   </Flex>

--- a/docs/content/Grid.md
+++ b/docs/content/Grid.md
@@ -8,8 +8,12 @@ Grid is a component that exposes grid system props. See the [CSS Tricks Complete
 
 ```jsx live
 <Grid gridTemplateColumns="repeat(2, auto)" gridGap={3}>
-    <Box p={3} bg="blue.2">1</Box>
-    <Box p={3} bg="yellow.2">2</Box>
+  <Box p={3} bg="bg.info">
+    1
+  </Box>
+  <Box p={3} bg="bg.warning">
+    2
+  </Box>
 </Grid>
 ```
 

--- a/docs/content/Grid.md
+++ b/docs/content/Grid.md
@@ -8,10 +8,10 @@ Grid is a component that exposes grid system props. See the [CSS Tricks Complete
 
 ```jsx live
 <Grid gridTemplateColumns="repeat(2, auto)" gridGap={3}>
-  <Box p={3} bg="bg.info">
+  <Box p={3} color="text.inverse" bg="bg.infoInverse">
     1
   </Box>
-  <Box p={3} bg="bg.warning">
+  <Box p={3} color="text.inverse" bg="bg.warningInverse">
     2
   </Box>
 </Grid>

--- a/docs/content/Label.md
+++ b/docs/content/Label.md
@@ -7,11 +7,11 @@ The Label component is used to add contextual metadata to a design. Visually it 
 ## Default example
 
 ```jsx live
-  <Label variant="small" outline borderColor="red.2" mr={2} color="red.4">small</Label>
+  <Label variant="small" outline borderColor="border.danger" mr={2} color="text.danger">small</Label>
   <Label variant="medium" mr={2}>medium (default)</Label>
   <Label variant="large" mr={2}>large</Label>
   <Label variant="xl">xl label</Label>
-  
+
   <Box mt={4}/>
   <Label variant="medium" bg="#A575FF" m={1}>good first issue</Label>
   <Label variant="medium" bg="#FF75C8" m={1}>🚂 deploy: train</Label>
@@ -26,9 +26,9 @@ Label components get `COMMON` system props. Read our [System Props](/system-prop
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| outline | Boolean | | Creates an outline style label |
-| variant | String | 'medium' | Can be one of `small`, `medium` (default), `large` or `xl` .
-| dropshadow | Boolean | | Adds a dropshadow to the label |
-| bg | String | 'gray.5' | Part of the `COMMON` system props, used to change the background of the label.
+| Name       | Type    |        Default         | Description                                                                    |
+| :--------- | :------ | :--------------------: | :----------------------------------------------------------------------------- |
+| outline    | Boolean |                        | Creates an outline style label                                                 |
+| variant    | String  |        'medium'        | Can be one of `small`, `medium` (default), `large` or `xl` .                   |
+| dropshadow | Boolean |                        | Adds a dropshadow to the label                                                 |
+| bg         | String  | 'label.primary.border' | Part of the `COMMON` system props, used to change the background of the label. |

--- a/docs/content/LabelGroup.md
+++ b/docs/content/LabelGroup.md
@@ -9,7 +9,7 @@ The LabelGroup component is used to add commonly used margins and wrapping for g
 ```jsx live
 <LabelGroup>
   <Label>Default label</Label>
-  <Label bg="prState.closed.bg">Label with background indicating a closed PR state</Label>
+  <Label color="prState.closed.text" bg="prState.closed.bg">Label with background indicating a closed PR state</Label>
   <Label outline>Default outline label</Label>
 </LabelGroup>
 ```

--- a/docs/content/LabelGroup.md
+++ b/docs/content/LabelGroup.md
@@ -9,7 +9,7 @@ The LabelGroup component is used to add commonly used margins and wrapping for g
 ```jsx live
 <LabelGroup>
   <Label>Default label</Label>
-  <Label bg='red.4'>Label with red background</Label>
+  <Label bg="prState.closed.bg">Label with red background</Label>
   <Label outline>Default outline label</Label>
 </LabelGroup>
 ```

--- a/docs/content/LabelGroup.md
+++ b/docs/content/LabelGroup.md
@@ -9,7 +9,7 @@ The LabelGroup component is used to add commonly used margins and wrapping for g
 ```jsx live
 <LabelGroup>
   <Label>Default label</Label>
-  <Label bg="prState.closed.bg">Label with red background</Label>
+  <Label bg="prState.closed.bg">Label with background indicating a closed PR state</Label>
   <Label outline>Default outline label</Label>
 </LabelGroup>
 ```

--- a/docs/content/Link.md
+++ b/docs/content/Link.md
@@ -2,7 +2,7 @@
 title: Link
 ---
 
-The Link component styles anchor tags with default blue styling and hover text decoration. `Link` is used for destinations, or moving from one page to another.
+The Link component styles anchor tags with default hyperlink color cues and hover text decoration. `Link` is used for destinations, or moving from one page to another.
 
 In special cases where you'd like a `<button>` styled like a `Link`, use `<Link as='button'>`. Make sure to provide a click handler with `onClick`.
 
@@ -22,10 +22,10 @@ Link components get `COMMON` and `TYPOGRAPHY` system props. Read our [System Pro
 
 ## Component props
 
-| Name      | Type    | Default | Description                                       |
-| :-------- | :------ | :-----: | :------------------------------------------------ |
-| href      | String  |         | URL to be used for the Link                       |
-| muted     | Boolean |  false  | Uses light gray for Link color, and blue on hover |
-| underline | Boolean |  false  | Adds underline to the Link                        |
-| as        | String  |   'a'   | Can be 'a', 'button', 'input', or 'summary'       |
-| hoverColor        | String  |    | Color used when hovering over link      |
+| Name       | Type    | Default | Description                                                                     |
+| :--------- | :------ | :-----: | :------------------------------------------------------------------------------ |
+| href       | String  |         | URL to be used for the Link                                                     |
+| muted      | Boolean |  false  | Uses a less prominent shade for Link color, and the default link shade on hover |
+| underline  | Boolean |  false  | Adds underline to the Link                                                      |
+| as         | String  |   'a'   | Can be 'a', 'button', 'input', or 'summary'                                     |
+| hoverColor | String  |         | Color used when hovering over link                                              |

--- a/docs/content/PointerBox.md
+++ b/docs/content/PointerBox.md
@@ -7,7 +7,7 @@ PointerBox is a [BorderBox](./BorderBox) component with a caret added to it.
 ## Default example
 
 ```jsx live
-<PointerBox m={4} p={2} minHeight={100} bg="green.1" borderColor="green.5">
+<PointerBox m={4} p={2} minHeight={100} bg="bg.success" borderColor="border.success">
   PointerBox
 </PointerBox>
 ```
@@ -18,10 +18,15 @@ function PointerBoxDemo(props) {
 
   return (
     <Box>
-      <Heading as="h3" fontSize={3}>Caret Position</Heading>
+      <Heading as="h3" fontSize={3}>
+        Caret Position
+      </Heading>
       <CaretSelector current={pos} onChange={setPos} />
       <Relative pt={4}>
-        <PointerBox m={4} p={2} minHeight={100} bg="green.1" borderColor="green.5" caret={pos}> Content </PointerBox>
+        <PointerBox m={4} p={2} minHeight={100} bg="bg.success" borderColor="border.success" caret={pos}>
+          {' '}
+          Content{' '}
+        </PointerBox>
       </Relative>
     </Box>
   )
@@ -29,15 +34,31 @@ function PointerBoxDemo(props) {
 
 function CaretSelector(props) {
   const choices = [
-    'top',         'bottom',      'left',         'right',
-    'left-bottom', 'left-top',    'right-bottom', 'right-top',
-    'top-left',    'bottom-left', 'top-right',    'bottom-right'
-  ].map((dir) => (
+    'top',
+    'bottom',
+    'left',
+    'right',
+    'left-bottom',
+    'left-top',
+    'right-bottom',
+    'right-top',
+    'top-left',
+    'bottom-left',
+    'top-right',
+    'bottom-right'
+  ].map(dir => (
     <label>
-      <input key={dir} type='radio' name='caret' value={dir}
-        checked={dir === props.current} onChange={() => props.onChange(dir)} /> {dir}
+      <input
+        key={dir}
+        type="radio"
+        name="caret"
+        value={dir}
+        checked={dir === props.current}
+        onChange={() => props.onChange(dir)}
+      />{' '}
+      {dir}
     </label>
-))
+  ))
 
   return (
     <Grid gridTemplateColumns="repeat(4, auto)" gridGap={3} my={2}>
@@ -55,6 +76,6 @@ PointerBox components get `COMMON`, `LAYOUT`, `BORDER`, and `FLEX` system props.
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| caret | String | bottom | Sets the location of the caret. The format is `[edge]-[position on edge]`. For example, `right-top` will position the caret on the top of the right edge of the box. Use `top`, `right`, `bottom`, or `left` to position a caret in the center of that edge. |
+| Name  | Type   | Default | Description                                                                                                                                                                                                                                                  |
+| :---- | :----- | :-----: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| caret | String | bottom  | Sets the location of the caret. The format is `[edge]-[position on edge]`. For example, `right-top` will position the caret on the top of the right edge of the box. Use `top`, `right`, `bottom`, or `left` to position a caret in the center of that edge. |

--- a/docs/content/Position.md
+++ b/docs/content/Position.md
@@ -10,32 +10,32 @@ The Position component is a wrapper component that gives the containing componen
 <Box p={2} mb={200}>
   <Heading mb={2}>Relative + Absolute</Heading>
   <Relative size={128} mx={128} my={6}>
-    <Box border={1} borderColor="ansi.gray" color="text.inverse" size="100%">
-      <Absolute left="100%" top={0} bg="ansi.red" p={1}>
+    <BorderBox size="100%">
+      <Absolute left="100%" top={0} color="text.inverse" bg="bg.successInverse" p={1}>
         rt
       </Absolute>
-      <Absolute right="100%" top={0} bg="ansi.green" p={1}>
+      <Absolute right="100%" top={0} color="text.inverse" bg="bg.successInverse" p={1}>
         lt
       </Absolute>
-      <Absolute left="100%" bottom={0} bg="ansi.blue" p={1}>
+      <Absolute left="100%" bottom={0} color="text.inverse" bg="bg.successInverse" p={1}>
         rb
       </Absolute>
-      <Absolute right="100%" bottom={0} bg="ansi.magenta" p={1}>
+      <Absolute right="100%" bottom={0} color="text.inverse" bg="bg.successInverse" p={1}>
         lb
       </Absolute>
-      <Absolute left={0} top="100%" bg="ansi.yellow" p={1}>
+      <Absolute left={0} top="100%" color="text.inverse" bg="bg.successInverse" p={1}>
         bl
       </Absolute>
-      <Absolute right={0} top="100%" bg="ansi.cyan" p={1}>
+      <Absolute right={0} top="100%" color="text.inverse" bg="bg.successInverse" p={1}>
         br
       </Absolute>
-      <Absolute left={0} bottom="100%" bg="ansi.redBright" p={1}>
+      <Absolute left={0} bottom="100%" color="text.inverse" bg="bg.successInverse" p={1}>
         tl
       </Absolute>
-      <Absolute right={0} bottom="100%" bg="ansi.blueBright" p={1}>
+      <Absolute right={0} bottom="100%" color="text.inverse" bg="bg.successInverse" p={1}>
         tr
       </Absolute>
-    </Box>
+    </BorderBox>
   </Relative>
 
   <Heading my={2}>Sticky</Heading>
@@ -49,7 +49,7 @@ The Position component is a wrapper component that gives the containing componen
   <Heading my={2}>Fixed</Heading>
   <p>(see the bottom right of the screen)</p>
 
-  <Fixed bottom={0} right={0} bg="bg.danger" p={2}>
+  <Fixed bottom={0} right={0} color="text.inverse" bg="bg.dangerInverse" p={2}>
     I'm fixed to the bottom right.
   </Fixed>
 </Box>

--- a/docs/content/Position.md
+++ b/docs/content/Position.md
@@ -10,22 +10,38 @@ The Position component is a wrapper component that gives the containing componen
 <Box p={2} mb={200}>
   <Heading mb={2}>Relative + Absolute</Heading>
   <Relative size={128} mx={128} my={6}>
-    <Box border={1} borderColor="gray.2" size="100%">
-      <Absolute left="100%" top={0} bg="red.1" p={1}>rt</Absolute>
-      <Absolute right="100%" top={0} bg="green.1" p={1}>lt</Absolute>
-      <Absolute left="100%" bottom={0} bg="blue.1" p={1}>rb</Absolute>
-      <Absolute right="100%" bottom={0} bg="purple.1" p={1}>lb</Absolute>
-      <Absolute left={0} top="100%" bg="orange.1" p={1}>bl</Absolute>
-      <Absolute right={0} top="100%" bg="yellow.3" p={1}>br</Absolute>
-      <Absolute left={0} bottom="100%" bg="red.1" p={1}>tl</Absolute>
-      <Absolute right={0} bottom="100%" bg="blue.1" p={1}>tr</Absolute>
+    <Box border={1} borderColor="ansi.gray" color="text.inverse" size="100%">
+      <Absolute left="100%" top={0} bg="ansi.red" p={1}>
+        rt
+      </Absolute>
+      <Absolute right="100%" top={0} bg="ansi.green" p={1}>
+        lt
+      </Absolute>
+      <Absolute left="100%" bottom={0} bg="ansi.blue" p={1}>
+        rb
+      </Absolute>
+      <Absolute right="100%" bottom={0} bg="ansi.magenta" p={1}>
+        lb
+      </Absolute>
+      <Absolute left={0} top="100%" bg="ansi.yellow" p={1}>
+        bl
+      </Absolute>
+      <Absolute right={0} top="100%" bg="ansi.cyan" p={1}>
+        br
+      </Absolute>
+      <Absolute left={0} bottom="100%" bg="ansi.redBright" p={1}>
+        tl
+      </Absolute>
+      <Absolute right={0} bottom="100%" bg="ansi.blueBright" p={1}>
+        tr
+      </Absolute>
     </Box>
   </Relative>
 
   <Heading my={2}>Sticky</Heading>
 
-  <BorderBox border={1} borderColor="green.5" height={500}>
-    <Sticky top={0} bg="green.2" p={6}>
+  <BorderBox border={1} borderColor="border.success" height={500}>
+    <Sticky top={0} bg="bg.success" p={6}>
       I'm sticky!
     </Sticky>
   </BorderBox>
@@ -33,7 +49,7 @@ The Position component is a wrapper component that gives the containing componen
   <Heading my={2}>Fixed</Heading>
   <p>(see the bottom right of the screen)</p>
 
-  <Fixed bottom={0} right={0} bg="red.2" p={2}>
+  <Fixed bottom={0} right={0} bg="bg.danger" p={2}>
     I'm fixed to the bottom right.
   </Fixed>
 </Box>

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -2,22 +2,22 @@
 title: ProgressBar
 ---
 
-
-Use `ProgressBar` to visualize task completion. 
+Use `ProgressBar` to visualize task completion.
 
 ## Default example
 
 ```jsx live
-<ProgressBar progress={80}/>
- ```
+<ProgressBar progress={80} />
+```
 
- If you'd like to use ProgressBar inline, pass the `inline` boolean prop & **be sure to set a width**.
- ```jsx live
-  <>
-    <Text mr={3}>5 of 10</Text>
-    <ProgressBar progress={50} inline width='100px'/>
-  </>
- ```
+If you'd like to use ProgressBar inline, pass the `inline` boolean prop & **be sure to set a width**.
+
+```jsx live
+<>
+  <Text mr={3}>5 of 10</Text>
+  <ProgressBar progress={50} inline width="100px" />
+</>
+```
 
 ## System props
 
@@ -25,9 +25,9 @@ ProgressBar components get `COMMON` system props. Read our [System Props](/syste
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| progress | Number | | Used to set the size of the green bar |
-| barSize | String | 'default' | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
-| inline | Boolean | false | Styles the progress bar inline |
-| bg | String | 'green.5' | Set the progress bar color, defaults to bg-green |
+| Name     | Type    |     Default     | Description                                                                                                                      |
+| :------- | :------ | :-------------: | :------------------------------------------------------------------------------------------------------------------------------- |
+| progress | Number  |                 | Used to set the size of the green bar                                                                                            |
+| barSize  | String  |    'default'    | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
+| inline   | Boolean |      false      | Styles the progress bar inline                                                                                                   |
+| bg       | String  | 'state.success' | Set the progress bar color, defaults to bg-green                                                                                 |

--- a/docs/content/ProgressBar.mdx
+++ b/docs/content/ProgressBar.mdx
@@ -25,9 +25,9 @@ ProgressBar components get `COMMON` system props. Read our [System Props](/syste
 
 ## Component props
 
-| Name     | Type    |     Default     | Description                                                                                                                      |
-| :------- | :------ | :-------------: | :------------------------------------------------------------------------------------------------------------------------------- |
-| progress | Number  |                 | Used to set the size of the green bar                                                                                            |
-| barSize  | String  |    'default'    | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
-| inline   | Boolean |      false      | Styles the progress bar inline                                                                                                   |
-| bg       | String  | 'state.success' | Set the progress bar color, defaults to bg-green                                                                                 |
+| Name     | Type    |       Default       | Description                                                                                                                      |
+| :------- | :------ | :-----------------: | :------------------------------------------------------------------------------------------------------------------------------- |
+| progress | Number  |                     | Used to set the size of the green bar                                                                                            |
+| barSize  | String  |      'default'      | Controls the height of the progress bar. Can be 'small', 'large', or 'default'. If omitted, height is set to the default height. |
+| inline   | Boolean |        false        | Styles the progress bar inline                                                                                                   |
+| bg       | String  | 'bg.successInverse' | Set the progress bar color, defaults to bg-green                                                                                 |

--- a/docs/content/SideNav.md
+++ b/docs/content/SideNav.md
@@ -35,11 +35,7 @@ Add the `variant='full'` prop to a `SideNav.Link` to spread child elements acros
     <Text>Text Only</Text>
   </SideNav.Link>
   <SideNav.Link href="#url">
-    <Avatar
-      size={16}
-      mr={2}
-      src="https://avatars.githubusercontent.com/hubot?s=32"
-    />
+    <Avatar size={16} mr={2} src="https://avatars.githubusercontent.com/hubot?s=32" />
     <Text>With an avatar</Text>
   </SideNav.Link>
   <SideNav.Link href="#url">
@@ -48,18 +44,20 @@ Add the `variant='full'` prop to a `SideNav.Link` to spread child elements acros
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full" selected>
     <Text>With a status icon</Text>
-    <StyledOcticon mr={2} size={16} icon={DotIcon} color="green.5" />
+    <StyledOcticon mr={2} size={16} icon={DotIcon} color="icon.success" />
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full">
     <Text>With a label</Text>
-    <Label bg='blue.5'>label</Label>
+    <Label bg="label.info.border">label</Label>
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full">
     <Text>With a counter</Text>
     <CounterLabel>16</CounterLabel>
   </SideNav.Link>
   <SideNav.Link href="#url">
-    <Heading as="h5" fontSize={1}>A heading</Heading>
+    <Heading as="h5" fontSize={1}>
+      A heading
+    </Heading>
     <Text>and some more content</Text>
   </SideNav.Link>
 </SideNav>
@@ -106,7 +104,7 @@ It can also appear nested, as a sub navigation. Use margin/padding [System Props
     <Text>Profile</Text>
   </SideNav.Link>
 
-  <SideNav bordered variant="lightweight" py={3} pl={6} backgroundColor="white">
+  <SideNav bordered variant="lightweight" py={3} pl={6} backgroundColor="sidenav.selectedBg">
     <SideNav.Link href="#url" selected>
       <Text>Sub item 1</Text>
     </SideNav.Link>
@@ -141,19 +139,19 @@ If using React Router, you can use the `as` prop to render the element as a `Nav
 
 ### SideNav
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| as | String | 'nav' | Sets the HTML tag for the component. |
-| bordered | Boolean | false | Renders the component with a border. |
-| variant | String | 'normal' | Set to `lightweight` to render [in a lightweight style](#lightweight-variant). |
+| Name     | Type    | Default  | Description                                                                    |
+| :------- | :------ | :------: | :----------------------------------------------------------------------------- |
+| as       | String  |  'nav'   | Sets the HTML tag for the component.                                           |
+| bordered | Boolean |  false   | Renders the component with a border.                                           |
+| variant  | String  | 'normal' | Set to `lightweight` to render [in a lightweight style](#lightweight-variant). |
 
 ### SideNav.Link
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| as | String | 'a' | Sets the HTML tag for the component. |
-| href      | String  |         | URL to be used for the Link                       |
-| muted     | Boolean |  false  | Uses light gray for Link color, and blue on hover |
-| selected | Boolean | false | Sets the link as selected, giving it a different style and setting the `aria-current` attribute. |
-| underline | Boolean |  false  | Adds underline to the Link                        |
-| variant | String | 'normal' | Set to `full` to render [a full variant](#full-variant), suitable for including icons and labels. |
+| Name      | Type    | Default  | Description                                                                                       |
+| :-------- | :------ | :------: | :------------------------------------------------------------------------------------------------ |
+| as        | String  |   'a'    | Sets the HTML tag for the component.                                                              |
+| href      | String  |          | URL to be used for the Link                                                                       |
+| muted     | Boolean |  false   | Uses a less prominent shade for Link color, and the default link shade on hover                   |
+| selected  | Boolean |  false   | Sets the link as selected, giving it a different style and setting the `aria-current` attribute.  |
+| underline | Boolean |  false   | Adds underline to the Link                                                                        |
+| variant   | String  | 'normal' | Set to `full` to render [a full variant](#full-variant), suitable for including icons and labels. |

--- a/docs/content/SideNav.md
+++ b/docs/content/SideNav.md
@@ -48,7 +48,7 @@ Add the `variant='full'` prop to a `SideNav.Link` to spread child elements acros
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full">
     <Text>With a label</Text>
-    <Label bg="label.info.border">label</Label>
+    <Label outline>label</Label>
   </SideNav.Link>
   <SideNav.Link href="#url" variant="full">
     <Text>With a counter</Text>

--- a/docs/content/StyledOcticon.md
+++ b/docs/content/StyledOcticon.md
@@ -8,8 +8,8 @@ StyledOcticon renders an [Octicon](https://octicons.github.com) with common syst
 ## Default example
 
 ```jsx live
-<StyledOcticon icon={CheckIcon} size={32} color="green.5" mr={2} />
-<StyledOcticon icon={XIcon} size={32} color="red.5" />
+<StyledOcticon icon={CheckIcon} size={32} color="icon.success" mr={2} />
+<StyledOcticon icon={XIcon} size={32} color="icon.danger" />
 ```
 
 ## System props
@@ -20,9 +20,9 @@ StyledOcticon components get `COMMON` system props. Read our [System Props](/sys
 
 StyledOcticon passes all of its props except the common system props down to the [Octicon component](https://github.com/primer/octicons/tree/master/lib/octicons_react#usage), including:
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| ariaLabel | String | | Specifies the `aria-label` attribute, which is read verbatim by screen readers |
-| icon | Component | | [Octicon component](https://github.com/primer/octicons/tree/master/lib/octicons_react) used in the component |
-| size | Number | 16 | Sets the uniform `width` and `height` of the SVG element |
-| verticalAlign | String | `text-bottom` | Sets the `vertical-align` CSS property |
+| Name          | Type      |    Default    | Description                                                                                                  |
+| :------------ | :-------- | :-----------: | :----------------------------------------------------------------------------------------------------------- |
+| ariaLabel     | String    |               | Specifies the `aria-label` attribute, which is read verbatim by screen readers                               |
+| icon          | Component |               | [Octicon component](https://github.com/primer/octicons/tree/master/lib/octicons_react) used in the component |
+| size          | Number    |      16       | Sets the uniform `width` and `height` of the SVG element                                                     |
+| verticalAlign | String    | `text-bottom` | Sets the `vertical-align` CSS property                                                                       |

--- a/docs/content/Text.md
+++ b/docs/content/Text.md
@@ -1,13 +1,15 @@
 ---
 title: Text
 ---
+
 The Text component is a wrapper component that will apply typography styles to the text inside.
 
 ## Default example
+
 ```jsx live
 <Text as='p' fontWeight="bold">bold</Text>
-<Text as='p' color="red.6">red color</Text>
-<Text as='p' color="white" bg="gray.9" p={2}>white on black</Text>
+<Text as='p' color="text.danger">danger color</Text>
+<Text as='p' color="text.inverse" bg="bg.canvasInverse" p={2}>inverse colors</Text>
 ```
 
 ## System props
@@ -16,6 +18,6 @@ Text components get `TYPOGRAPHY` and `COMMON` system props. Read our [System Pro
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| as | String | `span` | Sets the HTML tag for the component|
+| Name | Type   | Default | Description                         |
+| :--- | :----- | :-----: | :---------------------------------- |
+| as   | String | `span`  | Sets the HTML tag for the component |

--- a/docs/content/Timeline.md
+++ b/docs/content/Timeline.md
@@ -67,12 +67,6 @@ of the child `StyledOcticon` if necessary.
     </Timeline.Badge>
     <Timeline.Body>Background used when pull requests are merged</Timeline.Body>
   </Timeline.Item>
-  <Timeline.Item>
-    <Timeline.Badge bg="icon.info">
-      <StyledOcticon icon={FlameIcon} color="text.inverse" />
-    </Timeline.Badge>
-    <Timeline.Body>Background to indicate new events below</Timeline.Body>
-  </Timeline.Item>
 </Timeline>
 ```
 

--- a/docs/content/Timeline.md
+++ b/docs/content/Timeline.md
@@ -13,13 +13,13 @@ The Timeline.Item component is used to display items on a vertical timeline, con
       <StyledOcticon icon={FlameIcon} />
     </Timeline.Badge>
     <Timeline.Body>
-      <Link href="#" fontWeight="bold" color="gray.8" mr={1} muted>
+      <Link href="#" fontWeight="bold" color="text.primary" mr={1} muted>
         Monalisa
       </Link>
-      created one <Link href="#" fontWeight="bold" color="gray.8" mr={1} muted>
+      created one <Link href="#" fontWeight="bold" color="text.primary" mr={1} muted>
         hot potato
       </Link>
-      <Link href="#" color="gray.7" muted>
+      <Link href="#" color="timeline.text" muted>
         Just now
       </Link>
     </Timeline.Body>
@@ -50,28 +50,28 @@ of the child `StyledOcticon` if necessary.
 ```jsx live
 <Timeline>
   <Timeline.Item>
-    <Timeline.Badge bg="red.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="prState.closed.bg">
+      <StyledOcticon icon={FlameIcon} color="prState.closed.text" />
     </Timeline.Badge>
-    <Timeline.Body>Red background used when closed events occur</Timeline.Body>
+    <Timeline.Body>Background used when closed events occur</Timeline.Body>
   </Timeline.Item>
   <Timeline.Item>
-    <Timeline.Badge bg="green.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="prState.open.bg">
+      <StyledOcticon icon={FlameIcon} color="prState.open.text" />
     </Timeline.Badge>
-    <Timeline.Body>Green background when opened or passed events occur</Timeline.Body>
+    <Timeline.Body>Background when opened or passed events occur</Timeline.Body>
   </Timeline.Item>
   <Timeline.Item>
-    <Timeline.Badge bg="purple.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="prState.merged.bg">
+      <StyledOcticon icon={FlameIcon} color="prState.merged.text" />
     </Timeline.Badge>
-    <Timeline.Body>Purple background used when pull requests are merged</Timeline.Body>
+    <Timeline.Body>Background used when pull requests are merged</Timeline.Body>
   </Timeline.Item>
   <Timeline.Item>
-    <Timeline.Badge bg="blue.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="icon.info">
+      <StyledOcticon icon={FlameIcon} color="text.inverse" />
     </Timeline.Badge>
-    <Timeline.Body>Blue background to indicate new events below</Timeline.Body>
+    <Timeline.Body>Background to indicate new events below</Timeline.Body>
   </Timeline.Item>
 </Timeline>
 ```
@@ -104,17 +104,17 @@ To create a visual break in the timeline, use Timeline.Break. This adds a horizo
 ```jsx live
 <Timeline>
   <Timeline.Item>
-    <Timeline.Badge bg="red.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="prState.closed.bg">
+      <StyledOcticon icon={FlameIcon} color="prState.closed.text" />
     </Timeline.Badge>
-    <Timeline.Body>Red background used when closed events occur</Timeline.Body>
+    <Timeline.Body>Background used when closed events occur</Timeline.Body>
   </Timeline.Item>
   <Timeline.Break />
   <Timeline.Item>
-    <Timeline.Badge bg="green.5">
-      <StyledOcticon icon={FlameIcon} color="white" />
+    <Timeline.Badge bg="prState.open.bg">
+      <StyledOcticon icon={FlameIcon} color="prState.open.text" />
     </Timeline.Badge>
-    <Timeline.Body>Green background when opened or passed events occur</Timeline.Body>
+    <Timeline.Body>Background when opened or passed events occur</Timeline.Body>
   </Timeline.Item>
 </Timeline>
 ```

--- a/docs/content/Tooltip.md
+++ b/docs/content/Tooltip.md
@@ -2,17 +2,15 @@
 title: Tooltip
 ---
 
-The Tooltip component adds a tooltip to add context to elements on the page. The Tooltip has a black background by default.
+The Tooltip component adds a tooltip to add context to elements on the page.
 
-***⚠️ Usage warning! ⚠️***
+**_⚠️ Usage warning! ⚠️_**
 
 Tooltips as a UI pattern should be our last resort for conveying information because it is hidden by default and often with zero or little visual indicator of its existence.
 
 Before adding a tooltip, please consider: Is this information essential and necessary? Can the UI be made clearer? Can the information be shown on the page by default?
 
 **Attention:** we use aria-label for tooltip contents, because it is crucial that they are accessible to screen reader users. However, aria-label replaces the text content of an element in screen readers, so only use Tooltip on elements with no existing text content, or consider using `title` for supplemental information.
-
-
 
 ## Default example
 
@@ -28,10 +26,10 @@ Tooltip components get `COMMON` system props. Read our [System Props](/system-pr
 
 ## Component props
 
-| Name | Type | Default | Description |
-| :- | :- | :-: | :- |
-| align | String | | Can be either `left` or `right`.|
-| direction | String | | Can be one of `n`, `ne`, `e`, `se`, `s`, `sw`, `w`, `nw` | Sets where the tooltip renders in relation to the target. |
-| noDelay | Boolean | | When set to `true`, tooltip appears without any delay |
-| aria-label | String | | Text used in `aria-label` (for accessibility).
-| wrap | Boolean | | Use `true` to allow text within tooltip to wrap.
+| Name       | Type    | Default | Description                                              |
+| :--------- | :------ | :-----: | :------------------------------------------------------- | --------------------------------------------------------- |
+| align      | String  |         | Can be either `left` or `right`.                         |
+| direction  | String  |         | Can be one of `n`, `ne`, `e`, `se`, `s`, `sw`, `w`, `nw` | Sets where the tooltip renders in relation to the target. |
+| noDelay    | Boolean |         | When set to `true`, tooltip appears without any delay    |
+| aria-label | String  |         | Text used in `aria-label` (for accessibility).           |
+| wrap       | Boolean |         | Use `true` to allow text within tooltip to wrap.         |

--- a/docs/content/overriding-styles.mdx
+++ b/docs/content/overriding-styles.mdx
@@ -2,7 +2,7 @@
 title: Overriding styles with the sx prop
 ---
 
-Our goal with Primer React is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't *quite* flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
+Our goal with Primer React is to hit the sweet spot between providing too little and too much styling flexibility; too little and the design system is too rigid, and too much and it becomes too difficult to maintain a consistent style. Our components already support a standard set of [system props](/system-props), but sometimes a component just isn't _quite_ flexible enough to look the way you need it to look. For those cases, we provide the `sx` prop.
 
 The `sx` prop allows ad-hoc styling that is still theme aware. Declare the styles you want to apply in camel-cased object notation, and try to use theme values in appropriate CSS properties when possible. If you've passed a custom theme using `ThemeProvider` or a `theme` prop, the `sx` prop will honor the custom theme. For more information on theming in Primer React, check out [the Primer Theme documentation](/primer-theme).
 
@@ -10,9 +10,9 @@ The `sx` prop allows ad-hoc styling that is still theme aware. Declare the style
 
 The `sx` prop provides a lot of power, which means it is an easy tool to abuse. To best make use of it, we recommend following these guidelines:
 
-* Use the `sx` prop for small stylistic changes to components. For more substantial changes, consider abstracting your style changes into your own wrapper component.
-* Use [system props](/system-props) instead of the `sx` prop whenever possible.
-* Avoid nesting and pseudo-selectors in `sx` prop values when possible.
+- Use the `sx` prop for small stylistic changes to components. For more substantial changes, consider abstracting your style changes into your own wrapper component.
+- Use [system props](/system-props) instead of the `sx` prop whenever possible.
+- Avoid nesting and pseudo-selectors in `sx` prop values when possible.
 
 ## Basic example
 
@@ -25,7 +25,7 @@ This example demonstrates applying a bottom border to `Heading`, a component tha
   pb={2}
   sx={{
     borderBottomWidth: 1,
-    borderBottomColor: 'border.gray',
+    borderBottomColor: 'border.primary',
     borderBottomStyle: 'solid'
   }}>
     Heading with bottom border
@@ -40,9 +40,10 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 <BorderBox
   p={2}
   sx={{
-    bg: ['red.1', 'green.1', 'blue.1', 'purple.1', 'yellow.1']
-  }}>
-    Responsive background color
+    bg: ['bg.primary', 'bg.info', 'bg.success', 'bg.warning', 'bg.danger']
+  }}
+>
+  Responsive background color
 </BorderBox>
 ```
 
@@ -51,21 +52,23 @@ Just like [values passed to system props](https://styled-system.com/responsive-s
 The `sx` prop also allows for declaring styles based on media queries, psueudo-classes, and pseudo-elements. This example, though contrived, demonstrates the ability:
 
 ```jsx live
-<Box sx={{
-  '> *': {
-    borderWidth: 1,
-    borderColor: 'border.gray',
-    borderStyle: 'solid',
-    borderBottomWidth: 0,
-    padding: 2,
-    ':last-child': {
-      borderBottomWidth: 1
-    },
-    ':hover': {
-      bg: 'gray.1'
+<Box
+  sx={{
+    '> *': {
+      borderWidth: 1,
+      borderColor: 'border.primary',
+      borderStyle: 'solid',
+      borderBottomWidth: 0,
+      padding: 2,
+      ':last-child': {
+        borderBottomWidth: 1
+      },
+      ':hover': {
+        bg: 'border.tertiary'
+      }
     }
-  }
-}}>
+  }}
+>
   <Box>First</Box>
   <Box>Second</Box>
   <Box>Third</Box>

--- a/src/ProgressBar.tsx
+++ b/src/ProgressBar.tsx
@@ -45,7 +45,7 @@ function ProgressBar({progress, bg, theme, ...rest}: ProgressBarProps) {
 }
 
 ProgressBar.defaultProps = {
-  bg: 'state.success',
+  bg: 'bg.successInverse',
   barSize: 'default'
 }
 


### PR DESCRIPTION
This PR updates the documentation to remove references to old color values.

It also updates some language to make the language around colors more functional and less specific to a particular theme. This work is concentrated in the commit d204e73.

There are a few area's that still need attention, putting some notes on this one.

Part of https://github.com/primer/components/issues/1108