### PR TITLE
Ignore lint warning in example test file

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,5 +3,6 @@ module.exports = {
   cacheDirectory: '.test',
   collectCoverage: true,
   collectCoverageFrom: ['src/*.js'],
-  setupFilesAfterEnv: ['<rootDir>/src/utils/test-matchers.tsx', '<rootDir>/src/utils/test-deprecations.tsx']
+  setupFilesAfterEnv: ['<rootDir>/src/utils/test-matchers.tsx', '<rootDir>/src/utils/test-deprecations.tsx'],
+  testPathIgnorePatterns: ['example.js']
 }

--- a/src/__tests__/example.js
+++ b/src/__tests__/example.js
@@ -8,9 +8,7 @@ import {COMMON} from '../constants'
 // 2. remove this definition; it's just for eslint
 function SomeComponent() {}
 
-// 3. remove the ".skip" from this line to enable the test
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('SomeComponent', () => {
+describe('SomeComponent', () => {
   // if applicable, ensure that this is a "system component"
   it('is a system component', () => {
     expect(SomeComponent.systemComponent).toBe(true)

--- a/src/__tests__/example.js
+++ b/src/__tests__/example.js
@@ -8,7 +8,8 @@ import {COMMON} from '../constants'
 // 2. remove this definition; it's just for eslint
 function SomeComponent() {}
 
-// 3. remove the leading "x" from this line to enable the test
+// 3. remove the ".skip" from this line to enable the test
+// eslint-disable-next-line jest/no-disabled-tests
 describe.skip('SomeComponent', () => {
   // if applicable, ensure that this is a "system component"
   it('is a system component', () => {


### PR DESCRIPTION
I noticed there was an eslint warning popping up in all the recent PRs (see image below) because we skip the test in the `__tests__/example.js` file.  Adding an eslint ignore (and correcting the comment above which incorrectly tells you how to enable the test 😄 )

![image](https://user-images.githubusercontent.com/3026298/112907638-11f0e100-90a3-11eb-9bde-96027e8658aa.png)
