### PR TITLE
Perform ActionMenu actions after overlay has closed

### DIFF
--- a/.changeset/twelve-jeans-kneel.md
+++ b/.changeset/twelve-jeans-kneel.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Perform ActionMenu actions after overlay has closed. This allows the action to move focus if so desired, without the ActionMenu focus trap preventing focus from moving away.


### PR DESCRIPTION
This is an alternate approach to solve the problems addressed by #1188.  When an action is selected from the menu, we want to _wait_ until the menu has closed the overlay before performing the action.  This is important in situations where the action moves focus to a different element on the page.  Without this change, the focus change from the action would be detected by the overlay focus trap, preventing focus from actually shifting to the intended target.  While #1188 did present two valid ways of solving this problem, @T-Hugs and @smockle agreed that the approach in this PR is a simpler solution for the immediate issue. 

Closes #1188 

### Screenshots
![CleanShot 2021-04-30 at 11 48 09](https://user-images.githubusercontent.com/3026298/116740696-37c31b80-a9aa-11eb-9212-6af948b93f66.gif)


### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
