### PR TITLE
Check default portal still exists before using it

### DIFF
--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -12,19 +12,18 @@ const portalRootRegistry: {[key: string]: Element} = {}
  * @param name The name of the container, to be used with the `containerName` prop on the Portal Component.
  * If name is not specified, registers the default portal root.
  */
-export function registerPortalRoot(root: Element | undefined, name?: string): void {
-  if (root instanceof Element) {
-    portalRootRegistry[name ?? DEFAULT_PORTAL_CONTAINER_NAME] = root
-  } else {
-    delete portalRootRegistry[name ?? DEFAULT_PORTAL_CONTAINER_NAME]
-  }
+export function registerPortalRoot(root: Element, name = DEFAULT_PORTAL_CONTAINER_NAME): void {
+  portalRootRegistry[name] = root
 }
 
 // Ensures that a default portal root exists and is registered. If a DOM element exists
-// with id __primerPortalRoot__, allow that element to serve as the default portl root.
+// with id __primerPortalRoot__, allow that element to serve as the default portal root.
 // Otherwise, create that element and attach it to the end of document.body.
 function ensureDefaultPortal() {
-  if (!(DEFAULT_PORTAL_CONTAINER_NAME in portalRootRegistry)) {
+  if (
+    !(DEFAULT_PORTAL_CONTAINER_NAME in portalRootRegistry) ||
+    !document.body.contains(portalRootRegistry[DEFAULT_PORTAL_CONTAINER_NAME])
+  ) {
     let defaultPortalContainer = document.getElementById(PRIMER_PORTAL_ROOT_ID)
     if (!(defaultPortalContainer instanceof Element)) {
       defaultPortalContainer = document.createElement('div')
@@ -36,7 +35,8 @@ function ensureDefaultPortal() {
         document.body.appendChild(defaultPortalContainer)
       }
     }
-    portalRootRegistry[DEFAULT_PORTAL_CONTAINER_NAME] = defaultPortalContainer
+
+    registerPortalRoot(defaultPortalContainer)
   }
 }
 

--- a/src/__tests__/Portal.tsx
+++ b/src/__tests__/Portal.tsx
@@ -5,10 +5,6 @@ import React from 'react'
 import BaseStyles from '../BaseStyles'
 
 describe('Portal', () => {
-  afterEach(() => {
-    // since the registry is global, reset after each test
-    registerPortalRoot(undefined)
-  })
   it('renders a default portal into document.body (no BaseStyles present)', () => {
     const {baseElement} = render(<Portal>123test123</Portal>)
     const generatedRoot = baseElement.querySelector('#__primerPortalRoot__')

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -3,7 +3,6 @@ import React, {useState, useRef} from 'react'
 import {Meta} from '@storybook/react'
 import styled from 'styled-components'
 
-import {registerPortalRoot} from '../Portal'
 import {BaseStyles, Overlay, Button, Text, ButtonDanger, ThemeProvider, Position, Flex} from '..'
 
 export default {
@@ -11,9 +10,6 @@ export default {
   component: Overlay,
   decorators: [
     Story => {
-      // Since portal roots are registered globally, we need this line so that each storybook
-      // story works in isolation.
-      registerPortalRoot(undefined)
       return (
         <ThemeProvider>
           <BaseStyles>

--- a/src/stories/Portal.stories.tsx
+++ b/src/stories/Portal.stories.tsx
@@ -10,9 +10,6 @@ export default {
   component: Portal,
   decorators: [
     Story => {
-      // Since portal roots are registered globally, we need this line so that each storybook
-      // story works in isolation.
-      registerPortalRoot(undefined)
       return (
         <ThemeProvider>
           <BaseStyles>


### PR DESCRIPTION
The default portal root is cached by default if no name/element is provided.  This is a problem in Storybook because the DOM gets cleared out when switching between stories, but the global javascript context is not reset.  Calling `registerPortalRoot(undefined)` was the previous workaround, but this is an extra step that is easy to overlook.

This change adds a sanity check to verify not just that we have a default root _cached_, but also that the cached root is _still in the body_.  I played around with `MutationObserver` some, but the observer has to observe the _parent_ to know when children are removed, and if the _parent_ gets removed too, the observer never fires.

Now that we don't need to manually reset the root, I removed `undefined` as an option from `registerPortalRoot`.  Let me know if you think that will be an issue anywhere else.

### Merge checklist
- [x] Added/updated tests

