### PR TITLE
Remove `Object.values` in favor of `for..of` to remove timeouts in `useSafeTimeout`

### DIFF
--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -9,7 +9,7 @@ test('should call callback after time', async () => {
 })
 
 
-test('should clear timeouts', async () => {
+test('should clear timeouts', () => {
   jest.useFakeTimers();
   const { result } = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()

--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -19,7 +19,7 @@ test('should clear timeouts when safeClearTimeout is called', () => {
   expect(clearTimeout).toHaveBeenLastCalledWith(timeoutId);
 })
 
-test('should clear timeouts when the hook is unmounted', () => {
+test('should clear timeouts when the component is unmounted', () => {
   jest.useFakeTimers()
   const { result, unmount } = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()

--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -9,7 +9,7 @@ test('should call callback after time', async () => {
 })
 
 
-test('should clear timeouts', () => {
+test('should clear timeouts when call safeClearTimeout', () => {
   jest.useFakeTimers();
   const { result } = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()

--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -9,7 +9,7 @@ test('should call callback after time', async () => {
 })
 
 
-test('should clear timeouts when call safeClearTimeout', () => {
+test('should clear timeouts when safeClearTimeout is called', () => {
   jest.useFakeTimers();
   const { result } = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()

--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -18,3 +18,14 @@ test('should clear timeouts when call safeClearTimeout', () => {
   expect(clearTimeout).toHaveBeenCalledTimes(1);
   expect(clearTimeout).toHaveBeenLastCalledWith(timeoutId);
 })
+
+test('should clear timeouts when the hook is unmounted', () => {
+  jest.useFakeTimers()
+  const { result, unmount } = renderHook(() => useSafeTimeout())
+  const mockFunction = jest.fn()
+  const timeoutId = result.current.safeSetTimeout(mockFunction, 300)
+
+  unmount()
+  expect(clearTimeout).toHaveBeenCalledTimes(1);
+  expect(clearTimeout).toHaveBeenLastCalledWith(timeoutId);
+})

--- a/src/hooks/useSafeTimeout.ts
+++ b/src/hooks/useSafeTimeout.ts
@@ -24,7 +24,9 @@ export default function useSafeTimeout(): {safeSetTimeout: SetTimeout; safeClear
 
   useEffect(() => {
     return () => {
-      Object.values(timers.current).forEach(clearTimeout)
+      for (const id of timers.current) {
+        clearTimeout(id)
+      }
     }
   }, [])
 


### PR DESCRIPTION
I was wandering within the source code of this repository when I spotted this "silent" bug.

Currently, the cleanup effect of `useSafeTimeout` looks something like this:

```js
function useSafeTimeout() {
  const timers = useRef<Set<number>>(new Set<number>())
  // ...
  useEffect(() => {
    return () => {
      Object.values(timers.current).forEach(clearTimeout)
    }
  }, [])
  // ...
}
```

The problem is that `Object.values` does not work with iterators, such as `Set`. This bug was introduced in https://github.com/primer/components/commit/2b6415d759262bec98e5a7493941ba7fcf4f7a18, as:
- The object was changed to a set, but the cleanup function was not changed
- Tests were not written to cover that case

So, this PR fixes this by changing `Object.values().forEach(...)` to a `for..of` loop, which works correctly with iterators. I've also written tests to cover such case.

---

Closes: _I don't think there are any opened issues about this problem._

### Merge checklist
- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
- [x] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

