### PR TITLE
Support a "Clipping Rectangle" in anchored positioning behavior

### DIFF
--- a/docs/content/anchoredPosition.mdx
+++ b/docs/content/anchoredPosition.mdx
@@ -14,13 +14,17 @@ When calculating the position of the floating element, the algorithm relies on d
 
 1. The floating element's width and height
 2. The anchor element's x/y position and its width and height
-3. The floating element container's x/y position, width and heigh, and border sizes
+3. The floating element's clipping container (for x/y position, width and height, and border sizes)
 
 The public API only asks for the first two elements; the floating element's container is discovered via DOM traversal.
 
-#### Finding the floating element's container
+#### Finding the floating element's clipping container
 
-The returned anchored position calculation is relative to the floating element's closest [_positioned_](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning) ancestor. To find this ancestor, we try to check parents of the floating element until we find one that has a position set to anything other than `static` and use that element's bounding box as the container. If we can't find such an element, we will try to use `document.body`. This element should be large—big enough to accommodate the floating element and have plenty of space to be moved around. It may be a good idea to ensure that this container element _also_ contains the anchor element and is scrollable. This will ensure that when scrolled, the anchor and floating element will move together.
+The returned anchored position calculation is relative to the floating element's closest [_positioned_](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning) ancestor. To find this ancestor, we try to check parents of the floating element until we find one that has a position set to anything other than `static` and use that element's bounding box as the container. If we can't find such an element, we will try to use `document.body`.
+
+Once we have found the appropriate relative ancestor, we attempt to find the floating element's _clipping container_. The clipping container is an element that: 1) has `overflow` set to something other than `visible`, and 2) is either an ancestor of the relative ancestor, or is itself the relative ancestor. Again, if we cannot locate such an element, we will use `document.body` as the clipping container.
+
+Once we have the clipping container, its bounding box is used as the viewport for the position calculation (see the next section). If the clipping container ends up being `document.body`, we take one additional step, allowing the clipping rectangle to be at least as tall as the window. This is done because the `body` element doesn't take up the full window size by default, but we still want to allow the entire space to be used as the viewport for the position calculation. It may be a good idea to ensure that this clipping container element _also_ contains the anchor element and is scrollable. This will ensure that if scrolled, the anchor and floating element will move together.
 
 #### Positioning and overflow
 
@@ -33,7 +37,7 @@ For a more in-depth explanation of the positioning settings, see `PositionSettin
 
 ### Demo
 
-See [this CodePen](https://codepen.io/team/GitHub/pen/OJbPKNZ) for a demo of `useAnchoredPosition`.
+Deploy Storybook to see a live demo of `anchoredPosition`.
 
 ### Usage
 
@@ -90,10 +94,7 @@ The `getAnchoredPosition` function takes the following arguments.
 
 ### Best practices
 
-As discussed above, the positioning algorithm needs to first measure the size of three different elements. Therefore, all three of these elements (anchor element, floating element, and the floating element's closest positioned container) must be rendered at the time `getAnchoredPosition` is called. Use these tips to get the best results:
-
-1. To avoid a frame where the floating element is rendered at the `(0, 0)` position, give it a style of `visibility: hidden` until its position is returned at set. This allows the element to be measured without showing up on the page.
-2. When checking for overflow, the positioning algorithm checks that the floating element at its calculated coordinates completely fits within its closest [_positioned_](https://developer.mozilla.org/en-US/docs/Web/CSS/position#types_of_positioning) ancestor. Therefore, such a container should completely fill _its_ parent container without relying on automatic sizing or overflow.
+As discussed above, the positioning algorithm needs to first measure the size of three different elements. Therefore, all three of these elements (anchor element, floating element, and the floating element's closest positioned container) must be rendered at the time `getAnchoredPosition` is called. To avoid a frame where the floating element is rendered at the `(0, 0)` position, give it a style of `visibility: hidden` until its position is returned at set. This allows the element to be measured without showing up on the page.
 
 ### A note on performance
 
@@ -135,6 +136,20 @@ export const UseAnchoredPosition = () => {
   )
 }
 ```
