### PR TITLE
feat: ActionList.Item dividers

### DIFF
--- a/docs/content/ActionList.mdx
+++ b/docs/content/ActionList.mdx
@@ -64,8 +64,9 @@ An `ActionList` is a list of items which can be activated or selected. `ActionLi
 
 ## Component props
 
-| Name          | Type                                |      Default      | Description                                                                                                                                             |
-| :------------ | :---------------------------------- | :---------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| items         | `ItemProps[]`                       |    `undefined`    | Required. A list of item objects conforming to the `ActionList.Item` props interface.                                                                   |
-| renderItem    | `(props: ItemProps) => JSX.Element` | `ActionList.Item` | Optional. If defined, each item in `items` will be passed to this function, allowing for `ActionList`-wide custom item rendering.                       |
-| groupMetadata | `GroupProps[]`                      |    `undefined`    | Optional. If defined, `ActionList` will group `items` into `ActionList.Group`s separated by `ActionList.Divider` according to their `groupId` property. |
+| Name             | Type                                |      Default      | Description                                                                                                                                             |
+| :--------------- | :---------------------------------- | :---------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| items            | `ItemProps[]`                       |    `undefined`    | Required. A list of item objects conforming to the `ActionList.Item` props interface.                                                                   |
+| renderItem       | `(props: ItemProps) => JSX.Element` | `ActionList.Item` | Optional. If defined, each item in `items` will be passed to this function, allowing for `ActionList`-wide custom item rendering.                       |
+| groupMetadata    | `GroupProps[]`                      |    `undefined`    | Optional. If defined, `ActionList` will group `items` into `ActionList.Group`s separated by `ActionList.Divider` according to their `groupId` property. |
+| showItemDividers | `boolean`                           |      `false`      | Optional. If `true` dividers will be displayed above each `ActionList.Item` which does not follow an `ActionList.Header` or `ActionList.Divider`        |

--- a/src/ActionList/Divider.tsx
+++ b/src/ActionList/Divider.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 import {get} from '../constants'
 
-const StyledDivider = styled.div`
+export const StyledDivider = styled.div`
   height: 1px;
   background: ${get('colors.selectMenu.borderSecondary')};
   margin-top: calc(${get('space.2')} - 1px);

--- a/src/ActionList/Group.tsx
+++ b/src/ActionList/Group.tsx
@@ -21,6 +21,11 @@ export interface GroupProps extends React.ComponentPropsWithoutRef<'div'>, SxPro
    * `Items` to render in the `Group`.
    */
   items?: JSX.Element[]
+
+  /**
+   * Whether to display a divider above each `Item` in this `Group` when it does not follow a `Header` or `Divider`.
+   */
+  showItemDividers?: boolean
 }
 
 const StyledGroup = styled.div`

--- a/src/ActionList/Header.tsx
+++ b/src/ActionList/Header.tsx
@@ -26,7 +26,7 @@ export interface HeaderProps extends React.ComponentPropsWithoutRef<'div'>, SxPr
   auxiliaryText?: string
 }
 
