### PR TITLE
Fix `as` prop definition in TextInput

### DIFF
--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -122,7 +122,8 @@ const Wrapper = styled.span<StyledWrapperProps>`
 `
 
 type TextInputInternalProps = {
-  as?: string | React.ComponentType<unknown> // This is a band-aid fix until we have better type support for the `as` prop
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  as?: string | React.ComponentType<any> // This is a band-aid fix until we have better type support for the `as` prop
   icon?: React.ComponentType<{className?: string}>
 } & ComponentProps<typeof Wrapper> &
   ComponentProps<typeof Input>

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -122,7 +122,7 @@ const Wrapper = styled.span<StyledWrapperProps>`
 `
 
 type TextInputInternalProps = {
-  as?: React.ReactElement // This is a band-aid fix until we have better type support for the `as` prop
+  as?: string | React.ComponentType<unknown> // This is a band-aid fix until we have better type support for the `as` prop
   icon?: React.ComponentType<{className?: string}>
 } & ComponentProps<typeof Wrapper> &
   ComponentProps<typeof Input>

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -123,7 +123,7 @@ const Wrapper = styled.span<StyledWrapperProps>`
 
 type TextInputInternalProps = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  as?: string | React.ComponentType<any> // This is a band-aid fix until we have better type support for the `as` prop
+  as?: any // This is a band-aid fix until we have better type support for the `as` prop
   icon?: React.ComponentType<{className?: string}>
 } & ComponentProps<typeof Wrapper> &
   ComponentProps<typeof Input>

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -121,7 +121,10 @@ const Wrapper = styled.span<StyledWrapperProps>`
   ${sx};
 `
 
-type TextInputInternalProps = {icon?: React.ComponentType<{className?: string}>} & ComponentProps<typeof Wrapper> &
+type TextInputInternalProps = {
+  as?: React.ReactElement // This is a band-aid fix until we have better type support for the `as` prop
+  icon?: React.ComponentType<{className?: string}>
+} & ComponentProps<typeof Wrapper> &
   ComponentProps<typeof Input>
 
 // using forwardRef is important so that other components (ex. SelectMenu) can autofocus the input

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,12 +5,12 @@
  *
  * @example ComponentProps<typeof MyComponent>
  */
-export type ComponentProps<T> = T extends React.ComponentType<infer Props>
+export type ComponentProps<T> = (T extends React.ComponentType<infer Props>
   ? // eslint-disable-next-line @typescript-eslint/ban-types
     Props extends object
     ? Props
     : never
-  : never
+  : never) & {as?: React.ElementType} // This is a bandaid until we have better type support for the `as` prop
 
 /**
  * Contruct a type describing the items in `T`, if `T` is an array.

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,12 +5,12 @@
  *
  * @example ComponentProps<typeof MyComponent>
  */
-export type ComponentProps<T> = (T extends React.ComponentType<infer Props>
+export type ComponentProps<T> = T extends React.ComponentType<infer Props>
   ? // eslint-disable-next-line @typescript-eslint/ban-types
     Props extends object
     ? Props
     : never
-  : never) & {as?: React.ElementType} // This is a bandaid until we have better type support for the `as` prop
+  : never
 
 /**
  * Contruct a type describing the items in `T`, if `T` is an array.


### PR DESCRIPTION
## Problem

The `ComponentProps<>` utility that we used to extract prop types from styled-components doesn't correctly extract the `as` prop.

`TextInput` relys `ComponentProps<>` to define the `as` prop. This causes causes errors in consuming applications that use the `as` prop with `TextInpt`:

![image](https://user-images.githubusercontent.com/4608155/114081311-3d24be80-9861-11eb-8348-e1d0f4644703.png)

## Solution

This PR adds a band-aid fix to the `TextInput` component to define the `as` prop.

We still need a long-term solution for typing components that support the `as` prop.

