### PR TITLE
onMouseDown passthrough in ActionMenu and AnchoredOverlay

### DIFF
--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -6,12 +6,35 @@ import React, {useCallback, useEffect, useRef} from 'react'
 import {AnchoredOverlay} from './AnchoredOverlay'
 import {useProvidedStateOrCreate} from './hooks/useProvidedStateOrCreate'
 export interface ActionMenuProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
+  /**
+   * A custom function component used to render the anchor element.
+   * Will receive the `anchoredContent` prop as `children` prop when an item is activated.
+   * Uses a `Button` by default.
+   */
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   renderAnchor?: (props: any) => JSX.Element
+  /**
+   * Content that is passed into the renderAnchor component, which is a button by default.
+   */
   anchorContent?: React.ReactNode
+  /**
+   * A callback that triggers both on clicks and keyboard events. This callback will be overridden by item level `onAction` callbacks.
+   */
   onAction?: (props: ItemProps, event?: React.MouseEvent<HTMLDivElement> | React.KeyboardEvent<HTMLDivElement>) => void
+  /**
+   * If defined, will control the open/closed state of the overlay. Must be used in conjuction with `setOpen`.
+   */
   open?: boolean
+
+  /**
+   * If defined, will control the open/closed state of the overlay. Must be used in conjuction with `open`.
+   */
   setOpen?: (s: boolean) => void
+
+  /**
+   * An onMouseDown callback that will be passed into the internal AnchoredOverlay component
+   */
+  onOverlayMouseDown?: (e: React.MouseEvent) => unknown
 }
 
 const ActionMenuItem = (props: ItemProps) => <Item role="menuitem" {...props} />
@@ -25,6 +48,7 @@ const ActionMenuBase = ({
   onAction,
   open,
   setOpen,
+  onOverlayMouseDown,
   ...listProps
 }: ActionMenuProps): JSX.Element => {
   const pendingActionRef = useRef<() => unknown>()
@@ -69,7 +93,13 @@ const ActionMenuBase = ({
   }, [open])
 
   return (
-    <AnchoredOverlay renderAnchor={renderMenuAnchor} open={combinedOpenState} onOpen={onOpen} onClose={onClose}>
+    <AnchoredOverlay
+      renderAnchor={renderMenuAnchor}
+      open={combinedOpenState}
+      onOpen={onOpen}
+      onClose={onClose}
+      onMouseDown={onOverlayMouseDown}
+    >
       <List {...listProps} role="menu" renderItem={renderMenuItem} />
     </AnchoredOverlay>
   )

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -5,10 +5,6 @@ import {useFocusZone} from '../hooks/useFocusZone'
 import {useAnchoredPosition, useRenderForcingRef} from '../hooks'
 import {uniqueId} from '../utils/uniqueId'
 
-function preventDefault(event: React.UIEvent) {
-  event.preventDefault()
-}
-
 export interface AnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'width'> {
   /**
    * A custom function component used to render the anchor element.
@@ -30,6 +26,11 @@ export interface AnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'wid
    * A callback which is called whenever the overlay is currently open and a "close gesture" is detected.
    */
   onClose?: (gesture: 'click-outside' | 'escape') => unknown
+
+  /**
+   * A callback that occurs when a user presses a mouse button over an element.
+   */
+  onMouseDown?: (event: React.MouseEvent) => unknown
 }
 
 /**
@@ -43,6 +44,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   onOpen,
   onClose,
   height,
+  onMouseDown,
   width
 }) => {
   const anchorRef = useRef<HTMLElement>(null)
@@ -129,8 +131,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
           ref={updateOverlayRef}
           role="listbox"
           visibility={position ? 'visible' : 'hidden'}
-          onMouseDown={preventDefault}
-          onClick={preventDefault}
+          onMouseDown={onMouseDown}
           height={height}
           width={width}
           {...overlayPosition}


### PR DESCRIPTION
This PR provides a passthrough for onMouseDown events in `ActionMenu` to `AnchoredOverlay`

Also fills out some doc comments I realized were missing in `ActionMenu`