### PR TITLE
Trap focus in AnchoredOverlay as soon as it opens

### DIFF
--- a/.changeset/silver-scissors-love.md
+++ b/.changeset/silver-scissors-love.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Trap focus in `AnchoredOverlay` as soon as it opens, regardless of the event that triggered it to open

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useMemo, useRef} from 'react'
 import Overlay, {OverlayProps} from '../Overlay'
 import {useFocusTrap} from '../hooks/useFocusTrap'
 import {useFocusZone} from '../hooks/useFocusZone'
@@ -49,49 +49,26 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
 }) => {
   const anchorRef = useRef<HTMLElement>(null)
   const [overlayRef, updateOverlayRef] = useRenderForcingRef<HTMLDivElement>()
-  const [focusType, setFocusType] = useState<null | 'anchor' | 'list'>(open ? 'list' : null)
   const anchorId = useMemo(uniqueId, [])
 
   const onClickOutside = useCallback(() => onClose?.('click-outside'), [onClose])
   const onEscape = useCallback(() => onClose?.('escape'), [onClose])
 
-  useEffect(() => {
-    if (!open) {
-      setFocusType(null)
-    }
-  }, [open])
-
   const onAnchorKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLElement>) => {
       if (!event.defaultPrevented) {
-        if (!open) {
-          if (['ArrowDown', 'ArrowUp'].includes(event.key)) {
-            setFocusType('list')
-            onOpen?.('anchor-key-press')
-            event.preventDefault()
-          } else if ([' ', 'Enter'].includes(event.key)) {
-            setFocusType('anchor')
-            onOpen?.('anchor-key-press')
-            event.preventDefault()
-          }
-        } else if (focusType === 'anchor') {
-          if (['ArrowDown', 'ArrowUp', 'Tab', 'Enter'].includes(event.key)) {
-            setFocusType('list')
-            event.preventDefault()
-          } else if (event.key === 'Escape') {
-            onClose?.('escape')
-            event.preventDefault()
-          }
+        if (!open && ['ArrowDown', 'ArrowUp', ' ', 'Enter'].includes(event.key)) {
+          onOpen?.('anchor-key-press')
+          event.preventDefault()
         }
       }
     },
-    [open, focusType, onOpen, onClose]
+    [open, onOpen]
   )
   const onAnchorClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
       if (!event.defaultPrevented && event.button === 0 && !open) {
         onOpen?.('anchor-click')
-        setFocusType('anchor')
       }
     },
     [open, onOpen]
@@ -109,7 +86,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   }, [position])
 
   useFocusZone({containerRef: overlayRef, disabled: !open || !position})
-  useFocusTrap({containerRef: overlayRef, disabled: !open || focusType !== 'list' || !position})
+  useFocusTrap({containerRef: overlayRef, disabled: !open || !position})
 
   return (
     <>
@@ -124,7 +101,6 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
       })}
       {open ? (
         <Overlay
-          initialFocusRef={anchorRef}
           returnFocusRef={anchorRef}
           onClickOutside={onClickOutside}
           onEscape={onEscape}


### PR DESCRIPTION
In the current implementation of `AnchoredOverlay`, the behavior for when to activate focus trapping is fairly complicated.  If the user clicks or presses space/Enter to open the overlay, focus stays on the anchor.  They can then use up/down arrow, enter, or tab to move focus _into_ the overlay.  If, however, they press up/down on the anchor initially, focus immediately moves into the overlay.  In initial development, this felt like a good approach.  However, real use has uncovered some corner cases which indicate the complex initial state might not be worth it.  In particular, some new `ActionMenu`s that also include a text input, as well as the `SelectPanel`, need focus to be trapped as soon as the overlay is opened.  The easiest solution is to simply _always_ move focus into the overlay, rather than conditionally starting focus on the anchor. 

Closes #1210

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
