### PR TITLE
fix(AnchoredOverlay): use list focus if open on initial render

### DIFF
--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -35,7 +35,7 @@ export interface AnchoredOverlayProps {
 export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({renderAnchor, children, open, onOpen, onClose}) => {
   const anchorRef = useRef<HTMLElement>(null)
   const [overlayRef, updateOverlayRef] = useRenderForcingRef<HTMLDivElement>()
-  const [focusType, setFocusType] = useState<null | 'anchor' | 'list'>(null)
+  const [focusType, setFocusType] = useState<null | 'anchor' | 'list'>(open ? 'list' : null)
   const anchorId = useMemo(uniqueId, [])
 
   const onClickOutside = useCallback(() => onClose?.('click-outside'), [onClose])


### PR DESCRIPTION
Currently, if an `AnchoredOverlay` is rendered with `open={true}` on the _initial_ render, the internal `focusType` is `null` and _cannot_ change to `anchor` or `list` no matter how the user interacts with the page.  This change makes the assumption that rendering the overlay initially open indicates the user will be interacting with it immediately, so `focusType` should be set to `list` immediately.

### Screenshots
With open set on initial render:
![image](https://user-images.githubusercontent.com/3026298/116440751-a2872200-a805-11eb-8ace-87e6fb58cd2b.png)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