+
+### useAnchoredPosition hook
+| Name | Type | Default | Description |
+| :- | :- | :-: | :- |
+| settings | `UseAnchoredPositionSettings` | undefined | Optional settings to control how the anchored position is calculated. See below. |
+| dependencies | React.DependencyList | undefined | Dependencies to determine when to re-calculate the position. If undefined or `[]`, only calculate the position once. |
+
+**Return value**
+
+| Name | Type | Description |
+| :- | :- | :- |
+| floatingElementRef | `React.RefObject<Element>` | This ref must be added to the floating element JSX |
+| anchorElementRef | `React.RefObject<Element>` | This ref must be added to the anchor element JSX |
+| position | {top: number, left: number} | The calculated position |
 
 ### UseAnchoredPositionSettings interface
 `UseAnchoredPositionSettings` is an object with an interface that extends `PositionSettings` (see above). Additionally, it adds the following properties:

--- a/src/__tests__/behaviors/anchoredPosition.ts
+++ b/src/__tests__/behaviors/anchoredPosition.ts
@@ -35,6 +35,7 @@ function createVirtualDOM(
   parentBorders: {top: number; right: number; bottom: number; left: number} = {top: 0, right: 0, bottom: 0, left: 0}
 ) {
   const parent = document.createElement('div')
+  parent.style.overflow = 'hidden'
   parent.style.position = 'relative'
   parent.style.borderTopWidth = parentBorders.top + 'px'
   parent.style.borderRightWidth = parentBorders.right + 'px'
@@ -52,6 +53,22 @@ function createVirtualDOM(
 
 describe('getAnchoredPosition', () => {
   it('returns the correct position in the default case with no overflow', () => {
+    const anchorRect = makeDOMRect(300, 200, 50, 50)
+    const floatingRect = makeDOMRect(NaN, NaN, 100, 100)
+    document.body.innerHTML = `<div id="float"></div><div id="anchor"></div>`
+    const float = document.querySelector('#float')!
+    const anchor = document.querySelector('#anchor')!
+    float.getBoundingClientRect = () => floatingRect
+    anchor.getBoundingClientRect = () => anchorRect
+    document.body.getBoundingClientRect = () => makeDOMRect(0, 0, 1920, 0)
+    Object.defineProperty(window, 'innerHeight', {get: () => 1080})
+    const settings: Partial<PositionSettings> = {anchorOffset: 4}
+    const {top, left} = getAnchoredPosition(float, anchor, settings)
+    expect(top).toEqual(254)
+    expect(left).toEqual(300)
+  })
+
+  it('returns the correct position in the default case with no overflow, inside a clipping parent', () => {
     const parentRect = makeDOMRect(20, 20, 500, 500)
     const anchorRect = makeDOMRect(300, 200, 50, 50)
     const floatingRect = makeDOMRect(NaN, NaN, 100, 100)

--- a/src/behaviors/anchoredPosition.ts
+++ b/src/behaviors/anchoredPosition.ts
@@ -144,13 +144,6 @@ export function getAnchoredPosition(
     height: parentElementRect.height - borderTop - borderBottom
   }
 
-  // const parentViewport = {
-  //   top: clippingRect.top - relativeRect.top,
-  //   left: clippingRect.left - relativeRect.left,
-  //   width: clippingRect.width,
-  //   height: clippingRect.height
-  // } as BoxPosition
-
   return pureCalculateAnchoredPosition(
     clippingRect,
     relativeRect,
@@ -175,6 +168,12 @@ function getPositionedParent(element: Element) {
   return document.body
 }
 
+/**
+ * Returns the rectangle (relative to the window) that will clip the given element
+ * if it is rendered outside of its bounds.
+ * @param element 
+ * @returns 
+ */
 function getClippingRect(element: Element): BoxPosition {
   let parentNode: typeof element.parentNode = element
   while (parentNode != undefined) {
@@ -251,8 +250,9 @@ function getDefaultSettings(settings: Partial<PositionSettings> = {}): PositionS
  * Note: This is a pure function with no dependency on DOM APIs.
  * @see getAnchoredPosition
  * @see getDefaultSettings
- * @param viewportRect BoxPosition for the closest positioned proper parent of the floating element
- * @param relativeRect
+ * @param viewportRect BoxPosition for the rectangle that will clip the floating element if it is
+ *   rendered outside of the boundsof the rectangle.
+ * @param relativeRect BoxPosition for the closest positioned proper parent of the floating element
  * @param floatingRect WidthAndHeight for the floating element
  * @param anchorRect BoxPosition for the anchor element
  * @param PositionSettings to customize the calculated position for the floating element.
@@ -264,6 +264,8 @@ function pureCalculateAnchoredPosition(
   anchorRect: BoxPosition,
   {side, align, allowOutOfBounds, anchorOffset, alignmentOffset}: PositionSettings
 ): {top: number; left: number} {
+
+  // Compute the relative viewport rect, to bring it into the same coordinate space as `pos`
   const relativeViewportRect: BoxPosition = {
     top: viewportRect.top - relativeRect.top,
     left: viewportRect.left - relativeRect.left,
@@ -272,7 +274,6 @@ function pureCalculateAnchoredPosition(
   }
 
   let pos = calculatePosition(floatingRect, anchorRect, side, align, anchorOffset, alignmentOffset)
-  console.log(pos)
   pos.top -= relativeRect.top
   pos.left -= relativeRect.left
 

--- a/src/behaviors/anchoredPosition.ts
+++ b/src/behaviors/anchoredPosition.ts
@@ -131,17 +131,13 @@ export function getAnchoredPosition(
 
   const parentElementStyle = getComputedStyle(parentElement)
   const parentElementRect = parentElement.getBoundingClientRect()
-  const [borderTop, borderLeft, borderRight, borderBottom] = [
+  const [borderTop, borderLeft] = [
     parentElementStyle.borderTopWidth,
-    parentElementStyle.borderLeftWidth,
-    parentElementStyle.borderRightWidth,
-    parentElementStyle.borderBottomWidth
+    parentElementStyle.borderLeftWidth
   ].map(v => parseInt(v, 10) || 0)
   const relativeRect = {
     top: parentElementRect.top + borderTop,
-    left: parentElementRect.left + borderLeft,
-    width: parentElementRect.width - borderRight - borderLeft,
-    height: parentElementRect.height - borderTop - borderBottom
+    left: parentElementRect.left + borderLeft
   }
 
   return pureCalculateAnchoredPosition(
@@ -252,14 +248,14 @@ function getDefaultSettings(settings: Partial<PositionSettings> = {}): PositionS
  * @see getDefaultSettings
  * @param viewportRect BoxPosition for the rectangle that will clip the floating element if it is
  *   rendered outside of the boundsof the rectangle.
- * @param relativeRect BoxPosition for the closest positioned proper parent of the floating element
+ * @param relativePosition Position for the closest positioned proper parent of the floating element
  * @param floatingRect WidthAndHeight for the floating element
  * @param anchorRect BoxPosition for the anchor element
  * @param PositionSettings to customize the calculated position for the floating element.
  */
 function pureCalculateAnchoredPosition(
   viewportRect: BoxPosition,
-  relativeRect: BoxPosition,
+  relativePosition: Position,
   floatingRect: Size,
   anchorRect: BoxPosition,
   {side, align, allowOutOfBounds, anchorOffset, alignmentOffset}: PositionSettings
@@ -267,15 +263,15 @@ function pureCalculateAnchoredPosition(
 
   // Compute the relative viewport rect, to bring it into the same coordinate space as `pos`
   const relativeViewportRect: BoxPosition = {
-    top: viewportRect.top - relativeRect.top,
-    left: viewportRect.left - relativeRect.left,
+    top: viewportRect.top - relativePosition.top,
+    left: viewportRect.left - relativePosition.left,
     width: viewportRect.width,
     height: viewportRect.height
   }
 
   let pos = calculatePosition(floatingRect, anchorRect, side, align, anchorOffset, alignmentOffset)
-  pos.top -= relativeRect.top
-  pos.left -= relativeRect.left
+  pos.top -= relativePosition.top
+  pos.left -= relativePosition.left
 
   // Handle screen overflow
   if (!allowOutOfBounds) {
@@ -294,8 +290,8 @@ function pureCalculateAnchoredPosition(
 
         // If we have cut off in the same dimension as the "side" option, try flipping to the opposite side.
         pos = calculatePosition(floatingRect, anchorRect, nextSide, align, anchorOffset, alignmentOffset)
-        pos.top -= relativeRect.top
-        pos.left -= relativeRect.left
+        pos.top -= relativePosition.top
+        pos.left -= relativePosition.left
       }
     }
     // At this point we've flipped the position if applicable. Now just nudge until it's on-screen.

--- a/src/behaviors/anchoredPosition.ts
+++ b/src/behaviors/anchoredPosition.ts
@@ -71,7 +71,7 @@ export interface PositionSettings {
 
   /**
    * If false, when the above settings result in rendering the floating element
-   * wholly or partially outside of the bounds of the containing element, attempt 
+   * wholly or partially outside of the bounds of the containing element, attempt
    * to adjust the settings to prevent this. Only applies to "outside" positioning.
    *
    * First, attempt to flip to the opposite edge of the anchor if the floating
@@ -127,24 +127,33 @@ export function getAnchoredPosition(
   settings: Partial<PositionSettings> = {}
 ): {top: number; left: number} {
   const parentElement = getPositionedParent(floatingElement)
-  const parentRect = parentElement.getBoundingClientRect()
-  const parentStyle = getComputedStyle(parentElement)
-  const [parentTop, parentLeft, parentRight, parentBottom] = [
-    parentStyle.borderTopWidth,
-    parentStyle.borderLeftWidth,
-    parentStyle.borderRightWidth,
-    parentStyle.borderBottomWidth
-  ].map(v => parseInt(v, 10) || 0)
+  const clippingRect = getClippingRect(parentElement)
 
-  const parentViewport = {
-    top: parentRect.top + parentTop,
-    left: parentRect.left + parentLeft,
-    width: parentRect.width - parentLeft - parentRight,
-    height: parentRect.height - parentTop - parentBottom
-  } as BoxPosition
+  const parentElementStyle = getComputedStyle(parentElement)
+  const parentElementRect = parentElement.getBoundingClientRect()
+  const [borderTop, borderLeft, borderRight, borderBottom] = [
+    parentElementStyle.borderTopWidth,
+    parentElementStyle.borderLeftWidth,
+    parentElementStyle.borderRightWidth,
+    parentElementStyle.borderBottomWidth
+  ].map(v => parseInt(v, 10) || 0)
+  const relativeRect = {
+    top: parentElementRect.top + borderTop,
+    left: parentElementRect.left + borderLeft,
+    width: parentElementRect.width - borderRight - borderLeft,
+    height: parentElementRect.height - borderTop - borderBottom
+  }
+
+  // const parentViewport = {
+  //   top: clippingRect.top - relativeRect.top,
+  //   left: clippingRect.left - relativeRect.left,
+  //   width: clippingRect.width,
+  //   height: clippingRect.height
+  // } as BoxPosition
 
   return pureCalculateAnchoredPosition(
-    parentViewport,
+    clippingRect,
+    relativeRect,
     floatingElement.getBoundingClientRect(),
     anchorElement instanceof Element ? anchorElement.getBoundingClientRect() : anchorElement,
     getDefaultSettings(settings)
@@ -164,6 +173,43 @@ function getPositionedParent(element: Element) {
     parentNode = parentNode.parentNode
   }
   return document.body
+}
+
+function getClippingRect(element: Element): BoxPosition {
+  let parentNode: typeof element.parentNode = element
+  while (parentNode != undefined) {
+    if (parentNode === document.body) {
+      break
+    }
+    const parentNodeStyle = getComputedStyle(parentNode as Element)
+    if (parentNodeStyle.overflow !== 'visible') {
+      break
+    }
+    parentNode = parentNode.parentNode
+  }
+  const clippingNode = parentNode === document.body || !(parentNode instanceof HTMLElement) ? document.body : parentNode
+
+  const elemRect = clippingNode.getBoundingClientRect()
+  const elemStyle = getComputedStyle(clippingNode)
+
+  const [borderTop, borderLeft, borderRight, borderBottom] = [
+    elemStyle.borderTopWidth,
+    elemStyle.borderLeftWidth,
+    elemStyle.borderRightWidth,
+    elemStyle.borderBottomWidth
+  ].map(v => parseInt(v, 10) || 0)
+
+  return {
+    top: elemRect.top + borderTop,
+    left: elemRect.left + borderLeft,
+    width: elemRect.width - borderRight - borderLeft,
+
+    // If the clipping node is document.body, it can expand to the full height of the window
+    height: Math.max(
+      elemRect.height - borderTop - borderBottom,
+      clippingNode === document.body ? window.innerHeight : -Infinity
+    )
+  }
 }
 
 // Default settings to position a floating element
@@ -205,20 +251,30 @@ function getDefaultSettings(settings: Partial<PositionSettings> = {}): PositionS
  * Note: This is a pure function with no dependency on DOM APIs.
  * @see getAnchoredPosition
  * @see getDefaultSettings
- * @param parentRect BoxPosition for the closest positioned proper parent of the floating element
+ * @param viewportRect BoxPosition for the closest positioned proper parent of the floating element
+ * @param relativeRect
  * @param floatingRect WidthAndHeight for the floating element
  * @param anchorRect BoxPosition for the anchor element
  * @param PositionSettings to customize the calculated position for the floating element.
  */
 function pureCalculateAnchoredPosition(
-  parentRect: BoxPosition,
+  viewportRect: BoxPosition,
+  relativeRect: BoxPosition,
   floatingRect: Size,
   anchorRect: BoxPosition,
   {side, align, allowOutOfBounds, anchorOffset, alignmentOffset}: PositionSettings
 ): {top: number; left: number} {
+  const relativeViewportRect: BoxPosition = {
+    top: viewportRect.top - relativeRect.top,
+    left: viewportRect.left - relativeRect.left,
+    width: viewportRect.width,
+    height: viewportRect.height
+  }
+
   let pos = calculatePosition(floatingRect, anchorRect, side, align, anchorOffset, alignmentOffset)
-  pos.top -= parentRect.top
-  pos.left -= parentRect.left
+  console.log(pos)
+  pos.top -= relativeRect.top
+  pos.left -= relativeRect.left
 
   // Handle screen overflow
   if (!allowOutOfBounds) {
@@ -226,41 +282,37 @@ function pureCalculateAnchoredPosition(
     let positionAttempt = 0
     if (alternateOrder) {
       let prevSide = side
-      const containerDimensions = {
-        width: parentRect.width,
-        height: parentRect.height
-      }
 
       // Try all the alternate sides until one does not overflow
       while (
         positionAttempt < alternateOrder.length &&
-        shouldRecalculatePosition(prevSide, pos, containerDimensions, floatingRect)
+        shouldRecalculatePosition(prevSide, pos, relativeViewportRect, floatingRect)
       ) {
         const nextSide = alternateOrder[positionAttempt++]
         prevSide = nextSide
 
         // If we have cut off in the same dimension as the "side" option, try flipping to the opposite side.
         pos = calculatePosition(floatingRect, anchorRect, nextSide, align, anchorOffset, alignmentOffset)
-        pos.top -= parentRect.top
-        pos.left -= parentRect.left
+        pos.top -= relativeRect.top
+        pos.left -= relativeRect.left
       }
     }
     // At this point we've flipped the position if applicable. Now just nudge until it's on-screen.
-    if (pos.top < 0) {
-      pos.top = 0
+    if (pos.top < relativeViewportRect.top) {
+      pos.top = relativeViewportRect.top
     }
-    if (pos.left < 0) {
-      pos.left = 0
+    if (pos.left < relativeViewportRect.left) {
+      pos.left = relativeViewportRect.left
     }
-    if (pos.left + floatingRect.width > parentRect.width) {
-      pos.left = parentRect.width - floatingRect.width
+    if (pos.left + floatingRect.width > viewportRect.width + relativeViewportRect.left) {
+      pos.left = viewportRect.width + relativeViewportRect.left - floatingRect.width
     }
     // If we have exhausted all possible positions and none of them worked, we
     // say that overflowing the bottom of the screen is acceptable since it is
     // likely to be able to scroll.
     if (alternateOrder && positionAttempt < alternateOrder.length) {
-      if (pos.top + floatingRect.height > parentRect.height) {
-        pos.top = parentRect.height - floatingRect.height
+      if (pos.top + floatingRect.height > viewportRect.height + relativeViewportRect.top) {
+        pos.top = viewportRect.height + relativeViewportRect.top - floatingRect.height
       }
     }
   }
@@ -357,20 +409,26 @@ function calculatePosition(
 
 /**
  * Determines if there is an overflow
- * @param side 
- * @param currentPos 
- * @param containerDimensions 
- * @param elementDimensions 
+ * @param side
+ * @param currentPos
+ * @param containerDimensions
+ * @param elementDimensions
  */
 function shouldRecalculatePosition(
   side: AnchorSide,
   currentPos: Position,
-  containerDimensions: Size,
+  containerDimensions: BoxPosition,
   elementDimensions: Size
 ) {
   if (side === 'outside-top' || side === 'outside-bottom') {
-    return currentPos.top < 0 || currentPos.top + elementDimensions.height > containerDimensions.height
+    return (
+      currentPos.top < containerDimensions.top ||
+      currentPos.top + elementDimensions.height > containerDimensions.height + containerDimensions.top
+    )
   } else {
-    return currentPos.left < 0 || currentPos.left + elementDimensions.width > containerDimensions.width
+    return (
+      currentPos.left < containerDimensions.left ||
+      currentPos.left + elementDimensions.width > containerDimensions.width + containerDimensions.left
+    )
   }
 }

--- a/src/stories/useAnchoredPosition.stories.tsx
+++ b/src/stories/useAnchoredPosition.stories.tsx
@@ -178,7 +178,7 @@ export const ComplexAncestry = () => {
         sx={{
           border: '1px solid #000',
           backgroundColor: 'blue.1',
-          height: '400px',
+          height: '440px',
           overflow: 'auto',
           position: 'relative'
         }}
@@ -223,28 +223,6 @@ export const ComplexAncestry = () => {
       <Button onClick={onRecalculateClick}>Click to recalculate floating position</Button>
     </>
   )
-
-  // <Position
-  //   ref={anchorElementRef as React.RefObject<HTMLDivElement>}
-  //   position="absolute"
-  //   top={0}
-  //   bottom={0}
-  //   left={0}
-  //   right={0}
-  // >
-  //   <Float
-  //     ref={floatingElementRef as React.RefObject<HTMLDivElement>}
-  //     top={position?.top ?? 0}
-  //     left={position?.left ?? 0}
-  //   >
-  //     <p>Screen-Centered Floating Element </p>
-  //     <p>
-  //       <small>
-  //         <em>(Controls are ignored for this story)</em>
-  //       </small>
-  //     </p>
-  //   </Float>
-  // </Position>
 }
 
 const Nav = styled('nav')`

--- a/src/stories/useAnchoredPosition.stories.tsx
+++ b/src/stories/useAnchoredPosition.stories.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/explicit-module-boundary-types */
-import React from 'react'
+import React, {useCallback} from 'react'
 import {Meta} from '@storybook/react'
 
-import {BaseStyles, Box, ButtonPrimary, Position, theme} from '..'
+import {BaseStyles, Box, ButtonPrimary, Position, Relative, theme} from '..'
 import {useAnchoredPosition} from '../hooks/useAnchoredPosition'
 import styled, {ThemeProvider} from 'styled-components'
 import {get} from '../constants'
 import {AnchorSide} from '../behaviors/anchoredPosition'
 import Portal, {registerPortalRoot} from '../Portal'
+import Button from '../Button'
 
 export default {
   title: 'Hooks/useAnchoredPosition',
@@ -65,7 +66,7 @@ export default {
 
 const Float = styled(Position)`
   position: absolute;
-  border: 1px solid ${get('colors.gray.6')};
+  border: 1px solid ${get('colors.black')};
   border-radius: ${get('radii.2')};
   background-color: ${get('colors.orange.3')};
   display: flex;
@@ -77,7 +78,7 @@ const Float = styled(Position)`
 `
 const Anchor = styled(Position)`
   position: absolute;
-  border: 1px solid ${get('colors.gray.6')};
+  border: 1px solid ${get('colors.black')};
   border-radius: ${get('radii.2')};
   background-color: ${get('colors.blue.3')};
   display: flex;
@@ -93,7 +94,7 @@ export const UseAnchoredPosition = (args: any) => {
   const {floatingElementRef, anchorElementRef, position} = useAnchoredPosition(
     {
       side: `${args.anchorPosition ?? 'outside'}-${args.anchorSide ?? 'bottom'}` as AnchorSide,
-      align: args.anchorAlignment ?? 'first',
+      align: args.anchorAlignment ?? 'start',
       anchorOffset: args.anchorOffset && (parseInt(args.anchorOffset, 10) ?? undefined),
       alignmentOffset: args.alignmentOffset && (parseInt(args.alignmentOffset, 10) ?? undefined),
       allowOutOfBounds: args.allowOutOfBounds ?? undefined
@@ -101,7 +102,7 @@ export const UseAnchoredPosition = (args: any) => {
     [args]
   )
   return (
-    <Position position="absolute" top={2} bottom={0} left={2} right={0}>
+    <Relative m={2}>
       <Anchor
         top={args.anchorY ?? 0}
         left={args.anchorX ?? 0}
@@ -120,7 +121,7 @@ export const UseAnchoredPosition = (args: any) => {
       >
         Floating element
       </Float>
-    </Position>
+    </Relative>
   )
 }
 export const CenteredOnScreen = () => {
@@ -152,6 +153,98 @@ export const CenteredOnScreen = () => {
       </Float>
     </Position>
   )
+}
+
+export const ComplexAncestry = () => {
+  const [recalculateSignal, setRecalculateSignal] = React.useState(0)
+  const {floatingElementRef, anchorElementRef, position} = useAnchoredPosition(
+    {
+      side: 'outside-bottom',
+      align: 'start'
+    },
+    [recalculateSignal]
+  )
+  const onRecalculateClick = React.useCallback(() => {
+    setRecalculateSignal(recalculateSignal + 1)
+  }, [recalculateSignal])
+
+  // The outer Position element simply fills all available space
+  const space = 2
+  return (
+    <>
+      <Box
+        m={space}
+        p={space}
+        sx={{
+          border: '1px solid #000',
+          backgroundColor: 'blue.1',
+          height: '400px',
+          overflow: 'auto',
+          position: 'relative'
+        }}
+      >
+        Clipping container - this element has <code>overflow</code> set to something other than <code>visible</code>
+        <Box m={space} p={space} sx={{border: '1px solid #000', backgroundColor: 'blue.2', position: 'relative'}}>
+          Relatively positioned parent, but fluid height, so not the clipping parent.
+          <Box
+            m={space}
+            p={space}
+            sx={{border: '1px solid #000', backgroundColor: 'blue.3', position: 'static', overflow: 'hidden'}}
+          >
+            Floating element container. Position=static and overflow=hidden to show that overflow-hidden on a
+            statically-positioned element will not have any effect.
+            <Float
+              top={position?.top ?? 0}
+              left={position?.left ?? 0}
+              width={150}
+              height={220}
+              ref={floatingElementRef as React.RefObject<HTMLDivElement>}
+            >
+              Floating element
+            </Float>
+          </Box>
+        </Box>
+        <Box m={space} p={space} backgroundColor="blue.3" sx={{border: '1px solid #000', height: '2000px'}}>
+          Anchor element container. This element is really tall to demonstrate behavior within a scrollable clipping
+          container.
+          <Box
+            width="200px"
+            backgroundColor="orange.3"
+            height={60}
+            ref={anchorElementRef as React.RefObject<HTMLDivElement>}
+            sx={{border: '1px solid #000'}}
+            m={space}
+            p={space}
+          >
+            Anchor Element
+          </Box>
+        </Box>
+      </Box>
+      <Button onClick={onRecalculateClick}>Click to recalculate floating position</Button>
+    </>
+  )
+
+  // <Position
+  //   ref={anchorElementRef as React.RefObject<HTMLDivElement>}
+  //   position="absolute"
+  //   top={0}
+  //   bottom={0}
+  //   left={0}
+  //   right={0}
+  // >
+  //   <Float
+  //     ref={floatingElementRef as React.RefObject<HTMLDivElement>}
+  //     top={position?.top ?? 0}
+  //     left={position?.left ?? 0}
+  //   >
+  //     <p>Screen-Centered Floating Element </p>
+  //     <p>
+  //       <small>
+  //         <em>(Controls are ignored for this story)</em>
+  //       </small>
+  //     </p>
+  //   </Float>
+  // </Position>
 }
 
 const Nav = styled('nav')`


### PR DESCRIPTION
This change updates the anchored positioning behavior so that the floating element now respects its "clipping" container. This is the first ancestor element of the floating element that does _not_ have its `overflow` style set to anything other than `visible`. Furthermore, the clipping container must either be _positioned_ or be an ancestor of a _positioned_ ancestor of the floating element.

With this in place, we can now special-case `document.body` to take the full height of the window. This allows us to avoid having to manually create an element with full height just to contain the floating element.

**In other words, we now support positioning the floating element outside the bounds of a container as long as it will render visibly.**

Closes #1129 

### Screenshots
Screenshot of the new story that demonstrates the change:
![image](https://user-images.githubusercontent.com/397836/112051878-d2694880-8b28-11eb-91ef-2802b6e35ddf.png)

### Merge checklist
- [x] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
