### PR TITLE
Replaces border.overlay with border.primary

### DIFF
--- a/.changeset/mean-wasps-return.md
+++ b/.changeset/mean-wasps-return.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Replaces border.overlay with border.primary

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -297,7 +297,7 @@ const _Dialog = React.forwardRef<HTMLDivElement, React.PropsWithChildren<DialogP
 _Dialog.displayName = 'Dialog'
 
 const Header = styled(Box).attrs({as: 'header'})`
-  box-shadow: 0 1px 0 ${get('colors.border.overlay')};
+  box-shadow: 0 1px 0 ${get('colors.border.primary')};
   padding: ${get('space.2')};
   z-index: 1;
   flex-shrink: 0;
@@ -317,7 +317,7 @@ const Body = styled(Box)`
   padding: ${get('space.3')};
 `
 const Footer = styled(Box).attrs({as: 'footer'})`
-  box-shadow: 0 -1px 0 ${get('colors.border.overlay')};
+  box-shadow: 0 -1px 0 ${get('colors.border.primary')};
   padding: ${get('space.3')};
   display: flex;
   flex-flow: wrap;

--- a/src/Dropdown.tsx
+++ b/src/Dropdown.tsx
@@ -57,7 +57,7 @@ type StyledDropdownMenuProps = {
 const DropdownMenu = styled.ul<StyledDropdownMenuProps>`
   background-clip: padding-box;
   background-color: ${get('colors.bg.overlay')};
-  border: 1px solid ${get('colors.border.overlay')};
+  border: 1px solid ${get('colors.border.primary')};
   border-radius: ${get('radii.2')};
   box-shadow: ${get('shadows.dropdown.shadow')};
   left: 0;

--- a/src/DropdownStyles.ts
+++ b/src/DropdownStyles.ts
@@ -16,7 +16,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         right: -16px;
         left: auto;
         border-color: transparent;
-        border-left-color: ${get('colors.border.overlay')(theme)};
+        border-left-color: ${get('colors.border.primary')(theme)};
       }
 
       &::after {
@@ -24,7 +24,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         right: -14px;
         left: auto;
         border-color: transparent;
-        border-left-color: ${get('colors.border.overlay')(theme)};
+        border-left-color: ${get('colors.border.primary')(theme)};
       }
     `,
     e: `
@@ -38,14 +38,14 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
         top: 10px;
         left: -16px;
         border-color: transparent;
-        border-right-color: ${get('colors.border.overlay')(theme)};
+        border-right-color: ${get('colors.border.primary')(theme)};
       }
 
       &::after {
         top: 11px;
         left: -14px;
         border-color: transparent;
-        border-right-color: ${get('colors.border.overlay')(theme)};
+        border-right-color: ${get('colors.border.primary')(theme)};
       }
     `,
     ne: `
@@ -63,7 +63,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
       &::before {
         bottom: -8px;
         left: 9px;
-        border-top: 8px solid ${get('colors.border.overlay')(theme)};
+        border-top: 8px solid ${get('colors.border.primary')(theme)};
         border-bottom: 0;
         border-left: 8px solid transparent;
       }
@@ -71,7 +71,7 @@ const getDirectionStyles = (theme: Theme, direction: 'ne' | 'e' | 'se' | 's' | '
       &::after {
         bottom: -7px;
         left: 10px;
-        border-top: 7px solid ${get('colors.border.overlay')(theme)};
+        border-top: 7px solid ${get('colors.border.primary')(theme)};
         border-right: 7px solid transparent;
         border-bottom: 0;
         border-left: 7px solid transparent;

--- a/src/Popover.tsx
+++ b/src/Popover.tsx
@@ -67,7 +67,7 @@ const PopoverContent = styled(BorderBox)`
     top: -${get('space.3')};
     margin-left: -9px;
     border: ${get('space.2')} solid transparent; // TODO: solid?
-    border-bottom-color: ${get('colors.border.overlay')};
+    border-bottom-color: ${get('colors.border.primary')};
   }
 
   &::after {
@@ -89,7 +89,7 @@ const PopoverContent = styled(BorderBox)`
 
     &::before {
       bottom: -${get('space.3')};
-      border-top-color: ${get('colors.border.overlay')};
+      border-top-color: ${get('colors.border.primary')};
     }
 
     &::after {
@@ -168,7 +168,7 @@ const PopoverContent = styled(BorderBox)`
   ${Popover}.caret-pos--right-bottom & {
     &::before {
       right: -${get('space.3')};
-      border-left-color: ${get('colors.border.overlay')};
+      border-left-color: ${get('colors.border.primary')};
     }
 
     &::after {
@@ -184,7 +184,7 @@ const PopoverContent = styled(BorderBox)`
   ${Popover}.caret-pos--left-bottom & {
     &::before {
       left: -${get('space.3')};
-      border-right-color: ${get('colors.border.overlay')};
+      border-right-color: ${get('colors.border.primary')};
     }
 
     &::after {

--- a/src/SelectMenu/SelectMenuModal.tsx
+++ b/src/SelectMenu/SelectMenuModal.tsx
@@ -42,7 +42,7 @@ const modalStyles = css<StyledModalProps>`
     max-height: 350px;
     margin: ${get('space.1')} 0 ${get('space.3')} 0;
     font-size: ${get('fontSizes.0')};
-    border: ${get('borderWidths.1')} solid ${get('colors.border.overlay')};
+    border: ${get('borderWidths.1')} solid ${get('colors.border.primary')};
     border-radius: ${get('radii.2')};
     box-shadow: ${get('shadows.shadow.small')};
   }


### PR DESCRIPTION
The `border.overlay` will be removed from https://github.com/primer/primitives/pull/82. In preparation for that change, this PR replaces `border.overlay` with `border.primary`. There should be no visual change since both variables use the same color.

Is this a breaking change? I couldn't find where the `border.overlay` color is defined. Does it come directly from `primer/primitives`? If so, I guess this PR is just a "patch". But once https://github.com/primer/primitives/pull/82 is merged and part of the next major release of `primer/primitives`, then we'd have to mark `border.overlay` as a breaking change in PRC too.

This is part of https://github.com/github/design-systems/issues/1393.

### Screenshots

[Before](https://primer.style/components/Popover) | [After](https://primer-components-git-replace-border-overlay-primer.vercel.app/components/Popover)
--- | ---
![Screen Shot 2021-04-27 at 22 12 34](https://user-images.githubusercontent.com/378023/116247380-c0bd3580-a7a5-11eb-9ac4-6ca6978c09ab.png) | ![Screen Shot 2021-04-27 at 22 11 47](https://user-images.githubusercontent.com/378023/116247373-bf8c0880-a7a5-11eb-902b-d032968eed4d.png)

### Merge checklist
- [ ] ~Added/updated tests~
- [ ] ~Added/updated documentation~
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
