### PR TITLE
Pass onAction directly to Item and check for selection keys

### DIFF
--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -202,7 +202,9 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
         return
       }
       onClick?.(event)
-      onAction?.(itemProps as ItemProps, event)
+      if (!event.defaultPrevented) {
+        onAction?.(itemProps as ItemProps, event)
+      }
     },
     [onAction, disabled, itemProps, onClick]
   )

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -188,10 +188,10 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
       if (disabled) {
         return
       }
-      if (onAction) {
-        onAction(itemProps as ItemProps, event)
-      }
       onKeyPress?.(event)
+      if (!event.defaultPrevented && [' ', 'Enter'].includes(event.key)) {
+        onAction?.(itemProps as ItemProps, event)
+      }
     },
     [onAction, disabled, itemProps, onKeyPress]
   )
@@ -201,10 +201,8 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
       if (disabled) {
         return
       }
-      if (onAction) {
-        onAction(itemProps as ItemProps, event)
-      }
       onClick?.(event)
+      onAction?.(itemProps as ItemProps, event)
     },
     [onAction, disabled, itemProps, onClick]
   )

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -39,30 +39,21 @@ const ActionMenuBase = ({
   )
 
   const renderMenuItem: typeof Item = useCallback(
-    ({onClick, ...itemProps}) =>
-      renderItem({
+    ({onAction: itemOnAction, ...itemProps}) => {
+      const onActionWithClose = (
+        props: ItemProps,
+        event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>
+      ) => {
+        const actionCallback = itemOnAction ?? onAction
+        actionCallback?.(props as ItemProps, event)
+        onClose()
+      }
+      return renderItem({
         ...itemProps,
         role: 'menuitem',
-        onKeyPress: event => {
-          if (itemProps.disabled) {
-            return
-          }
-
-          const actionCallback = itemProps.onAction ?? onAction
-          actionCallback?.(itemProps as ItemProps, event)
-          onClose()
-        },
-        onClick: event => {
-          if (itemProps.disabled) {
-            return
-          }
-
-          const actionCallback = itemProps.onAction ?? onAction
-          actionCallback?.(itemProps as ItemProps, event)
-          onClick?.(event)
-          onClose()
-        }
-      }),
+        onAction: onActionWithClose
+      })
+    },
     [onAction, onClose, renderItem]
   )
 


### PR DESCRIPTION
Quick follow up I wanted to put in to address some comments @dgreif made in https://github.com/primer/components/pull/1186#discussion_r623215001 and https://github.com/primer/components/pull/1186#pullrequestreview-648382448

This cleans up the code a bit by delegating more click/keypress handling to Item, and it also makes sure we are checking for selection keys (space/enter) as a condition to firing onAction.