### PR TITLE
 a11y - substituted px based fontSize to rem in the main theme

### DIFF
--- a/src/__tests__/Button.tsx
+++ b/src/__tests__/Button.tsx
@@ -59,8 +59,8 @@ describe('Button', () => {
   })
 
   it('respects the "variant" prop', () => {
-    expect(render(<Button variant="small" />)).toHaveStyleRule('font-size', '12px')
-    expect(render(<Button variant="large" />)).toHaveStyleRule('font-size', '16px')
+    expect(render(<Button variant="small" />)).toHaveStyleRule('font-size', '0.75rem')
+    expect(render(<Button variant="large" />)).toHaveStyleRule('font-size', '1rem')
   })
 
   it('respects the "fontSize" prop over the "variant" prop', () => {

--- a/src/__tests__/Heading.tsx
+++ b/src/__tests__/Heading.tsx
@@ -7,12 +7,23 @@ import {axe, toHaveNoViolations} from 'jest-axe'
 import 'babel-polyfill'
 expect.extend(toHaveNoViolations)
 
+const baseFontSize = 16
+
 const theme = {
   breakpoints: ['400px', '640px', '960px', '1280px'],
   colors: {
     green: ['#010', '#020', '#030', '#040', '#050', '#060']
   },
-  fontSizes: ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px'],
+  fontSizes: [
+    `${12 / baseFontSize}rem`,
+    `${14 / baseFontSize}rem`,
+    `${16 / baseFontSize}rem`,
+    `${20 / baseFontSize}rem`,
+    `${24 / baseFontSize}rem`,
+    `${32 / baseFontSize}rem`,
+    `${40 / baseFontSize}rem`,
+    `${48 / baseFontSize}rem`
+  ],
   fonts: {
     normal: 'Helvetica,sans-serif',
     mono: 'Consolas,monospace'

--- a/src/__tests__/__snapshots__/BranchName.tsx.snap
+++ b/src/__tests__/__snapshots__/BranchName.tsx.snap
@@ -4,7 +4,7 @@ exports[`BranchName renders consistently 1`] = `
 .c0 {
   display: inline-block;
   padding: 2px 6px;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-family: SFMono-Regular,Consolas,"Liberation Mono",Menlo,Courier,monospace;
   color: #586069;
   background-color: #eaf5ff;

--- a/src/__tests__/__snapshots__/BreadcrumbItem.tsx.snap
+++ b/src/__tests__/__snapshots__/BreadcrumbItem.tsx.snap
@@ -4,7 +4,7 @@ exports[`Breadcrumb.Item adds activeClassName={SELECTED_CLASS} when it gets a "t
 .c0 {
   color: #0366d6;
   display: inline-block;
-  font-size: 14px;
+  font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -31,7 +31,7 @@ exports[`Breadcrumb.Item renders consistently 1`] = `
 .c0 {
   color: #0366d6;
   display: inline-block;
-  font-size: 14px;
+  font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
@@ -56,7 +56,7 @@ exports[`Breadcrumb.Item respects the "selected" prop 1`] = `
 .c0 {
   color: #0366d6;
   display: inline-block;
-  font-size: 14px;
+  font-size: 0.875rem;
   -webkit-text-decoration: none;
   text-decoration: none;
 }

--- a/src/__tests__/__snapshots__/Button.tsx.snap
+++ b/src/__tests__/__snapshots__/Button.tsx.snap
@@ -22,7 +22,7 @@ exports[`Button renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #24292e;
   background-color: #fafbfc;
   border: 1px solid rgba(27,31,35,0.15);
@@ -94,7 +94,7 @@ exports[`Button respects the "disabled" prop 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #24292e;
   background-color: #fafbfc;
   border: 1px solid rgba(27,31,35,0.15);
@@ -167,7 +167,7 @@ exports[`ButtonDanger renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #d73a49;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #fafbfc;
@@ -242,7 +242,7 @@ exports[`ButtonDanger renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #d73a49;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #fafbfc;
@@ -371,7 +371,7 @@ exports[`ButtonInvisible renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #fafbfc;
@@ -447,7 +447,7 @@ exports[`ButtonInvisible renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #0366d6;
   background-color: transparent;
   border: 0;
@@ -508,7 +508,7 @@ exports[`ButtonOutline renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #fafbfc;
@@ -584,7 +584,7 @@ exports[`ButtonOutline renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #0366d6;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #fafbfc;
@@ -661,7 +661,7 @@ exports[`ButtonPrimary renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #ffffff;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #2ea44f;
@@ -733,7 +733,7 @@ exports[`ButtonPrimary renders correct disabled styles 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #ffffff;
   border: 1px solid rgba(27,31,35,0.15);
   background-color: #2ea44f;
@@ -788,7 +788,7 @@ exports[`ButtonTableList renders consistently 1`] = `
 .c0 {
   display: inline-block;
   padding: 0;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #586069;
   -webkit-text-decoration: none;
   text-decoration: none;

--- a/src/__tests__/__snapshots__/CounterLabel.tsx.snap
+++ b/src/__tests__/__snapshots__/CounterLabel.tsx.snap
@@ -4,7 +4,7 @@ exports[`CounterLabel renders consistently 1`] = `
 .c0 {
   display: inline-block;
   padding: 2px 5px;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   line-height: 1;
   border-radius: 20px;

--- a/src/__tests__/__snapshots__/Dialog.tsx.snap
+++ b/src/__tests__/__snapshots__/Dialog.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Dialog Dialog.Header renders consistently 1`] = `
 .c1 {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   font-family: sans-serif;
   color: #24292e;
@@ -89,7 +89,7 @@ Array [
 }
 
 .c3 {
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
   font-family: sans-serif;
   color: #24292e;

--- a/src/__tests__/__snapshots__/Dropdown.tsx.snap
+++ b/src/__tests__/__snapshots__/Dropdown.tsx.snap
@@ -44,7 +44,7 @@ exports[`Dropdown.Button renders consistently 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #24292e;
   background-color: #fafbfc;
   border: 1px solid rgba(27,31,35,0.15);

--- a/src/__tests__/__snapshots__/FilterListItem.tsx.snap
+++ b/src/__tests__/__snapshots__/FilterListItem.tsx.snap
@@ -7,7 +7,7 @@ exports[`FilterList.Item renders consistently 1`] = `
   padding: 8px 11px;
   margin: 0 0 5px 0;
   overflow: hidden;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #586069;
   background-color: !important;
   -webkit-text-decoration: none;
@@ -46,7 +46,7 @@ exports[`FilterList.Item respects the "selected" prop 1`] = `
   padding: 8px 11px;
   margin: 0 0 5px 0;
   overflow: hidden;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #ffffff;
   background-color: #0366d6!important;
   -webkit-text-decoration: none;

--- a/src/__tests__/__snapshots__/FormGroup.tsx.snap
+++ b/src/__tests__/__snapshots__/FormGroup.tsx.snap
@@ -15,7 +15,7 @@ exports[`FormGroup.Label renders consistently 1`] = `
 .c0 {
   display: block;
   margin: 0 0 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
   font-weight: 600;
 }
 

--- a/src/__tests__/__snapshots__/Header.tsx.snap
+++ b/src/__tests__/__snapshots__/Header.tsx.snap
@@ -60,7 +60,7 @@ exports[`Header renders consistently 1`] = `
   display: -ms-flexbox;
   display: flex;
   padding: 16px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: rgba(255,255,255,0.7);
   background-color: #24292e;

--- a/src/__tests__/__snapshots__/Heading.tsx.snap
+++ b/src/__tests__/__snapshots__/Heading.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Heading renders consistently 1`] = `
 .c0 {
   font-weight: 600;
-  font-size: 32px;
+  font-size: 2rem;
   margin: 0;
 }
 

--- a/src/__tests__/__snapshots__/Label.tsx.snap
+++ b/src/__tests__/__snapshots__/Label.tsx.snap
@@ -6,7 +6,7 @@ exports[`Label renders consistently 1`] = `
   font-weight: 500;
   color: #ffffff;
   border-radius: 100px;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 20px;
   padding: 0 8px;
   background-color: #6a737d;
@@ -28,7 +28,7 @@ exports[`Label respects the "outline" prop 1`] = `
   font-weight: 500;
   color: #ffffff;
   border-radius: 100px;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 20px;
   padding: 0 8px;
   background-color: #6a737d;
@@ -57,7 +57,7 @@ exports[`Label respects the "variant" prop 1`] = `
   font-weight: 500;
   color: #ffffff;
   border-radius: 100px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 16px;
   padding: 8px 12px;
   background-color: #6a737d;

--- a/src/__tests__/__snapshots__/SelectMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectMenu.tsx.snap
@@ -22,7 +22,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   -webkit-text-decoration: none;
   text-decoration: none;
   text-align: center;
-  font-size: 14px;
+  font-size: 0.875rem;
   color: #24292e;
   background-color: #fafbfc;
   border: 1px solid rgba(27,31,35,0.15);
@@ -70,7 +70,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 .c6 {
   padding: 4px 16px;
   margin: 0;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-weight: 600;
   color: #6a737d;
   background-color: #f6f8fa;
@@ -80,7 +80,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
 .c7 {
   margin-top: -1px;
   padding: 8px 16px;
-  font-size: 12px;
+  font-size: 0.75rem;
   color: #6a737d;
   text-align: center;
   border-top: 1px solid #eaecef;
@@ -105,7 +105,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
   color: #586069;
   -webkit-text-decoration: none;
   text-decoration: none;
-  font-size: 12px;
+  font-size: 0.75rem;
   font-family: inherit;
   width: 100%;
 }
@@ -286,7 +286,7 @@ exports[`SelectMenu right-aligned modal has right: 0px 1`] = `
     height: auto;
     max-height: 350px;
     margin: 4px 0 16px 0;
-    font-size: 12px;
+    font-size: 0.75rem;
     border: 1px solid #e1e4e8;
     border-radius: 6px;
     box-shadow: 0 1px 0 rgba(27,31,35,0.04);

--- a/src/__tests__/__snapshots__/SideNav.tsx.snap
+++ b/src/__tests__/__snapshots__/SideNav.tsx.snap
@@ -9,7 +9,7 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
   display: block;
   width: 100%;
   text-align: left;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 .c0:hover {

--- a/src/__tests__/__snapshots__/StateLabel.tsx.snap
+++ b/src/__tests__/__snapshots__/StateLabel.tsx.snap
@@ -28,7 +28,7 @@ exports[`StateLabel renders children 1`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span
@@ -87,7 +87,7 @@ exports[`StateLabel renders consistently 1`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span
@@ -146,7 +146,7 @@ exports[`StateLabel respects the status prop 1`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span
@@ -204,7 +204,7 @@ exports[`StateLabel respects the status prop 2`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span
@@ -262,7 +262,7 @@ exports[`StateLabel respects the status prop 3`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span
@@ -320,7 +320,7 @@ exports[`StateLabel respects the variant prop 1`] = `
   padding-right: 8px;
   padding-top: 4px;
   padding-bottom: 4px;
-  font-size: 12px;
+  font-size: 0.75rem;
 }
 
 <span
@@ -378,7 +378,7 @@ exports[`StateLabel respects the variant prop 2`] = `
   padding-right: 12px;
   padding-top: 8px;
   padding-bottom: 8px;
-  font-size: 14px;
+  font-size: 0.875rem;
 }
 
 <span

--- a/src/__tests__/__snapshots__/SubNavLink.tsx.snap
+++ b/src/__tests__/__snapshots__/SubNavLink.tsx.snap
@@ -5,7 +5,7 @@ exports[`SubNav.Link adds activeClassName={SELECTED_CLASS} when it gets a "to" p
   padding-left: 16px;
   padding-right: 16px;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   min-height: 34px;
   color: #24292e;
@@ -72,7 +72,7 @@ exports[`SubNav.Link renders consistently 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   min-height: 34px;
   color: #24292e;
@@ -137,7 +137,7 @@ exports[`SubNav.Link respects the "selected" prop 1`] = `
   padding-left: 16px;
   padding-right: 16px;
   font-weight: 500;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   min-height: 34px;
   color: #24292e;

--- a/src/__tests__/__snapshots__/TabNav.tsx.snap
+++ b/src/__tests__/__snapshots__/TabNav.tsx.snap
@@ -3,7 +3,7 @@
 exports[`TabNav TabNav.Link renders consistently 1`] = `
 .c0 {
   padding: 8px 12px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   -webkit-text-decoration: none;

--- a/src/__tests__/__snapshots__/TextInput.tsx.snap
+++ b/src/__tests__/__snapshots__/TextInput.tsx.snap
@@ -25,7 +25,7 @@ exports[`TextInput renders 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -56,7 +56,7 @@ exports[`TextInput renders 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
@@ -96,7 +96,7 @@ exports[`TextInput renders block 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -129,7 +129,7 @@ exports[`TextInput renders block 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
@@ -169,7 +169,7 @@ exports[`TextInput renders consistently 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -200,7 +200,7 @@ exports[`TextInput renders consistently 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
@@ -239,7 +239,7 @@ exports[`TextInput renders large 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -254,7 +254,7 @@ exports[`TextInput renders large 1`] = `
   padding-right: 8px;
   padding-top: 10px;
   padding-bottom: 10px;
-  font-size: 20px;
+  font-size: 1.25rem;
 }
 
 .c0 .TextInput-icon {
@@ -275,7 +275,7 @@ exports[`TextInput renders large 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
@@ -315,7 +315,7 @@ exports[`TextInput renders small 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -331,7 +331,7 @@ exports[`TextInput renders small 1`] = `
   padding-right: 8px;
   padding-top: 3px;
   padding-bottom: 3px;
-  font-size: 12px;
+  font-size: 0.75rem;
   line-height: 20px;
 }
 
@@ -353,7 +353,7 @@ exports[`TextInput renders small 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 
@@ -393,7 +393,7 @@ exports[`TextInput should render a password input 1`] = `
   -ms-flex-align: stretch;
   align-items: stretch;
   min-height: 34px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 20px;
   color: #24292e;
   vertical-align: middle;
@@ -424,7 +424,7 @@ exports[`TextInput should render a password input 1`] = `
 
 @media (min-width:768px) {
   .c0 {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 }
 

--- a/src/__tests__/__snapshots__/UnderlineNavLink.tsx.snap
+++ b/src/__tests__/__snapshots__/UnderlineNavLink.tsx.snap
@@ -4,7 +4,7 @@ exports[`UnderlineNav.Link adds activeClassName={SELECTED_CLASS} when it gets a 
 .c0 {
   padding: 16px 8px;
   margin-right: 16px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: #24292e;
   text-align: center;
@@ -48,7 +48,7 @@ exports[`UnderlineNav.Link renders consistently 1`] = `
 .c0 {
   padding: 16px 8px;
   margin-right: 16px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: #24292e;
   text-align: center;
@@ -90,7 +90,7 @@ exports[`UnderlineNav.Link respects the "selected" prop 1`] = `
 .c0 {
   padding: 16px 8px;
   margin-right: 16px;
-  font-size: 14px;
+  font-size: 0.875rem;
   line-height: 1.5;
   color: #24292e;
   text-align: center;

--- a/src/stories/Text.stories.tsx
+++ b/src/stories/Text.stories.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
+import React from 'react'
+import {Meta} from '@storybook/react'
+import {ThemeProvider} from 'styled-components'
+
+import {BaseStyles, Text, theme} from '..'
+import {TextStyleProps} from 'styled-system'
+import {TextProps} from '../Text'
+type StrictTextStyleProps = TextStyleProps & {fontSize: TextProps['fontSize']}
+
+export default {
+  title: 'Composite components/Text',
+  component: Text,
+  decorators: [
+    Story => {
+      return (
+        <ThemeProvider theme={theme}>
+          <BaseStyles>
+            <Story />
+          </BaseStyles>
+        </ThemeProvider>
+      )
+    }
+  ],
+  argTypes: {
+    as: {
+      table: {
+        disable: true
+      }
+    },
+    theme: {
+      table: {
+        disable: true
+      }
+    },
+    sx: {
+      table: {
+        disable: true
+      }
+    },
+    fontSize: {
+      control: {
+        type: 'radio',
+        options: [0, 1, 2, 3, 4, 5, 6, 7]
+      }
+    }
+  }
+} as Meta
+
+export const defaultText = (args: StrictTextStyleProps) => <Text {...args}>This is a default text</Text>
+
+defaultText.args = {fontSize: 1}

--- a/src/theme-preval.js
+++ b/src/theme-preval.js
@@ -143,7 +143,17 @@ const sizes = {
   xlarge: '1280px'
 }
 
-const fontSizes = ['12px', '14px', '16px', '20px', '24px', '32px', '40px', '48px']
+const baseFontSize = 16
+const fontSizes = [
+  `${12 / baseFontSize}rem`,
+  `${14 / baseFontSize}rem`,
+  `${16 / baseFontSize}rem`,
+  `${20 / baseFontSize}rem`,
+  `${24 / baseFontSize}rem`,
+  `${32 / baseFontSize}rem`,
+  `${40 / baseFontSize}rem`,
+  `${48 / baseFontSize}rem`
+]
 
 const space = ['0', '4px', '8px', '16px', '24px', '32px', '40px', '48px', '64px', '80px', '96px', '112px', '128px']
 


### PR DESCRIPTION
## Description

The [Web Content Accessibility Guidelines (WCAG)](https://www.w3.org/WAI/standards-guidelines/wcag/), an organization that defines standards for web content accessibility, does not specify a minimum font size for the web.

All Primer Components were using `px` as units for the font sizes of the components. The WCAG recommends to use relative units like `em` and `rem` for font sizes. Size all major browsers have a default font size of 16px, we can set that size for the main text and calculate the rest proportionately with rem units. `em` units are relative to the font size of their own element, and `rem` units are relative to the root element.

### Sources 

- https://css-tricks.com/accessible-font-sizing-explained/
- https://www.w3.org/WAI/standards-guidelines/wcag/
- https://www.w3.org/WAI/tutorials/page-structure/styling/
- https://www.w3.org/TR/WCAG20-TECHS/C14.html
- https://www.sitepoint.com/understanding-and-using-rem-units-in-css/

## Changes

I've changed the theme to use only relative units for font sizes using `rem` as units, relative to the root element. Those changes were spread all across components, so I've re-generated the snapshots and adapted a couple of unit tests that were expecting `px` based values for font sizes. As well I've added a new storybook story for the `Text` component to see the changes in the browser.

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary- Not needed
- [x] Added/updated tests
- [x] Added/updated documentation - Not needed
- [x] Tested in Storybook
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
- [ ] Tested in an application when importing the components