-const StyledHeader = styled.div<{variant: HeaderProps['variant']} & SxProp>`
+export const StyledHeader = styled.div<{variant: HeaderProps['variant']} & SxProp>`
    {
     /* 6px vertical padding + 20px line height = 32px total height
      *

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -54,6 +54,11 @@ export interface ItemProps extends Omit<React.ComponentPropsWithoutRef<'div'>, '
   variant?: 'default' | 'danger'
 
   /**
+   * Whether to display a divider above the `Item` when it does not follow a `Header` or `Divider`.
+   */
+  showDivider?: boolean
+
+  /**
    * For `Item`s which can be selected, whether the `Item` is currently selected.
    */
   selected?: boolean
@@ -119,7 +124,9 @@ const StyledItemContent = styled.div`
   width: 100%;
 `
 
-const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemInput} & SxProp>`
+const StyledItem = styled.div<
+  {variant: ItemProps['variant']; showDivider: ItemProps['showDivider']; item?: ItemInput} & SxProp
+>`
   /* 6px vertical padding + 20px line height = 32px total height
    *
    * TODO: When rem-based spacing on a 4px scale lands, replace
@@ -138,15 +145,18 @@ const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemInput} 
     }
   }
 
+  // Item dividers
   :not(:first-of-type):not(${StyledDivider} + &):not(${StyledHeader} + &) {
-    margin-top: 1px;
+    margin-top: ${({showDivider}) => (showDivider ? `1px` : '0')};
 
     ${StyledItemContent}::before {
       content: ' ';
       display: block;
       position: relative;
       top: -7px;
-      border-top: 1px solid ${get('colors.selectMenu.borderSecondary')};
+      // NB: This 'get' won’t execute if it’s moved into the arrow function below.
+      border: 0 solid ${get('colors.selectMenu.borderSecondary')};
+      border-top-width: ${({showDivider}) => (showDivider ? `1px` : '0')};
     }
   }
 
@@ -208,6 +218,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     trailingIcon: TrailingIcon,
     trailingText,
     variant = 'default',
+    showDivider,
     disabled,
     onAction,
     onKeyPress,
@@ -253,6 +264,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     <StyledItem
       tabIndex={disabled ? undefined : -1}
       variant={variant}
+      showDivider={showDivider}
       aria-selected={selected}
       {...props}
       data-id={id}

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -2,8 +2,11 @@ import {CheckIcon, IconProps} from '@primer/octicons-react'
 import React, {useCallback} from 'react'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
+import Flex from '../Flex'
 import {ItemInput} from './List'
 import styled from 'styled-components'
+import {StyledHeader} from './Header'
+import {StyledDivider} from './Divider'
 
 /**
  * Contract for props passed to the `Item` component.
@@ -112,6 +115,10 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
   }
 }
 
+const StyledItemContent = styled.div`
+  width: 100%;
+`
+
 const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemInput} & SxProp>`
   /* 6px vertical padding + 20px line height = 32px total height
    *
@@ -122,11 +129,24 @@ const StyledItem = styled.div<{variant: ItemProps['variant']; item?: ItemInput} 
   display: flex;
   border-radius: ${get('radii.2')};
   color: ${({variant, item}) => getItemVariant(variant, item?.disabled).color};
+  position: relative;
 
   @media (hover: hover) and (pointer: fine) {
     :hover {
       background: ${({variant, item}) => getItemVariant(variant, item?.disabled).hoverBackground};
       cursor: ${({variant, item}) => getItemVariant(variant, item?.disabled).hoverCursor};
+    }
+  }
+
+  :not(:first-of-type):not(${StyledDivider} + &):not(${StyledHeader} + &) {
+    margin-top: 1px;
+
+    ${StyledItemContent}::before {
+      content: ' ';
+      display: block;
+      position: relative;
+      top: -7px;
+      border-top: 1px solid ${get('colors.selectMenu.borderSecondary')};
     }
   }
 
@@ -259,25 +279,29 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
           <LeadingVisual />
         </LeadingVisualContainer>
       )}
-      {children}
-      {(text || description) && (
-        <StyledTextContainer descriptionVariant={descriptionVariant}>
-          {text && <div>{text}</div>}
-          {description && (
-            <DescriptionContainer descriptionVariant={descriptionVariant}>{description}</DescriptionContainer>
+      <StyledItemContent>
+        <Flex>
+          {children}
+          {(text || description) && (
+            <StyledTextContainer descriptionVariant={descriptionVariant}>
+              {text && <div>{text}</div>}
+              {description && (
+                <DescriptionContainer descriptionVariant={descriptionVariant}>{description}</DescriptionContainer>
+              )}
+            </StyledTextContainer>
           )}
-        </StyledTextContainer>
-      )}
-      {(TrailingIcon || trailingText) && (
-        <TrailingVisualContainer variant={variant} disabled={disabled}>
-          {trailingText && <div>{trailingText}</div>}
-          {TrailingIcon && (
-            <div>
-              <TrailingIcon />
-            </div>
+          {(TrailingIcon || trailingText) && (
+            <TrailingVisualContainer variant={variant} disabled={disabled}>
+              {trailingText && <div>{trailingText}</div>}
+              {TrailingIcon && (
+                <div>
+                  <TrailingIcon />
+                </div>
+              )}
+            </TrailingVisualContainer>
           )}
-        </TrailingVisualContainer>
-      )}
+        </Flex>
+      </StyledItemContent>
     </StyledItem>
   )
 }

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -136,7 +136,6 @@ const StyledItem = styled.div<
   display: flex;
   border-radius: ${get('radii.2')};
   color: ${({variant, item}) => getItemVariant(variant, item?.disabled).color};
-  position: relative;
 
   @media (hover: hover) and (pointer: fine) {
     :hover {

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -50,6 +50,11 @@ export interface ListPropsBase {
    *  For `Item`s which can be selected, whether `multiple` `Item`s or a `single` `Item` can be selected
    */
   selectionVariant?: 'single' | 'multiple'
