### PR TITLE
Remove d.ts checkbox from pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,6 @@ Closes # (type the issue number after # if applicable; otherwise remove this lin
 Please provide before/after screenshots for any visual changes
 
 ### Merge checklist
-- [ ] Added or updated TypeScript definitions (`index.d.ts`) if necessary
 - [ ] Added/updated tests
 - [ ] Added/updated documentation
 - [ ] Tested in Chrome


### PR DESCRIPTION
No longer need a checkbox for updating `index.d.ts` now that #1147 has been merged

### Merge checklist
- [x] ~~Added or updated TypeScript definitions (`index.d.ts`) if necessary~~
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
