### PR TITLE
fix: Resolve Storybook deprecation warnings

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,10 +1,11 @@
-import {addons} from "@storybook/addons"
+import {addons} from '@storybook/addons'
+
+addons.setConfig({
+  // Some stories may set up keyboard event handlers, which can can be interfered
+  // with by these keyboard shortcuts.
+  enableShortcuts: false
+})
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  options: {
-    // Some stories may set up keyboard event handlers, which can can be interfered
-    // with by these keyboard shortcuts.
-    enableShortcuts: false
-  }
+  actions: {argTypesRegex: '^on[A-Z].*'}
 }

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -36,7 +36,7 @@ const meta: Meta = {
   ],
   parameters: {
     controls: {
-      disabled: true
+      disable: true
     }
   }
 }


### PR DESCRIPTION
This PR resolves the following deprecation warnings logged to console by Storybook:

```
Use 'parameters.key.disable' instead of 'parameters.key.disabled'.

https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-disabled-parameter
```

```
parameters.options.enableShortcuts is deprecated and will be removed in Storybook 7.0.
To change this setting, use `addons.setConfig`. See https://github.com/storybookjs/storybook/blob/next/MIGRATION.md#deprecated-immutable-options-parameters
```