### PR TITLE
Fix overlay position

### DIFF
--- a/.changeset/olive-planets-pump.md
+++ b/.changeset/olive-planets-pump.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix overlay position when using an AnchoredOverlay

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -90,6 +90,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({renderAnchor, c
     },
     [overlayRef.current]
   )
+  const overlayPosition = position && {top: `${position.top}px`, left: `${position.left}px`}
 
   useFocusZone({containerRef: overlayRef, disabled: !open || focusType !== 'list' || !position})
   useFocusTrap({containerRef: overlayRef, disabled: !open || focusType !== 'list' || !position})
@@ -114,7 +115,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({renderAnchor, c
           ref={updateOverlayRef}
           role="listbox"
           visibility={position ? 'visible' : 'hidden'}
-          {...position}
+          {...overlayPosition}
         >
           {children}
         </Overlay>

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -90,7 +90,9 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({renderAnchor, c
     },
     [overlayRef.current]
   )
-  const overlayPosition = position && {top: `${position.top}px`, left: `${position.left}px`}
+  const overlayPosition = useMemo(() => {
+    return position && {top: `${position.top}px`, left: `${position.left}px`}
+  }, [position])
 
   useFocusZone({containerRef: overlayRef, disabled: !open || focusType !== 'list' || !position})
   useFocusTrap({containerRef: overlayRef, disabled: !open || focusType !== 'list' || !position})


### PR DESCRIPTION
Fixes overlay position. Since we were passing a number to the "top" and "left" props, they were getting converted to "space.x" where x is one of the primitives (so 4 would become 24px).

Closes #[internal issue 138]

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge

