### PR TITLE
Run CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
   ci:
     name: CI
@@ -26,6 +26,7 @@ jobs:
         run: yarn test
 
       - name: Create .npmrc
+        if: github.repository == 'primer/components'
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -34,6 +35,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Publish canary version
+        if: github.repository == 'primer/components'
         run: |
           echo "$( jq '.version = "0.0.0"' package.json )" > package.json
           echo -e "---\n'@primer/components': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
@@ -43,6 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output canary version number
+        if: github.repository == 'primer/components'
         run: |
           name=$(jq -r .name package.json)
           version=$(jq -r .version package.json)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn test
 
       - name: Create .npmrc
-        if: github.repository == 'primer/components'
+        if: github.event_name == 'push'
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -35,7 +35,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Publish canary version
-        if: github.repository == 'primer/components'
+        if: github.event_name == 'push'
         run: |
           echo "$( jq '.version = "0.0.0"' package.json )" > package.json
           echo -e "---\n'@primer/components': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output canary version number
-        if: github.repository == 'primer/components'
+        if: github.event_name == 'push'
         run: |
           name=$(jq -r .name package.json)
           version=$(jq -r .version package.json)


### PR DESCRIPTION
This should allow CI to run when a pull request is opened/updated from a fork.  The main difference is that when it is triggered by the `pull_request` event (rather than `push`), the `GITHUB_TOKEN` is read only and all other secrets are not provided.  See [the docs](https://docs.github.com/en/enterprise-server@2.22/actions/reference/events-that-trigger-workflows#pull_request) for details.  

The main complication that this adds is we don't have access to `NPM_AUTH_TOKEN_SHARED` for canary versions.  This is fine, but I added a manual check to skip those steps so that the action doesn't fail when the secret isn't present.  I don't have a great way to test this check, so I guess we'll just see how it works when we get our next outside PR.