### PR TITLE
Allow custom `children` in `ActionItem`

### DIFF
--- a/.changeset/happy-plums-work.md
+++ b/.changeset/happy-plums-work.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Allow custom `children` in `ActionItem`.  `text` and `description` can still be provided as a shortcut, but `children` is now available if you need more control over the rending of the item, without sacrifising benefits from `Item` by using `renderItem`.

--- a/.changeset/happy-plums-work.md
+++ b/.changeset/happy-plums-work.md
@@ -2,4 +2,4 @@
 "@primer/components": patch
 ---
 
-Allow custom `children` in `ActionItem`.  `text` and `description` can still be provided as a shortcut, but `children` is now available if you need more control over the rending of the item, without sacrifising benefits from `Item` by using `renderItem`.
+Allow custom `children` in `ActionItem`.  `text` and `description` can still be provided as a shortcut, but `children` is now available if you need more control over the rending of the item, without sacrificing benefits from `Item` by using `renderItem`.

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -21,11 +21,6 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
   description?: string
 
   /**
-   * Custom children content to show if text/description is not flexible enough.  If supplied, leading/trailing elements can still be used.
-   */
-  children?: React.ReactNode
-
-  /**
    * Secondary text style variations. Usage is discretionary.
    *
    * - `"inline"` - Secondary text is positioned beside primary text.

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -13,12 +13,17 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
   /**
    * Primary text which names an `Item`.
    */
-  text: string
+  text?: string
 
   /**
    * Secondary text which provides additional information about an `Item`.
    */
   description?: string
+
+  /**
+   * Custom children content to show if text/description is not flexible enough.  If supplied, leading/traling elements can still be used.
+   */
+  children?: React.ReactNode
 
   /**
    * Secondary text style variations. Usage is discretionary.
@@ -179,6 +184,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     disabled,
     onAction,
     onKeyPress,
+    children,
     onClick,
     ...props
   } = itemProps
@@ -224,10 +230,13 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
           <LeadingVisual />
         </LeadingVisualContainer>
       )}
-      <StyledTextContainer descriptionVariant={descriptionVariant}>
-        <div>{text}</div>
-        {description && <DescriptionContainer>{description}</DescriptionContainer>}
-      </StyledTextContainer>
+      {children}
+      {(text || description) && (
+        <StyledTextContainer descriptionVariant={descriptionVariant}>
+          {text && <div>{text}</div>}
+          {description && <DescriptionContainer>{description}</DescriptionContainer>}
+        </StyledTextContainer>
+      )}
       {(TrailingIcon || trailingText) && (
         <TrailingVisualContainer variant={variant} disabled={disabled}>
           {trailingText && <div>{trailingText}</div>}

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -21,7 +21,7 @@ export interface ItemProps extends React.ComponentPropsWithoutRef<'div'>, SxProp
   description?: string
 
   /**
-   * Custom children content to show if text/description is not flexible enough.  If supplied, leading/traling elements can still be used.
+   * Custom children content to show if text/description is not flexible enough.  If supplied, leading/trailing elements can still be used.
    */
   children?: React.ReactNode
 

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -78,7 +78,7 @@ describe('ActionMenu', () => {
     })
     portalRoot = menu.baseElement.querySelector('#__primerPortalRoot__')
     expect(portalRoot).toBeTruthy()
-    const menuItem = await menu.queryByText(items[0].text)
+    const menuItem = await menu.queryByText(items[0].text!)
     act(() => {
       fireEvent.click(menuItem as Element)
     })

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -263,4 +263,4 @@ export function CustomItemChildren(): JSX.Element {
     </>
   )
 }
-SimpleListStory.storyName = 'Simple List'
+CustomItemChildren.storyName = 'Custom Item Children'

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -7,12 +7,14 @@ import {
   NoteIcon,
   ProjectIcon,
   FilterIcon,
-  GearIcon
+  GearIcon,
+  ArrowRightIcon,
+  ArrowLeftIcon
 } from '@primer/octicons-react'
 import {Meta} from '@storybook/react'
 import React from 'react'
 import styled from 'styled-components'
-import {ThemeProvider} from '..'
+import {Label, ThemeProvider} from '..'
 import {ActionList as _ActionList} from '../ActionList'
 import {Header} from '../ActionList/Header'
 import BaseStyles from '../BaseStyles'
@@ -238,3 +240,27 @@ export function HeaderStory(): JSX.Element {
   )
 }
 HeaderStory.storyName = 'Header'
+
+export function CustomItemChildren(): JSX.Element {
+  return (
+    <>
+      <h1>Custom Item Children</h1>
+      <ErsatzOverlay>
+        <ActionList
+          items={[
+            {
+              leadingVisual: ArrowRightIcon,
+              children: (
+                <Label outline borderColor="border.success">
+                  Choose this one
+                </Label>
+              ),
+              trailingIcon: ArrowLeftIcon
+            }
+          ]}
+        />
+      </ErsatzOverlay>
+    </>
+  )
+}
+SimpleListStory.storyName = 'Simple List'

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -48,7 +48,7 @@ const ErsatzOverlay = styled.div`
 export function ActionsStory(): JSX.Element {
   const [option, setOption] = useState('Select an option')
   const onAction = (itemProps: ItemProps) => {
-    setOption(itemProps.text || '')
+    setOption(itemProps.text ?? '')
   }
   return (
     <>

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -48,7 +48,7 @@ const ErsatzOverlay = styled.div`
 export function ActionsStory(): JSX.Element {
   const [option, setOption] = useState('Select an option')
   const onAction = (itemProps: ItemProps) => {
-    setOption(itemProps.text)
+    setOption(itemProps.text || '')
   }
   return (
     <>
@@ -85,7 +85,7 @@ ActionsStory.storyName = 'Actions'
 export function SimpleListStory(): JSX.Element {
   const [option, setOption] = useState('Select an option')
   const onAction = (itemProps: ItemProps) => {
-    setOption(itemProps.text)
+    setOption(itemProps.text || '')
   }
   return (
     <>
@@ -116,7 +116,7 @@ SimpleListStory.storyName = 'Simple List'
 export function ComplexListStory(): JSX.Element {
   const [option, setOption] = useState('Select an option')
   const onAction = (itemProps: ItemProps) => {
-    setOption(itemProps.text)
+    setOption(itemProps.text || '')
   }
   return (
     <>
@@ -177,7 +177,7 @@ export function CustomTrigger(): JSX.Element {
   const customAnchor = (props: LinkProps) => <Link {...props} sx={{cursor: 'pointer'}} />
   const [option, setOption] = useState('Select an option')
   const onAction = useCallback((itemProps: ItemProps) => {
-    setOption(itemProps.text)
+    setOption(itemProps.text || '')
   }, [])
   return (
     <>


### PR DESCRIPTION
Some use cases for `ActionList` have revealed that the built-in rendering is not always providing enough flexibility, such as if you want to render the text inside a `<Label>`.  Although we can override rendering with `renderItem`, this fully replaces the _entire_ item and removes helpful tools like `onAction` and the `selected` checkmark. Additionally, the requirement of `text` on `ItemProps` forces consumers to convert existing data structures into a secondary data structure in order to provide `text`.  This change makes all fields optional (which opens it up for use by any item interface), and adds a `children` prop that will render a custom `ReactNode` before the `text` section of the item.  

### Screenshots
![image](https://user-images.githubusercontent.com/3026298/116629118-6804ae80-a905-11eb-9075-b1e7bb8723e7.png)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
