### PR TITLE
fix: Don’t clip 'ConfirmationDialog' button outlines

### DIFF
--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -77,7 +77,6 @@ const StyledConfirmationFooter = styled(Box)`
   button {
     font-size: ${get('fontSizes.1')};
     flex: 1 1 0;
-    border-radius: 0;
     border-bottom: 0;
     margin: 0;
     border-right: 0;
@@ -88,6 +87,21 @@ const StyledConfirmationFooter = styled(Box)`
       // this is a bit of a hack to get the focus outlines to show up
       z-index: 1;
     }
+  }
+  button:first-of-type {
+    // All except border-bottom-left-radius, which should follow the curvature of the container
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+  }
+  button:last-of-type {
+    // All except border-bottom-right-radius, which should follow the curvature of the container
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+    border-bottom-left-radius: 0;
+  }
+  button:not(:first-of-type):not(:last-of-type) {
+    border-radius: 0;
   }
 `
 const ConfirmationFooter: React.FC<DialogProps> = ({footerButtons}) => {

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -88,17 +88,22 @@ const StyledConfirmationFooter = styled(Box)`
       z-index: 1;
     }
   }
-  button:first-of-type {
+  button:first-of-type:not(:last-of-type) {
     // All except border-bottom-left-radius, which should follow the curvature of the container
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
   }
-  button:last-of-type {
+  button:last-of-type:not(:first-of-type) {
     // All except border-bottom-right-radius, which should follow the curvature of the container
     border-top-left-radius: 0;
     border-top-right-radius: 0;
     border-bottom-left-radius: 0;
+  }
+  button:first-of-type:last-of-type {
+    // When the footer contains a single button, it should follow the curvature of the container
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
   }
   button:not(:first-of-type):not(:last-of-type) {
     border-radius: 0;

--- a/src/Dialog/Dialog.tsx
+++ b/src/Dialog/Dialog.tsx
@@ -189,7 +189,6 @@ const StyledDialog = styled.div<StyledDialogProps & SystemCommonProps & SystemPo
   width: ${props => widthMap[props.width ?? ('xl' as const)]};
   height: ${props => heightMap[props.height ?? ('auto' as const)]};
   border-radius: 12px;
-  overflow: hidden;
   opacity: 1;
   animation: overlay--dialog-appear ${ANIMATION_DURATION} ${get('animation.easeOutCubic')};
 


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/129

Previously `Dialog` had `overflow: hidden`, which caused focus rings to clip. This PR removes `overflow: hidden`, then updates the `border-radius` of `ConfirmationDialog` buttons to follow the curvature of their container.

| Before | After |
|:---:|:---:|
| ![before](https://user-images.githubusercontent.com/3104489/116756437-15e18d00-a9da-11eb-8f21-8a6c3af32c29.gif) | ![after](https://user-images.githubusercontent.com/3104489/116756439-1712ba00-a9da-11eb-918e-95b37582148a.gif) |


