### PR TITLE
ActionList and ActionMenu API updates

### DIFF
--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -53,6 +53,7 @@ An `ActionList` is a list of items which can be activated or selected. `ActionLi
       key: '6',
       leadingVisual: FilterIcon,
       text: 'Save sort and filters to current view',
+      disabled: true,
       groupId: '3'
     },
     {key: '7', leadingVisual: FilterIcon, text: 'Save sort and filters to new view', groupId: '3'},

--- a/docs/content/ActionMenu.mdx
+++ b/docs/content/ActionMenu.mdx
@@ -57,6 +57,7 @@ An `ActionMenu` is an ActionList-based component for creating a menu of actions 
       key: '6',
       leadingVisual: FilterIcon,
       text: 'Save sort and filters to current view',
+      disabled: true,
       groupId: '3'
     },
     {key: '7', leadingVisual: FilterIcon, text: 'Save sort and filters to new view', groupId: '3'},

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -69,10 +69,7 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
   /**
    * Callback that will trigger both on click selection and keyboard selection.
    */
-  onAction?: (
-    item: Partial<ItemProps>,
-    event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
-  ) => void
+  onAction?: (item: ItemProps, event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void
 }
 
 const getItemVariant = (variant = 'default', disabled?: boolean) => {
@@ -106,7 +103,7 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
   }
 }
 
-const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemProps} & SxProp>`
+const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemInput} & SxProp>`
   /* 6px vertical padding + 20px line height = 32px total height
    *
    * TODO: When rem-based spacing on a 4px scale lands, replace

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -4,6 +4,7 @@ import {get} from '../constants'
 import sx, {SxProp} from '../sx'
 import {ItemInput} from './List'
 import styled from 'styled-components'
+import {themeGet} from '..'
 
 /**
  * Contract for props passed to the `Item` component.
@@ -59,9 +60,50 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
    * Designates the group that an item belongs to.
    */
   groupId?: string
+
+  /**
+   * Items that are disabled can not be clicked, selected, or navigated through.
+   */
+  disabled?: boolean
+
+  /**
+   * Callback that will trigger both on click selection and keyboard selection.
+   */
+  onAction?: (item: Partial<ItemProps>, event?: MouseEvent | KeyboardEvent) => void
 }
 
-const StyledItem = styled.div<{variant: ItemProps['variant']} & SxProp>`
+const getItemVariant = (variant = 'default', disabled?: boolean) => {
+  if (disabled) {
+    return {
+      color: themeGet('colors.text.disabled'),
+      iconColor: themeGet('colors.text.disabled'),
+      annotationColor: themeGet('colors.text.disabled'),
+      hoverBackground: 'inherit',
+      hoverCursor: 'default'
+    }
+  }
+
+  switch (variant) {
+    case 'danger':
+      return {
+        color: themeGet('colors.text.danger'),
+        iconColor: themeGet('colors.icon.danger'),
+        annotationColor: themeGet('colors.text.disabled'),
+        hoverBackground: themeGet('colors.bg.danger'),
+        hoverCursor: 'pointer'
+      }
+    default:
+      return {
+        color: 'inherit',
+        iconColor: themeGet('colors.text.disabled'),
+        annotationColor: themeGet('colors.text.disabled'),
+        hoverBackground: themeGet('colors.selectMenu.tapHighlight'),
+        hoverCursor: 'pointer'
+      }
+  }
+}
+
+const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemProps} & SxProp>`
   /* 6px vertical padding + 20px line height = 32px total height
    *
    * TODO: When rem-based spacing on a 4px scale lands, replace
@@ -70,13 +112,12 @@ const StyledItem = styled.div<{variant: ItemProps['variant']} & SxProp>`
   padding: 6px ${get('space.2')};
   display: flex;
   border-radius: ${get('radii.2')};
-  color: ${({variant}) => (variant === 'danger' ? get('colors.text.danger') : 'inherit')};
+  color: ${({variant, item}) => getItemVariant(variant, item?.disabled).color};
 
   @media (hover: hover) and (pointer: fine) {
     :hover {
-      background: ${props =>
-        props.variant === 'danger' ? get('colors.bg.danger') : get('colors.selectMenu.tapHighlight')};
-      cursor: pointer;
+      background: ${({variant, item}) => getItemVariant(variant, item?.disabled).hoverBackground};
+      cursor: ${({variant, item}) => getItemVariant(variant, item?.disabled).hoverCursor};
     }
   }
 
@@ -87,7 +128,7 @@ const StyledTextContainer = styled.div<{descriptionVariant: ItemProps['descripti
   flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
 `
 
-const BaseVisualContainer = styled.div`
+const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled?: boolean}>`
   // Match visual height to adjacent text line height.
   // TODO: When rem-based spacing on a 4px scale lands, replace
   // hardcoded '20px' with '${get('space.s20')}'.
@@ -99,7 +140,7 @@ const BaseVisualContainer = styled.div`
   margin-right: ${get('space.2')};
 
   svg {
-    fill: ${get('colors.text.secondary')};
+    fill: ${({variant, disabled}) => getItemVariant(variant, disabled).iconColor};
     font-size: ${get('fontSizes.0')};
   }
 `
@@ -107,7 +148,7 @@ const BaseVisualContainer = styled.div`
 const LeadingVisualContainer = styled(BaseVisualContainer)``
 
 const TrailingVisualContainer = styled(BaseVisualContainer)`
-  color: ${get('colors.icon.tertiary')};
+  color: ${({variant, disabled}) => getItemVariant(variant, disabled).annotationColor}};
   margin-left: auto;
   margin-right: 0;
   div:nth-child(2) {
@@ -125,22 +166,50 @@ const DescriptionContainer = styled.span`
 /**
  * An actionable or selectable `Item` with an optional icon and description.
  */
-export function Item({
-  text,
-  description,
-  descriptionVariant = 'inline',
-  selected,
-  leadingVisual: LeadingVisual,
-  trailingIcon: TrailingIcon,
-  trailingText,
-  variant = 'default',
-  ...props
-}: Partial<ItemProps> & {item?: ItemInput}): JSX.Element {
+export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.Element {
+  const {
+    text,
+    description,
+    descriptionVariant = 'inline',
+    selected,
+    leadingVisual: LeadingVisual,
+    trailingIcon: TrailingIcon,
+    trailingText,
+    variant = 'default',
+    disabled,
+    onAction,
+    onKeyPress,
+    onClick,
+    ...props
+  } = itemProps
   return (
-    <StyledItem tabIndex={-1} variant={variant} aria-selected={selected} {...props}>
+    <StyledItem
+      tabIndex={disabled ? undefined : -1}
+      variant={variant}
+      aria-selected={selected}
+      {...props}
+      onKeyPress={event => {
+        if (disabled) {
+          return
+        }
+        if (onAction) {
+          onAction(itemProps as ItemProps, event)
+        }
+        onKeyPress?.(event)
+      }}
+      onClick={event => {
+        if (disabled) {
+          return
+        }
+        if (onAction) {
+          onAction(itemProps as ItemProps, event)
+        }
+        onClick?.(event)
+      }}
+    >
       {!!selected === selected && <LeadingVisualContainer>{selected && <CheckIcon />}</LeadingVisualContainer>}
       {LeadingVisual && (
-        <LeadingVisualContainer>
+        <LeadingVisualContainer variant={variant} disabled={disabled}>
           <LeadingVisual />
         </LeadingVisualContainer>
       )}
@@ -149,7 +218,7 @@ export function Item({
         {description && <DescriptionContainer>{description}</DescriptionContainer>}
       </StyledTextContainer>
       {(TrailingIcon || trailingText) && (
-        <TrailingVisualContainer>
+        <TrailingVisualContainer variant={variant} disabled={disabled}>
           {trailingText && <div>{trailingText}</div>}
           {TrailingIcon && (
             <div>

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -1,5 +1,5 @@
 import {CheckIcon, IconProps} from '@primer/octicons-react'
-import React from 'react'
+import React, {useCallback} from 'react'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
 import {ItemInput} from './List'
@@ -69,7 +69,10 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
   /**
    * Callback that will trigger both on click selection and keyboard selection.
    */
-  onAction?: (item: Partial<ItemProps>, event?: MouseEvent | KeyboardEvent) => void
+  onAction?: (
+    item: Partial<ItemProps>,
+    event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
+  ) => void
 }
 
 const getItemVariant = (variant = 'default', disabled?: boolean) => {
@@ -182,30 +185,41 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     onClick,
     ...props
   } = itemProps
+
+  const keyPressHandler = useCallback(
+    event => {
+      if (disabled) {
+        return
+      }
+      if (onAction) {
+        onAction(itemProps as ItemProps, event)
+      }
+      onKeyPress?.(event)
+    },
+    [onAction, disabled, itemProps, onKeyPress]
+  )
+
+  const clickHandler = useCallback(
+    event => {
+      if (disabled) {
+        return
+      }
+      if (onAction) {
+        onAction(itemProps as ItemProps, event)
+      }
+      onClick?.(event)
+    },
+    [onAction, disabled, itemProps, onClick]
+  )
+
   return (
     <StyledItem
       tabIndex={disabled ? undefined : -1}
       variant={variant}
       aria-selected={selected}
       {...props}
-      onKeyPress={event => {
-        if (disabled) {
-          return
-        }
-        if (onAction) {
-          onAction(itemProps as ItemProps, event)
-        }
-        onKeyPress?.(event)
-      }}
-      onClick={event => {
-        if (disabled) {
-          return
-        }
-        if (onAction) {
-          onAction(itemProps as ItemProps, event)
-        }
-        onClick?.(event)
-      }}
+      onKeyPress={keyPressHandler}
+      onClick={clickHandler}
     >
       {!!selected === selected && <LeadingVisualContainer>{selected && <CheckIcon />}</LeadingVisualContainer>}
       {LeadingVisual && (

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -9,7 +9,7 @@ export interface ActionMenuProps extends Partial<Omit<GroupedListProps, keyof Li
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderAnchor?: (props: any) => JSX.Element
   anchorContent?: React.ReactNode
-  onAction?: (props: ItemProps) => void
+  onAction?: (props: ItemProps, event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void
 }
 
 const ActionMenuItem = (props: ItemProps) => <Item role="menuitem" {...props} />
@@ -43,16 +43,13 @@ const ActionMenuBase = ({
       renderItem({
         ...itemProps,
         role: 'menuitem',
-        onKeyPress: _event => {
+        onKeyPress: event => {
           if (itemProps.disabled) {
             return
           }
 
-          if (itemProps.onAction) {
-            itemProps.onAction(itemProps)
-          } else if (onAction) {
-            onAction(itemProps as ItemProps)
-          }
+          const actionCallback = itemProps.onAction ?? onAction
+          actionCallback?.(itemProps as ItemProps, event)
           onClose()
         },
         onClick: event => {
@@ -60,11 +57,8 @@ const ActionMenuBase = ({
             return
           }
 
-          if (itemProps.onAction) {
-            itemProps.onAction(itemProps)
-          } else if (onAction) {
-            onAction(itemProps as ItemProps)
-          }
+          const actionCallback = itemProps.onAction ?? onAction
+          actionCallback?.(itemProps as ItemProps, event)
           onClick?.(event)
           onClose()
         }

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -44,11 +44,27 @@ const ActionMenuBase = ({
         ...itemProps,
         role: 'menuitem',
         onKeyPress: _event => {
-          onAction?.(itemProps as ItemProps)
+          if (itemProps.disabled) {
+            return
+          }
+
+          if (itemProps.onAction) {
+            itemProps.onAction(itemProps)
+          } else if (onAction) {
+            onAction(itemProps as ItemProps)
+          }
           onClose()
         },
         onClick: event => {
-          onAction?.(itemProps as ItemProps)
+          if (itemProps.disabled) {
+            return
+          }
+
+          if (itemProps.onAction) {
+            itemProps.onAction(itemProps)
+          } else if (onAction) {
+            onAction(itemProps as ItemProps)
+          }
           onClick?.(event)
           onClose()
         }

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -8,8 +8,7 @@ import {
   ProjectIcon,
   FilterIcon,
   GearIcon,
-  ArrowRightIcon,
-  TrashIcon
+  ArrowRightIcon
 } from '@primer/octicons-react'
 import {Meta} from '@storybook/react'
 import React, {useCallback, useState} from 'react'

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -8,7 +8,8 @@ import {
   ProjectIcon,
   FilterIcon,
   GearIcon,
-  ArrowRightIcon
+  ArrowRightIcon,
+  TrashIcon
 } from '@primer/octicons-react'
 import {Meta} from '@storybook/react'
 import React, {useCallback, useState} from 'react'
@@ -96,11 +97,15 @@ export function SimpleListStory(): JSX.Element {
           onAction={onAction}
           anchorContent="Menu"
           items={[
-            {text: 'New file', trailingText: '⌘O'},
+            {text: 'New file', trailingText: '⌘O', disabled: true, leadingVisual: ProjectIcon},
             ActionList.Divider,
             {text: 'Copy link', trailingText: 'ctrl+C'},
             {text: 'Edit file', trailingText: '⌘E'},
-            {text: 'Delete file', variant: 'danger', trailingText: '⌘D'}
+            {
+              text: 'Delete file',
+              variant: 'danger',
+              trailingText: '⌘D'
+            }
           ]}
         />
       </ErsatzOverlay>


### PR DESCRIPTION
This PR:

- makes icons respect the variant styling
- adds a disabled flag that styles an item as disabled and also takes it out of the tab order
- adds item level `onAction` callback

Closes https://github.com/github/primer/issues/125
Closes https://github.com/github/primer/issues/126
Closes https://github.com/github/primer/issues/127

### Screenshots
A bit of a contrived example here, but this shows both disabled and variant styling. Wondering if the `trailingText` should also be styled by the variant?

<img width="504" alt="Screen Shot 2021-04-28 at 10 16 32 AM" src="https://user-images.githubusercontent.com/16739070/116429878-e9781600-a80b-11eb-87b7-1314bc1be425.png">



### Merge checklist
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
