### PR TITLE
Use github recommended lint in typescript files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,9 @@
     "plugin:react/recommended",
     "plugin:jsx-a11y/recommended",
     "plugin:react-hooks/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:github/recommended",
+    "plugin:github/browser"
   ],
   "ignorePatterns": [
     "node_modules",
@@ -41,28 +43,58 @@
     "react/prop-types": 0,
     "react/display-name": 0,
     "react-hooks/exhaustive-deps": "error",
-    "jsx-a11y/label-has-for": [2, {"components": []}]
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "components": []
+      }
+    ],
+    "camelcase": [
+      "error",
+      {
+        "allow": [
+          "dark_dimmed"
+        ]
+      }
+    ]
   },
   "overrides": [
     // rules which apply only to JS
     {
-      "files": ["**/*.js", "**/*.jsx"],
-      "extends": ["plugin:github/recommended", "plugin:github/browser"],
+      "files": [
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "rules": {
         "eslint-comments/no-use": 0,
         "import/no-namespace": 0,
         "no-shadow": 0,
-        "no-unused-vars": ["error", {"ignoreRestSiblings": true}]
+        "no-unused-vars": [
+          "error",
+          {
+            "ignoreRestSiblings": true
+          }
+        ]
       }
     },
     // rules which apply only to TS
     {
-      "files": ["**/*.ts", "**/*.tsx"],
-      "extends": ["plugin:@typescript-eslint/recommended"],
+      "files": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
+      "extends": [
+        "plugin:@typescript-eslint/recommended"
+      ],
       "rules": {
         "@typescript-eslint/no-explicit-any": 2,
         "@typescript-eslint/explicit-module-boundary-types": 0,
-        "@typescript-eslint/no-unused-vars": ["error", {"argsIgnorePattern": "^_"}]
+        "@typescript-eslint/no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_"
+          }
+        ]
       }
     }
   ]

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -155,7 +155,7 @@ export function List(props: ListProps): JSX.Element {
      * A map of group identifiers to `Group`s, each with an associated array of `Item`s belonging to that `Group`.
      */
     const groupMap = props.groupMetadata.reduce(
-      (groups, groupMetadata) => groups.set(groupMetadata.groupId, groupMetadata),
+      (groupAccumulator, groupMetadata) => groupAccumulator.set(groupMetadata.groupId, groupMetadata),
       new Map<string, GroupProps | (Partial<GroupProps> & {renderItem?: typeof Item; renderGroup?: typeof Group})>()
     )
 

--- a/src/ActionList/index.ts
+++ b/src/ActionList/index.ts
@@ -1,10 +1,10 @@
 import {List} from './List'
-export type {ListProps as ActionListProps} from './List'
 import {Group} from './Group'
-export type {GroupProps} from './Group'
 import {Item} from './Item'
-export type {ItemProps} from './Item'
 import {Divider} from './Divider'
+export type {ListProps as ActionListProps} from './List'
+export type {GroupProps} from './Group'
+export type {ItemProps} from './Item'
 
 /**
  * Collection of list-related components.

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -129,4 +129,4 @@ const ActionMenuBase = ({
 
 ActionMenuBase.displayName = 'ActionMenu'
 
-export const ActionMenu = Object.assign(ActionMenuBase, {Divider: Divider, Item: ActionMenuItem})
+export const ActionMenu = Object.assign(ActionMenuBase, {Divider, Item: ActionMenuItem})

--- a/src/Breadcrumb.tsx
+++ b/src/Breadcrumb.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import styled, {css} from 'styled-components'
 import {BORDER, COMMON, get, SystemBorderProps, SystemCommonProps, SystemTypographyProps, TYPOGRAPHY} from './constants'

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -63,7 +63,7 @@ export const Portal: React.FC<PortalProps> = ({children, onMount, containerName:
 
   React.useLayoutEffect(() => {
     let containerName = _containerName
-    if (containerName == undefined) {
+    if (containerName === undefined) {
       containerName = DEFAULT_PORTAL_CONTAINER_NAME
       ensureDefaultPortal()
     }

--- a/src/SelectMenu/SelectMenu.tsx
+++ b/src/SelectMenu/SelectMenu.tsx
@@ -110,7 +110,7 @@ export type {SelectMenuTabProps} from './SelectMenuTab'
 export type {SelectMenuTabPanelProps} from './SelectMenuTabPanel'
 export type {SelectMenuTabsProps} from './SelectMenuTabs'
 export default Object.assign(SelectMenu, {
-  MenuContext: MenuContext,
+  MenuContext,
   List: SelectMenuList,
   Divider: SelectMenuDivider,
   Filter: SelectMenuFilter,

--- a/src/SelectMenu/SelectMenuFilter.tsx
+++ b/src/SelectMenu/SelectMenuFilter.tsx
@@ -25,7 +25,7 @@ type SelectMenuFilterInternalProps = {
 } & TextInputProps
 
 const SelectMenuFilter = forwardRef<HTMLInputElement, SelectMenuFilterInternalProps>(
-  ({theme, value, sx, ...rest}, forwardedRef) => {
+  ({theme, value, sx: sxProp, ...rest}, forwardedRef) => {
     const inputRef = useRef<HTMLInputElement>(null)
     const ref = forwardedRef ?? inputRef
     const {open} = useContext(MenuContext)
@@ -38,7 +38,7 @@ const SelectMenuFilter = forwardRef<HTMLInputElement, SelectMenuFilterInternalPr
     }, [open])
 
     return (
-      <StyledForm theme={theme} sx={sx}>
+      <StyledForm theme={theme} sx={sxProp}>
         <TextInput theme={theme} ref={ref} width="100%" block value={value} contrast {...rest} />
       </StyledForm>
     )

--- a/src/SelectMenu/SelectMenuModal.tsx
+++ b/src/SelectMenu/SelectMenuModal.tsx
@@ -99,10 +99,10 @@ const ModalWrapper = styled.div<StyledModalWrapperProps>`
 type SelectMenuModalInternalProps = Pick<StyledModalProps, 'width'> & ComponentProps<typeof ModalWrapper>
 
 const SelectMenuModal = React.forwardRef<HTMLDivElement, SelectMenuModalInternalProps>(
-  ({children, theme, width, ...rest}, forwardedRef) => {
+  ({children, theme, width: widthProp, ...rest}, forwardedRef) => {
     return (
       <ModalWrapper theme={theme} {...rest} role="menu" ref={forwardedRef}>
-        <Modal theme={theme} width={width}>
+        <Modal theme={theme} width={widthProp}>
           {children}
         </Modal>
       </ModalWrapper>

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import React from 'react'
 import styled, {css} from 'styled-components'

--- a/src/StateLabel.tsx
+++ b/src/StateLabel.tsx
@@ -92,10 +92,10 @@ const StateLabelBase = styled.span<StyledStateLabelBaseProps>`
 
 export type StateLabelProps = ComponentProps<typeof StateLabelBase>
 
-function StateLabel({children, status, variant, ...rest}: StateLabelProps) {
-  const octiconProps = variant === 'small' ? {width: '1em'} : {}
+function StateLabel({children, status, variant: variantProp, ...rest}: StateLabelProps) {
+  const octiconProps = variantProp === 'small' ? {width: '1em'} : {}
   return (
-    <StateLabelBase {...rest} variant={variant} status={status}>
+    <StateLabelBase {...rest} variant={variantProp} status={status}>
       {status && <StyledOcticon mr={1} {...octiconProps} icon={octiconMap[status] || QuestionIcon} />}
       {children}
     </StateLabelBase>

--- a/src/SubNav.tsx
+++ b/src/SubNav.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/src/TabNav.tsx
+++ b/src/TabNav.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/src/TextInput.tsx
+++ b/src/TextInput.tsx
@@ -130,7 +130,7 @@ type TextInputInternalProps = {
 
 // using forwardRef is important so that other components (ex. SelectMenu) can autofocus the input
 const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
-  ({icon: IconComponent, contrast, className, block, disabled, theme, sx, ...rest}, ref) => {
+  ({icon: IconComponent, contrast, className, block, disabled, theme, sx: sxProp, ...rest}, ref) => {
     // this class is necessary to style FilterSearch, plz no touchy!
     const wrapperClasses = classnames(className, 'TextInput-wrapper')
     const wrapperProps = pick(rest)
@@ -143,7 +143,7 @@ const TextInput = React.forwardRef<HTMLInputElement, TextInputInternalProps>(
         theme={theme}
         disabled={disabled}
         contrast={contrast}
-        sx={sx}
+        sx={sxProp}
         {...wrapperProps}
       >
         {IconComponent && <IconComponent className="TextInput-icon" />}

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -104,8 +104,7 @@ function useSystemColorMode() {
 
     function handleChange(event: MediaQueryListEvent) {
       const isNight = event.matches
-      const systemColorMode = isNight ? 'night' : 'day'
-      setSystemColorMode(systemColorMode)
+      setSystemColorMode(isNight ? 'night' : 'day')
     }
 
     media?.addEventListener('change', handleChange)
@@ -150,6 +149,7 @@ function applyColorScheme(theme: Theme, colorScheme: string) {
   }
 
   if (!theme.colorSchemes[colorScheme]) {
+    // eslint-disable-next-line no-console
     console.error(`\`${colorScheme}\` scheme not defined in \`theme.colorSchemes\``)
     return theme
   }

--- a/src/UnderlineNav.tsx
+++ b/src/UnderlineNav.tsx
@@ -1,4 +1,5 @@
 import classnames from 'classnames'
+// eslint-disable-next-line import/no-namespace
 import * as History from 'history'
 import React from 'react'
 import styled from 'styled-components'

--- a/src/__tests__/.eslintrc.json
+++ b/src/__tests__/.eslintrc.json
@@ -1,5 +1,8 @@
 {
   "extends": [
     "plugin:jest/recommended"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-non-null-assertion": 0
+  }
 }

--- a/src/__tests__/Dialog.tsx
+++ b/src/__tests__/Dialog.tsx
@@ -91,7 +91,6 @@ describe('Dialog', () => {
   it('should have no axe violations', async () => {
     const spy = jest.spyOn(console, 'warn').mockImplementation()
     const {container} = HTMLRender(comp)
-    // eslint-disable-next-line no-console
     spy.mockRestore()
     const results = await axe(container)
     expect(results).toHaveNoViolations()

--- a/src/__tests__/Portal.tsx
+++ b/src/__tests__/Portal.tsx
@@ -60,7 +60,6 @@ describe('Portal', () => {
     const portalRoot = baseElement.querySelector('#myPortalRoot')
     expect(portalRoot).toBeInstanceOf(HTMLElement)
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     registerPortalRoot(baseElement.querySelector('#myPortalRoot')!)
 
     const toRender = <Portal>123test123</Portal>
@@ -83,9 +82,7 @@ describe('Portal', () => {
     expect(fancyPortalRoot1).toBeInstanceOf(HTMLElement)
     expect(fancyPortalRoot2).toBeInstanceOf(HTMLElement)
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     registerPortalRoot(baseElement.querySelector('#myPortalRoot1')!, 'fancyPortal1')
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     registerPortalRoot(baseElement.querySelector('#myPortalRoot2')!, 'fancyPortal2')
 
     const toRender = (

--- a/src/__tests__/behaviors/anchoredPosition.ts
+++ b/src/__tests__/behaviors/anchoredPosition.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {getAnchoredPosition, PositionSettings} from '../../behaviors/anchoredPosition'
 
 /*
@@ -37,12 +36,13 @@ function createVirtualDOM(
   const parent = document.createElement('div')
   parent.style.overflow = 'hidden'
   parent.style.position = 'relative'
-  parent.style.borderTopWidth = parentBorders.top + 'px'
-  parent.style.borderRightWidth = parentBorders.right + 'px'
-  parent.style.borderBottomWidth = parentBorders.bottom + 'px'
-  parent.style.borderLeftWidth = parentBorders.left + 'px'
+  parent.style.borderTopWidth = `${parentBorders.top}px`
+  parent.style.borderRightWidth = `${parentBorders.right}px`
+  parent.style.borderBottomWidth = `${parentBorders.bottom}px`
+  parent.style.borderLeftWidth = `${parentBorders.left}px`
   parent.id = 'parent'
-  parent.innerHTML = `<div id="float"></div><div id="anchor"></div>`
+  // eslint-disable-next-line github/unescaped-html-literal
+  parent.innerHTML = '<div id="float"></div><div id="anchor"></div>'
   const float = parent.querySelector('#float')!
   const anchor = parent.querySelector('#anchor')!
   anchor.getBoundingClientRect = () => anchorRect
@@ -55,7 +55,8 @@ describe('getAnchoredPosition', () => {
   it('returns the correct position in the default case with no overflow', () => {
     const anchorRect = makeDOMRect(300, 200, 50, 50)
     const floatingRect = makeDOMRect(NaN, NaN, 100, 100)
-    document.body.innerHTML = `<div id="float"></div><div id="anchor"></div>`
+    // eslint-disable-next-line github/unescaped-html-literal
+    document.body.innerHTML = '<div id="float"></div><div id="anchor"></div>'
     const float = document.querySelector('#float')!
     const anchor = document.querySelector('#anchor')!
     float.getBoundingClientRect = () => floatingRect

--- a/src/__tests__/behaviors/focusTrap.tsx
+++ b/src/__tests__/behaviors/focusTrap.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import {fireEvent, render} from '@testing-library/react'
 import {focusTrap} from '../../behaviors/focusTrap'
@@ -18,7 +17,9 @@ beforeAll(() => {
         get: () => () => [42]
       }
     })
-  } catch {}
+  } catch {
+    // ignore
+  }
 })
 
 it('Should initially focus the first focusable element when activated', () => {

--- a/src/__tests__/behaviors/focusZone.tsx
+++ b/src/__tests__/behaviors/focusZone.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import {render} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -24,7 +22,9 @@ beforeAll(() => {
         get: () => () => [42]
       }
     })
-  } catch {}
+  } catch {
+    // ignore
+  }
 })
 
 it('Should allow arrow keys to move focus', () => {
@@ -173,18 +173,10 @@ it('Should call custom getNextFocusable callback', () => {
   expect(document.activeElement).toEqual(firstButton)
 
   userEvent.type(firstButton, '{arrowdown}')
-  expect(getNextFocusableCallback).toHaveBeenCalledWith<[string, HTMLElement, any]>(
-    'next',
-    firstButton,
-    expect.anything()
-  )
+  expect(getNextFocusableCallback).toHaveBeenCalledWith('next', firstButton, expect.anything())
 
   userEvent.type(secondButton, '{home}')
-  expect(getNextFocusableCallback).toHaveBeenCalledWith<[string, HTMLElement, any]>(
-    'start',
-    secondButton,
-    expect.anything()
-  )
+  expect(getNextFocusableCallback).toHaveBeenCalledWith('start', secondButton, expect.anything())
 
   controller.abort()
 })

--- a/src/__tests__/behaviors/iterateFocusableElements.tsx
+++ b/src/__tests__/behaviors/iterateFocusableElements.tsx
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/anchor-is-valid */
-/* eslint-disable jsx-a11y/no-noninteractive-tabindex */
-
 import React from 'react'
 import {iterateFocusableElements} from '../../utils/iterateFocusableElements'
 import {render} from '@testing-library/react'
@@ -14,6 +11,7 @@ it('Should iterate through focusable elements only', () => {
       <input />
       <button>Hello</button>
       <p>Not focusable</p>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
       <div tabIndex={0}>
         <a tabIndex={-1} href="#boo">
           Not focusable
@@ -42,6 +40,7 @@ it('Should iterate through focusable elements in reverse', () => {
       <input />
       <button>Hello</button>
       <p>Not focusable</p>
+      {/* eslint-disable-next-line jsx-a11y/no-noninteractive-tabindex */}
       <div tabIndex={0}>
         <a tabIndex={-1} href="#boo">
           Not focusable

--- a/src/__tests__/hooks/useOnOutsideClick.tsx
+++ b/src/__tests__/hooks/useOnOutsideClick.tsx
@@ -10,7 +10,7 @@ const Component = ({callback}: ComponentProps) => {
   const containerRef = useRef<HTMLDivElement>(null)
   const outerButton = useRef<HTMLButtonElement>(null)
   const secondButton = useRef<HTMLButtonElement>(null)
-  useOnOutsideClick({ignoreClickRefs: [secondButton], containerRef: containerRef, onClickOutside: callback})
+  useOnOutsideClick({ignoreClickRefs: [secondButton], containerRef, onClickOutside: callback})
   return (
     <div>
       <button ref={outerButton}>button</button>

--- a/src/behaviors/anchoredPosition.ts
+++ b/src/behaviors/anchoredPosition.ts
@@ -154,7 +154,7 @@ export function getAnchoredPosition(
  */
 function getPositionedParent(element: Element) {
   let parentNode = element.parentNode
-  while (parentNode != undefined) {
+  while (parentNode !== null) {
     if (parentNode instanceof HTMLElement && getComputedStyle(parentNode).position !== 'static') {
       return parentNode
     }
@@ -171,7 +171,7 @@ function getPositionedParent(element: Element) {
  */
 function getClippingRect(element: Element): BoxPosition {
   let parentNode: typeof element.parentNode = element
-  while (parentNode != undefined) {
+  while (parentNode !== null) {
     if (parentNode === document.body) {
       break
     }

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -87,6 +87,7 @@ export function focusTrap(
             return
           } else {
             // no element focusable within trap, blur the external element instead
+            // eslint-disable-next-line github/no-blur
             focusedElement.blur()
           }
         }

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -26,6 +26,7 @@ export type FocusMovementKeys =
   | 'PageUp'
   | 'PageDown'
 
+// eslint-disable-next-line no-shadow
 export enum FocusKeys {
   // Left and right arrow keys (previous and next, respectively)
   ArrowHorizontal = 0b000000001,
@@ -494,7 +495,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
         if (event.target instanceof HTMLElement) {
           // If a click initiated the focus movement, we always want to set our internal state
           // to reflect the clicked element as the currently focused one.
-          if (elementIndexFocusedByClick != undefined) {
+          if (elementIndexFocusedByClick !== undefined) {
             if (elementIndexFocusedByClick >= 0) {
               if (focusableElements[elementIndexFocusedByClick] !== currentFocusedElement) {
                 updateTabIndex(currentFocusedElement, focusableElements[elementIndexFocusedByClick])
@@ -536,7 +537,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
                   elementToFocus.focus()
                   return
                 } else {
-                  // Should we warn here?
+                  // eslint-disable-next-line no-console
                   console.warn('Element requested is not a known focusable element.')
                 }
               } else {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,5 @@
 import {themeGet} from '@styled-system/theme-get'
+// eslint-disable-next-line import/no-namespace
 import * as styledSystem from 'styled-system'
 import theme from './theme'
 

--- a/src/polyfills/eventListenerSignal.ts
+++ b/src/polyfills/eventListenerSignal.ts
@@ -17,7 +17,7 @@ try {
     {},
     {
       signal: {
-        get: function () {
+        get() {
           signalSupported = true
         }
       }

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -123,8 +123,8 @@ export function ComplexListStory(): JSX.Element {
                   )}
                 />
               ),
-              renderGroup: ({sx, ...props}) => (
-                <ActionList.Group {...props} sx={{...sx, backgroundColor: 'cornflowerblue', color: 'white'}} />
+              renderGroup: ({sx: sxProps, ...props}) => (
+                <ActionList.Group {...props} sx={{...sxProps, backgroundColor: 'cornflowerblue', color: 'white'}} />
               )
             }
           ]}
@@ -183,8 +183,8 @@ export function ComplexListStory(): JSX.Element {
                   )}
                 />
               ),
-              renderGroup: ({sx, ...props}) => (
-                <ActionList.Group {...props} sx={{...sx, backgroundColor: 'cornflowerblue', color: 'white'}} />
+              renderGroup: ({sx: sxProps, ...props}) => (
+                <ActionList.Group {...props} sx={{...sxProps, backgroundColor: 'cornflowerblue', color: 'white'}} />
               )
             }
           ]}

--- a/src/stories/Button.stories.tsx
+++ b/src/stories/Button.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React from 'react'
 import {Meta} from '@storybook/react'
 

--- a/src/stories/Overlay.stories.tsx
+++ b/src/stories/Overlay.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React, {useState, useRef} from 'react'
 import {Meta} from '@storybook/react'
 import styled from 'styled-components'

--- a/src/stories/Portal.stories.tsx
+++ b/src/stories/Portal.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React from 'react'
 import {Meta} from '@storybook/react'
 

--- a/src/stories/ThemeProvider.stories.tsx
+++ b/src/stories/ThemeProvider.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React from 'react'
 import {Meta, Story} from '@storybook/react'
 

--- a/src/stories/useAnchoredPosition.stories.tsx
+++ b/src/stories/useAnchoredPosition.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React from 'react'
 import {Meta} from '@storybook/react'
 import {BaseStyles, Box, ButtonPrimary, Position, Relative, ThemeProvider} from '..'

--- a/src/stories/useFocusTrap.stories.tsx
+++ b/src/stories/useFocusTrap.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React, {useCallback, useEffect} from 'react'
 import {Meta} from '@storybook/react'
 import styled, {createGlobalStyle} from 'styled-components'

--- a/src/stories/useFocusZone.stories.tsx
+++ b/src/stories/useFocusZone.stories.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React, {useCallback, useRef, useState} from 'react'
 import {Meta} from '@storybook/react'
 import styled, {createGlobalStyle} from 'styled-components'
@@ -409,7 +408,7 @@ export const ChangingSubtree = () => {
 
   const buttons: JSX.Element[] = []
   for (let i = 0; i < buttonCount; ++i) {
-    buttons.push(<MarginButton key={'button' + i}>{i + 1}</MarginButton>)
+    buttons.push(<MarginButton key={`button${i}`}>{i + 1}</MarginButton>)
   }
 
   return (
@@ -449,7 +448,7 @@ export const ActiveDescendant = () => {
 
   const containerRef = useRef<HTMLElement>(null)
   const controllingElementRef = useRef<HTMLElement>(null)
-  const {theme} = useTheme()
+  const {theme: themeFromContext} = useTheme()
 
   // We set up two arrow focus behaviors on the same container!
   // 1. Handles the active descendant treatment when the <input> element is focused
@@ -460,7 +459,7 @@ export const ActiveDescendant = () => {
     bindKeys: FocusKeys.ArrowVertical,
     onActiveDescendantChanged: (current, previous) => {
       if (current) {
-        current.style.outline = `2px solid ${theme?.colors.border.info}`
+        current.style.outline = `2px solid ${themeFromContext?.colors.border.info}`
       }
       if (previous) {
         previous.style.outline = ''

--- a/src/theme-preval.js
+++ b/src/theme-preval.js
@@ -108,7 +108,6 @@ const theme = {
       colors: darkColors,
       shadows: darkShadows
     },
-    // eslint-disable-next-line camelcase
     dark_dimmed: {
       colors: darkDimmedColors,
       shadows: darkDimmedShadows

--- a/src/utils/deprecate.tsx
+++ b/src/utils/deprecate.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import {useRef, useCallback} from 'react'
 declare let __DEV__: boolean
 
@@ -58,6 +57,7 @@ export class Deprecations {
 
   static deprecate({name, message, version}: DeprecationType) {
     const msg = `WARNING! ${name} is deprecated and will be removed in version ${version}. ${message}`
+    // eslint-disable-next-line no-console
     console.warn(msg)
 
     this.get().deprecations.push({name, message, version})

--- a/src/utils/test-matchers.tsx
+++ b/src/utils/test-matchers.tsx
@@ -46,7 +46,6 @@ expect.extend({
     }
 
     const elem = React.cloneElement(element, {sx: sxPropValue})
-    const rendered = render(elem)
 
     function checkStylesDeep(rendered: ReactTestRendererJSON): boolean {
       const className = rendered?.props ? rendered.props.className : ''
@@ -62,7 +61,7 @@ expect.extend({
     }
 
     return {
-      pass: checkStylesDeep(rendered),
+      pass: checkStylesDeep(render(elem)),
       message: () => 'sx prop values did not change styles of component nor of any sub-components'
     }
   },


### PR DESCRIPTION
One more eslint adjustment.  The GitHub recommended rules were only being applied in javascript.  This adds them to _all_ contexts, and fixes up all the errors that were found.