### PR TITLE
fix(useFocusZone): handle add/remove nodes that have focusable children

### DIFF
--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -1,4 +1,4 @@
-import {isFocusable, iterateFocusableElements} from '../utils/iterateFocusableElements'
+import {iterateFocusableElements} from '../utils/iterateFocusableElements'
 import {polyfill as eventListenerSignalPolyfill} from '../polyfills/eventListenerSignal'
 import {isMacOS} from '../utils/userAgent'
 import {uniqueId} from '../utils/uniqueId'
@@ -442,12 +442,12 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
   const observer = new MutationObserver(mutations => {
     for (const mutation of mutations) {
       for (const addedNode of mutation.addedNodes) {
-        if (addedNode instanceof HTMLElement && isFocusable(addedNode)) {
+        if (addedNode instanceof HTMLElement) {
           beginFocusManagement(...iterateFocusableElements(addedNode))
         }
       }
       for (const removedNode of mutation.removedNodes) {
-        if (removedNode instanceof HTMLElement && savedTabIndex.has(removedNode)) {
+        if (removedNode instanceof HTMLElement) {
           endFocusManagement(...iterateFocusableElements(removedNode))
         }
       }

--- a/src/stories/useFocusZone.stories.tsx
+++ b/src/stories/useFocusZone.stories.tsx
@@ -408,7 +408,11 @@ export const ChangingSubtree = () => {
 
   const buttons: JSX.Element[] = []
   for (let i = 0; i < buttonCount; ++i) {
-    buttons.push(<MarginButton key={`button${i}`}>{i + 1}</MarginButton>)
+    buttons.push(
+      <div>
+        <MarginButton key={`button${i}`}>{i + 1}</MarginButton>
+      </div>
+    )
   }
 
   return (


### PR DESCRIPTION
Within a focus zone, we watch for child nodes to be added/removed.  Currently, we only do something with those changes if the node that was changed `isFocusable`, or has been registered as a focus target.  _If_ that condition is met, we search all children of the changed node to find focus targets.  This setup does not account for scenarios when the added/removed node is not _itself_ focusable, but it does have children that are focusable.  This change removes the top-level check and simply always searches for focusable children.  This is a noticeable issue in `SelectPanel`, where the list items are added/removed frequently with changes to the filter.

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge