### PR TITLE
renderMenuItem in ActionMenu checks preventDefault onClose

### DIFF
--- a/.changeset/silver-fans-jump.md
+++ b/.changeset/silver-fans-jump.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+renderMenuItem in ActionMenu checks preventDefault for conditionally calling onClose

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -52,7 +52,9 @@ const ActionMenuBase = ({
           const actionCallback = itemOnAction ?? onAction
           pendingActionRef.current = () => actionCallback?.(props as ItemProps, event)
           actionCallback?.(props as ItemProps, event)
-          onClose()
+          if (!event.defaultPrevented) {
+            onClose()
+          }
         }
       })
     },


### PR DESCRIPTION
Small change here to check if the default has been prevented before we close the Overlay - if the default is prevented, we should not be closing the overlay.