### PR TITLE
Disallow any with eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -60,7 +60,7 @@
       "files": ["**/*.ts", "**/*.tsx"],
       "extends": ["plugin:@typescript-eslint/recommended"],
       "rules": {
-        "@typescript-eslint/no-explicit-any": 0,
+        "@typescript-eslint/no-explicit-any": 2,
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
       }

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ declare module '@primer/components' {
   import {ReactComponentLike} from 'prop-types'
   import * as History from 'history'
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export interface BaseProps extends React.Props<any> {
     as?: React.ReactType
     className?: string
@@ -606,7 +607,9 @@ declare module '@primer/components' {
     Item: React.FunctionComponent<BreadcrumbItemProps>
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export const theme: {[key: string]: any}
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export const themeGet: (key: any) => any
 
   export interface DialogProps extends CommonProps, LayoutProps, Omit<React.HTMLAttributes<HTMLDivElement>, 'color'> {
@@ -646,6 +649,7 @@ declare module '@primer/components' {
 
   export const ProgressBar: React.FunctionComponent<ProgressBarProps>
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   type Theme = any
   type ColorMode = 'day' | 'night'
   type ColorModeWithAuto = ColorMode | 'auto'

--- a/src/Caret.tsx
+++ b/src/Caret.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {ThemeContext} from 'styled-components'
 import {style} from 'styled-system'
+import {Theme} from './ThemeProvider'
 
 type Location =
   | 'top'
@@ -56,7 +57,7 @@ export type CaretProps = {
   borderWidth?: string | number
   size?: number
   location?: Location
-  theme?: any
+  theme?: Theme
 }
 
 function Caret(props: CaretProps) {

--- a/src/DropdownStyles.ts
+++ b/src/DropdownStyles.ts
@@ -1,6 +1,7 @@
 import {get} from './constants'
+import {Theme} from './ThemeProvider'
 
-const getDirectionStyles = (theme: any, direction: 'ne' | 'e' | 'se' | 's' | 'sw' | 'w') => {
+const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | 'sw' | 'w') => {
   const map = {
     w: `
       top: 0;

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -7,7 +7,8 @@ const defaultColorMode = 'day'
 const defaultDayScheme = 'light'
 const defaultNightScheme = 'dark'
 
-type Theme = any
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Theme = {[key: string]: any}
 type ColorMode = 'day' | 'night'
 type ColorModeWithAuto = ColorMode | 'auto'
 

--- a/src/__tests__/BreadcrumbItem.tsx
+++ b/src/__tests__/BreadcrumbItem.tsx
@@ -26,7 +26,7 @@ describe('Breadcrumb.Item', () => {
   })
 
   it('adds activeClassName={SELECTED_CLASS} when it gets a "to" prop', () => {
-    const Link = ({theme: _ignoredTheme, ...props}: any) => <div {...props} />
+    const Link = ({theme: _ignoredTheme, ...props}: Record<string, unknown>) => <div {...props} />
     expect(render(<Breadcrumb.Item as={Link} to="#" />)).toMatchSnapshot()
   })
 })

--- a/src/__tests__/Pagination/PaginationModel.tsx
+++ b/src/__tests__/Pagination/PaginationModel.tsx
@@ -1,11 +1,13 @@
 import 'babel-polyfill'
 import {buildPaginationModel} from '../../Pagination/model'
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function first(array: Array<any>, count = 1) {
   const slice = array.slice(0, count)
   return count === 1 ? slice[0] : slice
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function last(array: Array<any>, count = 1) {
   const len = array.length
   const slice = array.slice(len - count, len)

--- a/src/__tests__/SelectMenu.tsx
+++ b/src/__tests__/SelectMenu.tsx
@@ -13,6 +13,7 @@ const BasicSelectMenu = ({
   align = 'left'
 }: {
   onClick?: SelectMenuItemProps['onClick']
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   as?: any
   align?: SelectMenuModalProps['align']
 }) => {

--- a/src/__tests__/SubNavLink.tsx
+++ b/src/__tests__/SubNavLink.tsx
@@ -26,7 +26,7 @@ describe('SubNav.Link', () => {
   })
 
   it('adds activeClassName={SELECTED_CLASS} when it gets a "to" prop', () => {
-    const Link = ({theme: _ignoredTheme, ...props}: any) => <div {...props} />
+    const Link = ({theme: _ignoredTheme, ...props}: Record<string, unknown>) => <div {...props} />
     expect(render(<SubNav.Link as={Link} to="#" />)).toMatchSnapshot()
   })
 })

--- a/src/__tests__/UnderlineNavLink.tsx
+++ b/src/__tests__/UnderlineNavLink.tsx
@@ -26,7 +26,7 @@ describe('UnderlineNav.Link', () => {
   })
 
   it('adds activeClassName={SELECTED_CLASS} when it gets a "to" prop', () => {
-    const Link = ({theme: _ignoredTheme, ...props}: any) => <div {...props} />
+    const Link = ({theme: _ignoredTheme, ...props}: Record<string, unknown>) => <div {...props} />
     expect(render(<UnderlineNav.Link as={Link} to="#" />)).toMatchSnapshot()
   })
 })

--- a/src/__tests__/filterObject.ts
+++ b/src/__tests__/filterObject.ts
@@ -39,7 +39,7 @@ describe('filterObject', () => {
       }
     }
 
-    expect(filterObject(colors, (value: any) => isColorValue(value))).toEqual(expected)
+    expect(filterObject(colors, (value: unknown) => isColorValue(value))).toEqual(expected)
   })
 
   it('filters out color values', () => {
@@ -49,6 +49,6 @@ describe('filterObject', () => {
       }
     }
 
-    expect(filterObject(colors, (value: any) => isShadowValue(value))).toEqual(expected)
+    expect(filterObject(colors, (value: unknown) => isShadowValue(value))).toEqual(expected)
   })
 })

--- a/src/hooks/useSafeTimeout.ts
+++ b/src/hooks/useSafeTimeout.ts
@@ -1,6 +1,6 @@
 import {useCallback, useEffect, useRef} from 'react'
 
-type SetTimeout = (handler: TimerHandler, timeout?: number, ...args: any[]) => number
+type SetTimeout = (handler: TimerHandler, timeout?: number, ...args: unknown[]) => number
 type ClearTimeout = (id: number) => void
 
 /**
@@ -11,11 +11,14 @@ type ClearTimeout = (id: number) => void
 export default function useSafeTimeout(): {safeSetTimeout: SetTimeout; safeClearTimeout: ClearTimeout} {
   const timers = useRef<Set<number>>(new Set<number>())
 
-  const safeSetTimeout = useCallback((handler: TimerHandler, timeout?: number | undefined, ...args: any[]): number => {
-    const id = window.setTimeout(handler, timeout, ...args)
-    timers.current.add(id)
-    return id
-  }, [])
+  const safeSetTimeout = useCallback(
+    (handler: TimerHandler, timeout?: number | undefined, ...args: unknown[]): number => {
+      const id = window.setTimeout(handler, timeout, ...args)
+      timers.current.add(id)
+      return id
+    },
+    []
+  )
 
   const safeClearTimeout = useCallback((id: number) => {
     clearTimeout(id)

--- a/src/stories/useFocusZone.stories.tsx
+++ b/src/stories/useFocusZone.stories.tsx
@@ -447,7 +447,7 @@ export const ActiveDescendant = () => {
     bindKeys: FocusKeys.ArrowVertical,
     onActiveDescendantChanged: (current, previous) => {
       if (current) {
-        current.style.outline = `2px solid ${theme.colors.border.info}`
+        current.style.outline = `2px solid ${theme?.colors.border.info}`
       }
       if (previous) {
         previous.style.outline = ''

--- a/src/utils/isNumeric.tsx
+++ b/src/utils/isNumeric.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export default function isNumeric(n: any) {
   return !isNaN(parseFloat(n)) && isFinite(n)
 }

--- a/src/utils/testing.tsx
+++ b/src/utils/testing.tsx
@@ -6,6 +6,8 @@ import Adapter from '@wojtekmaj/enzyme-adapter-react-17'
 import {ThemeProvider} from '..'
 import {default as defaultTheme} from '../theme'
 
+type ComputedStyles = Record<string, string | Record<string, string>>
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const readFile = promisify(require('fs').readFile)
 
@@ -85,18 +87,18 @@ export function percent(value: number | string): string {
   return typeof value === 'number' ? `${value}%` : value
 }
 
-export function renderStyles(node: React.ReactElement): any {
+export function renderStyles(node: React.ReactElement) {
   const {
     props: {className}
   } = render(node)
   return getComputedStyles(className)
 }
 
-export function getComputedStyles(className: string): Record<string, string | Record<string, string>> {
+export function getComputedStyles(className: string) {
   const div = document.createElement('div')
   div.className = className
 
-  const computed = {} as any
+  const computed: ComputedStyles = {}
   for (const sheet of document.styleSheets) {
     // CSSRulesLists assumes every rule is a CSSRule, not a CSSStyleRule
     for (const rule of sheet.cssRules) {
@@ -123,7 +125,7 @@ export function getComputedStyles(className: string): Record<string, string | Re
     }
   }
 
-  function readRule(rule: CSSStyleRule, dest: any) {
+  function readRule(rule: CSSStyleRule, dest: ComputedStyles) {
     if (matchesSafe(div, rule.selectorText)) {
       const {style} = rule
       for (let i = 0; i < style.length; i++) {
@@ -196,8 +198,9 @@ interface Options {
 }
 
 interface BehavesAsComponent {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   Component: React.ComponentType<any>
-  systemPropArray: any[]
+  systemPropArray: unknown[]
   toRender?: () => React.ReactElement
   options?: Options
 }
@@ -230,6 +233,7 @@ export function behavesAsComponent({Component, toRender, options}: BehavesAsComp
   })
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function checkExports(path: string, exports: Record<any, any>): void {
   it('has declared exports', () => {
     // eslint-disable-next-line @typescript-eslint/no-var-requires


### PR DESCRIPTION
@smockle pointed out that #1145 allows `any` without any warnings from eslint.  I agree that this is a bad practice, so this PR adds the lint rule back as an error (not just a warning as it is by default).  I tried to add correct types where possible, and used inline eslint disables everywhere else.  