+
+  /**
+   * Whether to display a divider above each `Item` in this `List` when it does not follow a `Header` or `Divider`.
+   */
+  showItemDividers?: boolean
 }
 
 /**
@@ -151,6 +156,7 @@ export function List(props: ListProps): JSX.Element {
     const key = itemProps.key ?? itemProps.id?.toString() ?? uniqueId()
     return (
       <ItemComponent
+        showDivider={props.showItemDividers}
         selectionVariant={props.selectionVariant}
         {...itemProps}
         key={key}
@@ -193,6 +199,7 @@ export function List(props: ListProps): JSX.Element {
           ...(group?.items ?? []),
           renderItem(
             {
+              showDivider: group?.showItemDividers,
               ...(group && 'renderItem' in group && {renderItem: group.renderItem}),
               ...itemProps
             },

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -58,6 +58,7 @@ export function ActionsStory(): JSX.Element {
       <h1>Actions</h1>
       <ErsatzOverlay>
         <ActionList
+          showItemDividers
           items={[
             {
               leadingVisual: ServerIcon,
@@ -87,11 +88,11 @@ export function SimpleListStory(): JSX.Element {
       <ErsatzOverlay>
         <ActionList
           items={[
-            {text: 'New file'},
+            {text: 'New file', showDivider: true},
             ActionList.Divider,
-            {text: 'Copy link'},
-            {text: 'Edit file'},
-            {text: 'Delete file', variant: 'danger'}
+            {text: 'Copy link', showDivider: true},
+            {text: 'Edit file', showDivider: true},
+            {text: 'Delete file', variant: 'danger', showDivider: true}
           ]}
         />
       </ErsatzOverlay>
@@ -155,7 +156,7 @@ export function ComplexListInsetVariantStory(): JSX.Element {
           groupMetadata={[
             {groupId: '0'},
             {groupId: '1', header: {title: 'Live query', variant: 'filled'}},
-            {groupId: '2', header: {title: 'Layout', variant: 'subtle'}},
+            {groupId: '2', header: {title: 'Layout', variant: 'subtle'}, showItemDividers: true},
             {groupId: '3', renderItem: props => <ActionList.Item style={{fontWeight: 'bold'}} {...props} />},
             {
               groupId: '4',


### PR DESCRIPTION
This PR adds a `showDivider` prop to `ActionList.Item` and corresponding `showItemDividers` props to `ActionList.Group` and `ActionList` to set `showDivider` for each `ActionList.Item` in an `ActionList.Group` or `ActionList`, respectively. 

Dividers are not displayed when an `ActionList.Item` immediately follows an `ActionList.Header` or `ActionList.Divider`, to avoid excessive horizontal rules.

### Screenshots
| `ActionList.Item`-level | `ActionList.Group`-level | `ActionList`-level |
|:---:|:---:|:---:|
| <img width="250" alt="Screenshot showing the effect of passing the 'showDivider' prop to 'ActionList.Item's" src="https://user-images.githubusercontent.com/3104489/118069756-b9378800-b372-11eb-9c45-5dc3b0eb5bc2.png"> | <img width="250" alt="Screenshot showing the effect of passing the 'showItemDividers' prop to 'ActionList.Group'" src="https://user-images.githubusercontent.com/3104489/118069761-bb014b80-b372-11eb-81e7-70ca4bd53991.png"> | <img width="250" alt="Screenshot showing the effect of passing the 'showItemDividers' prop to 'ActionList'" src="https://user-images.githubusercontent.com/3104489/118069752-b76dc480-b372-11eb-9aa1-e87bc6c5c496.png"> |

### Merge checklist
- [ ] Added/updated tests
- [x] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
