### PR TITLE
Transfer: Remove `Object.values` in favor of `for..of` to remove timeouts in `useSafeTimeout`

### DIFF
--- a/src/__tests__/useSafeTimeout.tsx
+++ b/src/__tests__/useSafeTimeout.tsx
@@ -9,12 +9,23 @@ test('should call callback after time', async () => {
 })
 
 
-test('should clear timeouts', async () => {
+test('should clear timeouts when safeClearTimeout is called', () => {
   jest.useFakeTimers();
   const { result } = renderHook(() => useSafeTimeout())
   const mockFunction = jest.fn()
   const timeoutId = result.current.safeSetTimeout(mockFunction, 300)
   result.current.safeClearTimeout(timeoutId)
+  expect(clearTimeout).toHaveBeenCalledTimes(1);
+  expect(clearTimeout).toHaveBeenLastCalledWith(timeoutId);
+})
+
+test('should clear timeouts when the component is unmounted', () => {
+  jest.useFakeTimers()
+  const { result, unmount } = renderHook(() => useSafeTimeout())
+  const mockFunction = jest.fn()
+  const timeoutId = result.current.safeSetTimeout(mockFunction, 300)
+
+  unmount()
   expect(clearTimeout).toHaveBeenCalledTimes(1);
   expect(clearTimeout).toHaveBeenLastCalledWith(timeoutId);
 })

--- a/src/hooks/useSafeTimeout.ts
+++ b/src/hooks/useSafeTimeout.ts
@@ -24,7 +24,9 @@ export default function useSafeTimeout(): {safeSetTimeout: SetTimeout; safeClear
 
   useEffect(() => {
     return () => {
-      Object.values(timers.current).forEach(clearTimeout)
+      for (const id of timers.current) {
+        clearTimeout(id)
+      }
     }
   }, [])
 


### PR DESCRIPTION
Transferring PR #1133 from @lffg to run CI checks.