### PR TITLE
Add SelectPanel alpha component

### DIFF
--- a/.changeset/khaki-meals-pay.md
+++ b/.changeset/khaki-meals-pay.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Add `SelectPanel` alpha component

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -1,0 +1,10 @@
+---
+title: SelectPanel
+status: Alpha
+---
+
+A `SelectPanel` provides an anchor that will open an overlay with a list of selectable items, and a text input to filter the selectable items
+
+## Example
+
+## Component props

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
+import React, {useCallback} from 'react'
 import {GroupedListProps, ListPropsBase} from '../ActionList/List'
-import TextInput from '../TextInput'
+import TextInput, {TextInputProps} from '../TextInput'
 import Box from '../Box'
 import SelectMenu from '../SelectMenu'
 import {ActionList} from '../ActionList'
@@ -8,31 +8,36 @@ import {ActionList} from '../ActionList'
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
   placeholderText: string
-  filterValue: string
-  onChange: (e: React.ChangeEvent<HTMLInputElement>) => unknown
+  setFilter: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
+  textInputProps?: Partial<TextInputProps>
 }
 
 export function FilteredActionList({
   loading = false,
   placeholderText,
-  filterValue,
-  onChange,
+  setFilter,
   items,
+  textInputProps,
   ...listProps
 }: FilteredActionListProps): JSX.Element {
+  const onInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = e.target.value
+      setFilter(value, e)
+    },
+    [setFilter]
+  )
+
   return (
     <>
       <TextInput
         block
         width="auto"
         color="text.primary"
-        defaultValue={filterValue}
-        onChange={onChange}
+        onChange={onInputChange}
         placeholder={placeholderText}
         aria-label={placeholderText}
-        mx={2}
-        my={2}
-        contrast
+        {...textInputProps}
       />
       <Box flexGrow={1} overflow="auto">
         {loading ? <SelectMenu.LoadingAnimation /> : <ActionList items={items} {...listProps} role="listbox" />}

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -9,7 +9,7 @@ export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, 
   loading?: boolean
   placeholderText: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
-  textInputProps?: Partial<TextInputProps>
+  textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>
 }
 
 export function FilteredActionList({

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -8,14 +8,14 @@ import {ActionList} from '../ActionList'
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
   placeholderText: string
-  setFilter: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
+  onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<TextInputProps>
 }
 
 export function FilteredActionList({
   loading = false,
   placeholderText,
-  setFilter,
+  onFilterChange,
   items,
   textInputProps,
   ...listProps
@@ -23,9 +23,9 @@ export function FilteredActionList({
   const onInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
-      setFilter(value, e)
+      onFilterChange(value, e)
     },
-    [setFilter]
+    [onFilterChange]
   )
 
   return (

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import {GroupedListProps, ListPropsBase} from '../ActionList/List'
+import TextInput from '../TextInput'
+import Box from '../Box'
+import SelectMenu from '../SelectMenu'
+import {ActionList} from '../ActionList'
+
+export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
+  loading?: boolean
+  placeholderText: string
+  filterValue: string
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => unknown
+}
+
+export function FilteredActionList({
+  loading = false,
+  placeholderText,
+  filterValue,
+  onChange,
+  items,
+  ...listProps
+}: FilteredActionListProps): JSX.Element {
+  return (
+    <>
+      <TextInput
+        block
+        width="auto"
+        color="text.primary"
+        defaultValue={filterValue}
+        onChange={onChange}
+        placeholder={placeholderText}
+        aria-label={placeholderText}
+        mx={2}
+        my={2}
+        contrast
+      />
+      <Box flexGrow={1} overflow="auto">
+        {loading ? <SelectMenu.LoadingAnimation /> : <ActionList items={items} {...listProps} role="listbox" />}
+      </Box>
+    </>
+  )
+}
+
+FilteredActionList.displayName = 'FilteredActionList'

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -2,8 +2,8 @@ import React, {useCallback} from 'react'
 import {GroupedListProps, ListPropsBase} from '../ActionList/List'
 import TextInput, {TextInputProps} from '../TextInput'
 import Box from '../Box'
-import SelectMenu from '../SelectMenu'
 import {ActionList} from '../ActionList'
+import Spinner from '../Spinner'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
@@ -40,7 +40,13 @@ export function FilteredActionList({
         {...textInputProps}
       />
       <Box flexGrow={1} overflow="auto">
-        {loading ? <SelectMenu.LoadingAnimation /> : <ActionList items={items} {...listProps} role="listbox" />}
+        {loading ? (
+          <Box width="100%" display="flex" flexDirection="row" justifyContent="center" pt={6} pb={7}>
+            <Spinner />
+          </Box>
+        ) : (
+          <ActionList items={items} {...listProps} role="listbox" />
+        )}
       </Box>
     </>
   )

--- a/src/FilteredActionList/index.ts
+++ b/src/FilteredActionList/index.ts
@@ -1,0 +1,2 @@
+export {FilteredActionList} from './FilteredActionList'
+export type {FilteredActionListProps} from './FilteredActionList'

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -106,8 +106,7 @@ export function SelectPanel({
           if (isMultiSelectVariant(selected)) {
             // multi select
             const otherSelectedItems = selected.filter(selectedItem => selectedItem !== item)
-            const newSelectedItems =
-              !item || selected.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
+            const newSelectedItems = selected.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
 
             const multiSelectOnChange = onSelectedChange as SelectPanelMultiSelection['onSelectedChange']
             multiSelectOnChange(newSelectedItems)

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -3,7 +3,7 @@ import {FilteredActionList, FilteredActionListProps} from '../FilteredActionList
 import {OverlayProps} from '../Overlay'
 import {ItemInput} from '../ActionList/List'
 import {FocusZoneSettings} from '../behaviors/focusZone'
-import {DropdownButton, DropdownButtonProps} from '../DropdownMenu'
+import {DropdownButton} from '../DropdownMenu'
 import {ItemProps} from '../ActionList'
 import {AnchoredOverlay, AnchoredOverlayProps} from '../AnchoredOverlay'
 import Flex from '../Flex'
@@ -57,7 +57,7 @@ const textInputProps: Partial<TextInputProps> = {
 export function SelectPanel({
   open,
   setOpen,
-  renderAnchor = <T extends DropdownButtonProps>(props: T) => <DropdownButton {...props} />,
+  renderAnchor = props => <DropdownButton {...props} />,
   placeholder,
   selected,
   setSelected,
@@ -76,8 +76,8 @@ export function SelectPanel({
     [setFilter, setOpen]
   )
 
-  const renderMenuAnchor = useCallback(
-    <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
+  const renderMenuAnchor: AnchoredOverlayProps['renderAnchor'] = useCallback(
+    props => {
       const selectedItems = Array.isArray(selected) ? selected : [...(selected ? [selected] : [])]
 
       return renderAnchor({

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -1,25 +1,44 @@
 import React, {useCallback, useMemo} from 'react'
-
 import {FilteredActionList, FilteredActionListProps} from '../FilteredActionList'
 import {OverlayProps} from '../Overlay'
 import {ItemInput} from '../ActionList/List'
 import {FocusZoneSettings} from '../behaviors/focusZone'
 import {DropdownButton, DropdownButtonProps} from '../DropdownMenu'
 import {ItemProps} from '../ActionList'
-import {AnchoredOverlay} from '../AnchoredOverlay'
+import {AnchoredOverlay, AnchoredOverlayProps} from '../AnchoredOverlay'
 import Flex from '../Flex'
+import {TextInputProps} from '../TextInput'
 
-export interface SelectPanelProps extends Omit<FilteredActionListProps, 'onChange'> {
-  open: boolean
-  onOpen: (gesture: 'anchor-click' | 'anchor-key-press') => unknown
-  onClose: (gesture: 'click-outside' | 'escape') => unknown
-  renderAnchor?: <T extends React.HTMLAttributes<HTMLElement>>(props: T) => JSX.Element
+interface SelectPanelSingleSelection {
+  selected: ItemInput | undefined
+  setSelected: (selected: ItemInput | undefined) => void
+}
+
+interface SelectPanelMultiSelection {
+  selected: ItemInput[]
+  setSelected: (selected: ItemInput[]) => void
+}
+
+interface SelectPanelBaseProps {
+  renderAnchor?: AnchoredOverlayProps['renderAnchor']
+  setOpen: (
+    open: boolean,
+    gesture: 'anchor-click' | 'anchor-key-press' | 'click-outside' | 'escape' | 'selection'
+  ) => void
   placeholder?: string
-  selectedItems: ItemInput[]
-  selectionVariant?: 'single' | 'multiple'
-  onChange?: (selectedItems: ItemInput[]) => unknown
-  onFilterChange: (e: React.ChangeEvent<HTMLInputElement>) => unknown
+  setFilter: (value: string, e?: React.ChangeEvent<HTMLInputElement>) => void
   overlayProps?: Partial<OverlayProps>
+}
+
+export type SelectPanelProps = SelectPanelBaseProps &
+  Omit<FilteredActionListProps, 'setFilter' | 'selectionVariant'> &
+  Pick<AnchoredOverlayProps, 'open'> &
+  (SelectPanelSingleSelection | SelectPanelMultiSelection)
+
+function isMultiSelectVariant(
+  selected: SelectPanelSingleSelection['selected'] | SelectPanelMultiSelection['selected']
+): selected is SelectPanelMultiSelection['selected'] {
+  return Array.isArray(selected)
 }
 
 const focusZoneSettings: Partial<FocusZoneSettings> = {
@@ -29,36 +48,54 @@ const focusZoneSettings: Partial<FocusZoneSettings> = {
   }
 }
 
+const textInputProps: Partial<TextInputProps> = {
+  mx: 2,
+  my: 2,
+  contrast: true
+}
+
 export function SelectPanel({
   open,
-  onOpen,
-  onClose,
+  setOpen,
   renderAnchor = <T extends DropdownButtonProps>(props: T) => <DropdownButton {...props} />,
   placeholder,
-  selectedItems,
-  selectionVariant = 'single',
-  onChange,
-  onFilterChange,
+  selected,
+  setSelected,
+  setFilter,
   items,
   overlayProps,
   ...listProps
 }: SelectPanelProps): JSX.Element {
+  const onOpen: AnchoredOverlayProps['onOpen'] = useCallback(gesture => setOpen(true, gesture), [setOpen])
+  const onClose = useCallback(
+    (gesture: 'click-outside' | 'escape' | 'selection') => {
+      setOpen(false, gesture)
+      // ensure consuming component clears filter since the input will be blank on next open
+      setFilter('')
+    },
+    [setFilter, setOpen]
+  )
+
   const renderMenuAnchor = useCallback(
     <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
+      const selectedItems = Array.isArray(selected) ? selected : [...(selected ? [selected] : [])]
+
       return renderAnchor({
         ...props,
         children: selectedItems.length ? selectedItems.map(item => item.text).join(', ') : placeholder
       })
     },
-    [placeholder, renderAnchor, selectedItems]
+    [placeholder, renderAnchor, selected]
   )
 
   const itemsToRender = useMemo(() => {
     return items.map(item => {
+      const isItemSelected = isMultiSelectVariant(selected) ? selected.includes(item) : selected === item
+
       return {
         ...item,
         role: 'option',
-        selected: 'selected' in item && item.selected === undefined ? undefined : selectedItems.includes(item),
+        selected: 'selected' in item && item.selected === undefined ? undefined : isItemSelected,
         onAction: (itemFromAction, event) => {
           item.onAction?.(itemFromAction, event)
 
@@ -66,21 +103,25 @@ export function SelectPanel({
             return
           }
 
-          if (selectionVariant === 'single') {
-            const newSelectedItems = !item || selectedItems.includes(item) ? [] : [item]
-            onChange?.(newSelectedItems)
+          if (isMultiSelectVariant(selected)) {
+            // multi select
+            const otherSelectedItems = selected.filter(selectedItem => selectedItem !== item)
+            const newSelectedItems =
+              !item || selected.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
+
+            const multiSelectOnChange = setSelected as SelectPanelMultiSelection['setSelected']
+            multiSelectOnChange(newSelectedItems)
             return
           }
 
-          const otherSelectedItems = selectedItems.filter(selectedItem => selectedItem !== item)
-          const newSelectedItems =
-            !item || selectedItems.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
-
-          onChange?.(newSelectedItems)
+          // single select
+          const singleSelectOnChange = setSelected as SelectPanelSingleSelection['setSelected']
+          singleSelectOnChange(item === selected ? undefined : item)
+          onClose('selection')
         }
       } as ItemProps
     })
-  }, [items, onChange, selectedItems, selectionVariant])
+  }, [onClose, items, selected, setSelected])
 
   return (
     <AnchoredOverlay
@@ -93,11 +134,12 @@ export function SelectPanel({
     >
       <Flex flexDirection="column" width="100%" height="100%">
         <FilteredActionList
-          onChange={onFilterChange}
+          setFilter={setFilter}
           {...listProps}
           role="listbox"
           items={itemsToRender}
-          selectionVariant={selectionVariant}
+          selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
+          textInputProps={textInputProps}
         />
       </Flex>
     </AnchoredOverlay>

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -1,0 +1,107 @@
+import React, {useCallback, useMemo} from 'react'
+
+import {FilteredActionList, FilteredActionListProps} from '../FilteredActionList'
+import {OverlayProps} from '../Overlay'
+import {ItemInput} from '../ActionList/List'
+import {FocusZoneSettings} from '../behaviors/focusZone'
+import {DropdownButton, DropdownButtonProps} from '../DropdownMenu'
+import {ItemProps} from '../ActionList'
+import {AnchoredOverlay} from '../AnchoredOverlay'
+import Flex from '../Flex'
+
+export interface SelectPanelProps extends Omit<FilteredActionListProps, 'onChange'> {
+  open: boolean
+  onOpen: (gesture: 'anchor-click' | 'anchor-key-press') => unknown
+  onClose: (gesture: 'click-outside' | 'escape') => unknown
+  renderAnchor?: <T extends React.HTMLAttributes<HTMLElement>>(props: T) => JSX.Element
+  placeholder?: string
+  selectedItems: ItemInput[]
+  selectionVariant?: 'single' | 'multiple'
+  onChange?: (selectedItems: ItemInput[]) => unknown
+  onFilterChange: (e: React.ChangeEvent<HTMLInputElement>) => unknown
+  overlayProps?: Partial<OverlayProps>
+}
+
+const focusZoneSettings: Partial<FocusZoneSettings> = {
+  focusOutBehavior: 'wrap',
+  focusableElementFilter: element => {
+    return !(element instanceof HTMLInputElement) || element.type !== 'checkbox'
+  }
+}
+
+export function SelectPanel({
+  open,
+  onOpen,
+  onClose,
+  renderAnchor = <T extends DropdownButtonProps>(props: T) => <DropdownButton {...props} />,
+  placeholder,
+  selectedItems,
+  selectionVariant = 'single',
+  onChange,
+  onFilterChange,
+  items,
+  overlayProps,
+  ...listProps
+}: SelectPanelProps): JSX.Element {
+  const renderMenuAnchor = useCallback(
+    <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
+      return renderAnchor({
+        ...props,
+        children: selectedItems.length ? selectedItems.map(item => item.text).join(', ') : placeholder
+      })
+    },
+    [placeholder, renderAnchor, selectedItems]
+  )
+
+  const itemsToRender = useMemo(() => {
+    return items.map(item => {
+      return {
+        ...item,
+        role: 'option',
+        selected: 'selected' in item && item.selected === undefined ? undefined : selectedItems.includes(item),
+        onAction: (itemFromAction, event) => {
+          item.onAction?.(itemFromAction, event)
+
+          if (event.defaultPrevented) {
+            return
+          }
+
+          if (selectionVariant === 'single') {
+            const newSelectedItems = !item || selectedItems.includes(item) ? [] : [item]
+            onChange?.(newSelectedItems)
+            return
+          }
+
+          const otherSelectedItems = selectedItems.filter(selectedItem => selectedItem !== item)
+          const newSelectedItems =
+            !item || selectedItems.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
+
+          onChange?.(newSelectedItems)
+        }
+      } as ItemProps
+    })
+  }, [items, onChange, selectedItems, selectionVariant])
+
+  return (
+    <AnchoredOverlay
+      renderAnchor={renderMenuAnchor}
+      open={open}
+      onOpen={onOpen}
+      onClose={onClose}
+      overlayProps={overlayProps}
+      focusZoneSettings={focusZoneSettings}
+    >
+      <Flex flexDirection="column" width="100%" height="100%">
+        <FilteredActionList
+          onChange={onFilterChange}
+          {...listProps}
+          role="listbox"
+          items={itemsToRender}
+          selectionVariant={selectionVariant}
+        />
+      </Flex>
+    </AnchoredOverlay>
+  )
+}
+
+SelectPanel.displayName = 'SelectPanel'

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -11,27 +11,27 @@ import {TextInputProps} from '../TextInput'
 
 interface SelectPanelSingleSelection {
   selected: ItemInput | undefined
-  setSelected: (selected: ItemInput | undefined) => void
+  onSelectedChange: (selected: ItemInput | undefined) => void
 }
 
 interface SelectPanelMultiSelection {
   selected: ItemInput[]
-  setSelected: (selected: ItemInput[]) => void
+  onSelectedChange: (selected: ItemInput[]) => void
 }
 
 interface SelectPanelBaseProps {
   renderAnchor?: AnchoredOverlayProps['renderAnchor']
-  setOpen: (
+  onOpenChange: (
     open: boolean,
     gesture: 'anchor-click' | 'anchor-key-press' | 'click-outside' | 'escape' | 'selection'
   ) => void
   placeholder?: string
-  setFilter: (value: string, e?: React.ChangeEvent<HTMLInputElement>) => void
+  onFilterChange: (value: string, e?: React.ChangeEvent<HTMLInputElement>) => void
   overlayProps?: Partial<OverlayProps>
 }
 
 export type SelectPanelProps = SelectPanelBaseProps &
-  Omit<FilteredActionListProps, 'setFilter' | 'selectionVariant'> &
+  Omit<FilteredActionListProps, 'onFilterChange' | 'selectionVariant'> &
   Pick<AnchoredOverlayProps, 'open'> &
   (SelectPanelSingleSelection | SelectPanelMultiSelection)
 
@@ -56,24 +56,24 @@ const textInputProps: Partial<TextInputProps> = {
 
 export function SelectPanel({
   open,
-  setOpen,
+  onOpenChange,
   renderAnchor = props => <DropdownButton {...props} />,
   placeholder,
   selected,
-  setSelected,
-  setFilter,
+  onSelectedChange,
+  onFilterChange,
   items,
   overlayProps,
   ...listProps
 }: SelectPanelProps): JSX.Element {
-  const onOpen: AnchoredOverlayProps['onOpen'] = useCallback(gesture => setOpen(true, gesture), [setOpen])
+  const onOpen: AnchoredOverlayProps['onOpen'] = useCallback(gesture => onOpenChange(true, gesture), [onOpenChange])
   const onClose = useCallback(
     (gesture: 'click-outside' | 'escape' | 'selection') => {
-      setOpen(false, gesture)
+      onOpenChange(false, gesture)
       // ensure consuming component clears filter since the input will be blank on next open
-      setFilter('')
+      onFilterChange('')
     },
-    [setFilter, setOpen]
+    [onFilterChange, onOpenChange]
   )
 
   const renderMenuAnchor: AnchoredOverlayProps['renderAnchor'] = useCallback(
@@ -109,19 +109,19 @@ export function SelectPanel({
             const newSelectedItems =
               !item || selected.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
 
-            const multiSelectOnChange = setSelected as SelectPanelMultiSelection['setSelected']
+            const multiSelectOnChange = onSelectedChange as SelectPanelMultiSelection['onSelectedChange']
             multiSelectOnChange(newSelectedItems)
             return
           }
 
           // single select
-          const singleSelectOnChange = setSelected as SelectPanelSingleSelection['setSelected']
+          const singleSelectOnChange = onSelectedChange as SelectPanelSingleSelection['onSelectedChange']
           singleSelectOnChange(item === selected ? undefined : item)
           onClose('selection')
         }
       } as ItemProps
     })
-  }, [onClose, items, selected, setSelected])
+  }, [onClose, onSelectedChange, items, selected])
 
   return (
     <AnchoredOverlay
@@ -134,7 +134,7 @@ export function SelectPanel({
     >
       <Flex flexDirection="column" width="100%" height="100%">
         <FilteredActionList
-          setFilter={setFilter}
+          onFilterChange={onFilterChange}
           {...listProps}
           role="listbox"
           items={itemsToRender}

--- a/src/SelectPanel/index.ts
+++ b/src/SelectPanel/index.ts
@@ -1,0 +1,2 @@
+export {SelectPanel} from './SelectPanel'
+export type {SelectPanelProps} from './SelectPanel'

--- a/src/__tests__/SelectPanel.tsx
+++ b/src/__tests__/SelectPanel.tsx
@@ -14,8 +14,8 @@ expect.extend(toHaveNoViolations)
 const items = [{text: 'Foo'}, {text: 'Bar'}, {text: 'Baz'}, {text: 'Bon'}] as ItemInput[]
 
 function SimpleSelectPanel(): JSX.Element {
-  const [selectedItems, setSelectedItems] = React.useState<ItemInput[]>([])
-  const [filterValue, setFilterValue] = React.useState('')
+  const [selected, setSelected] = React.useState<ItemInput[]>([])
+  const [, setFilter] = React.useState('')
   const [open, setOpen] = React.useState(false)
 
   return (
@@ -25,13 +25,11 @@ function SimpleSelectPanel(): JSX.Element {
           items={items}
           placeholder="Select Items"
           placeholderText="Filter Items"
-          selectedItems={selectedItems}
-          onChange={setSelectedItems}
-          filterValue={filterValue}
-          onFilterChange={e => setFilterValue(e.target.value)}
+          selected={selected}
+          setSelected={setSelected}
+          setFilter={setFilter}
           open={open}
-          onOpen={() => setOpen(true)}
-          onClose={() => setOpen(false)}
+          setOpen={setOpen}
         />
         <div id="portal-root"></div>
       </BaseStyles>

--- a/src/__tests__/SelectPanel.tsx
+++ b/src/__tests__/SelectPanel.tsx
@@ -1,0 +1,65 @@
+import {cleanup, render as HTMLRender} from '@testing-library/react'
+import 'babel-polyfill'
+import {axe, toHaveNoViolations} from 'jest-axe'
+import React from 'react'
+import theme from '../theme'
+import {SelectPanel} from '../SelectPanel'
+import {COMMON} from '../constants'
+import {behavesAsComponent, checkExports} from '../utils/testing'
+import {BaseStyles, ThemeProvider} from '..'
+import {ItemInput} from '../ActionList/List'
+
+expect.extend(toHaveNoViolations)
+
+const items = [{text: 'Foo'}, {text: 'Bar'}, {text: 'Baz'}, {text: 'Bon'}] as ItemInput[]
+
+function SimpleSelectPanel(): JSX.Element {
+  const [selectedItems, setSelectedItems] = React.useState<ItemInput[]>([])
+  const [filterValue, setFilterValue] = React.useState('')
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <ThemeProvider theme={theme}>
+      <BaseStyles>
+        <SelectPanel
+          items={items}
+          placeholder="Select Items"
+          placeholderText="Filter Items"
+          selectedItems={selectedItems}
+          onChange={setSelectedItems}
+          filterValue={filterValue}
+          onFilterChange={e => setFilterValue(e.target.value)}
+          open={open}
+          onOpen={() => setOpen(true)}
+          onClose={() => setOpen(false)}
+        />
+        <div id="portal-root"></div>
+      </BaseStyles>
+    </ThemeProvider>
+  )
+}
+
+describe('SelectPanel', () => {
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  behavesAsComponent({
+    Component: SelectPanel,
+    systemPropArray: [COMMON],
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <SimpleSelectPanel />
+  })
+
+  checkExports('SelectPanel', {
+    default: undefined,
+    SelectPanel
+  })
+
+  it('should have no axe violations', async () => {
+    const {container} = HTMLRender(<SimpleSelectPanel />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+    cleanup()
+  })
+})

--- a/src/__tests__/SelectPanel.tsx
+++ b/src/__tests__/SelectPanel.tsx
@@ -26,10 +26,10 @@ function SimpleSelectPanel(): JSX.Element {
           placeholder="Select Items"
           placeholderText="Filter Items"
           selected={selected}
-          setSelected={setSelected}
-          setFilter={setFilter}
+          onSelectedChange={setSelected}
+          onFilterChange={setFilter}
           open={open}
-          setOpen={setOpen}
+          onOpenChange={setOpen}
         />
         <div id="portal-root"></div>
       </BaseStyles>

--- a/src/__tests__/__snapshots__/SelectPanel.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.tsx.snap
@@ -1,0 +1,122 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SelectPanel renders consistently 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji";
+  line-height: 1.5;
+  color: #24292e;
+}
+
+.c1 {
+  position: relative;
+  display: inline-block;
+  padding: 6px 16px;
+  font-family: inherit;
+  font-weight: 600;
+  line-height: 20px;
+  white-space: nowrap;
+  vertical-align: middle;
+  cursor: pointer;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+  border-radius: 6px;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  text-align: center;
+  font-size: 14px;
+  color: #24292e;
+  background-color: #fafbfc;
+  border: 1px solid rgba(27,31,35,0.15);
+  box-shadow: 0 1px 0 rgba(27,31,35,0.04),inset 0 1px 0 rgba(255,255,255,0.25);
+}
+
+.c1:hover {
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1:focus {
+  outline: none;
+}
+
+.c1:disabled {
+  cursor: default;
+}
+
+.c1:disabled svg {
+  opacity: 0.6;
+}
+
+.c1:hover {
+  background-color: #f3f4f6;
+  border-color: rgba(27,31,35,0.15);
+}
+
+.c1:focus {
+  border-color: rgba(27,31,35,0.15);
+  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+}
+
+.c1:active {
+  background-color: #edeff2;
+  box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+}
+
+.c1:disabled {
+  color: #959da5;
+  background-color: #fafbfc;
+  border-color: rgba(27,31,35,0.15);
+}
+
+.c2 {
+  margin-left: 4px;
+}
+
+<div
+  className="c0"
+  color="text.primary"
+  data-portal-root={true}
+  fontFamily="normal"
+>
+  <button
+    aria-haspopup="listbox"
+    aria-labelledby="__primer_id_10000"
+    className="c1"
+    id="__primer_id_10000"
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    tabIndex={0}
+  >
+    Select Items
+    <svg
+      aria-hidden="true"
+      className="c2"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "<path d=\\"M4.427 7.427l3.396 3.396a.25.25 0 00.354 0l3.396-3.396A.25.25 0 0011.396 7H4.604a.25.25 0 00-.177.427z\\"></path>",
+        }
+      }
+      fill="currentColor"
+      height={16}
+      role="img"
+      style={
+        Object {
+          "display": "inline-block",
+          "userSelect": "none",
+          "verticalAlign": "text-bottom",
+        }
+      }
+      viewBox="0 0 16 16"
+      width={16}
+    />
+  </button>
+  <div
+    id="portal-root"
+  />
+</div>
+`;

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -1,11 +1,10 @@
 import {Meta} from '@storybook/react'
-import React, {useCallback, useState} from 'react'
+import React, {useState} from 'react'
 import {theme, ThemeProvider} from '..'
 import {ItemInput} from '../ActionList/List'
 import BaseStyles from '../BaseStyles'
 import {DropdownButton} from '../DropdownMenu'
 import {SelectPanel} from '../SelectPanel'
-import {ItemProps} from '../ActionList'
 import BorderBox from '../BorderBox'
 
 const meta: Meta = {
@@ -36,28 +35,23 @@ function getColorCircle(color: string) {
   }
 }
 
-export function LabelStory(): JSX.Element {
-  const items = React.useMemo(
-    (): ItemProps[] => [
-      {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
-      {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
-      {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
-      {leadingVisual: getColorCircle('#8dc6fc'), text: 'design', id: 4}
-    ],
-    []
-  )
-  const [selectedItems, setSelectedItems] = React.useState<ItemInput[]>([items[0], items[1]])
-  const [filterValue, setFilterValue] = React.useState('')
-  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filterValue.toLowerCase()))
-  const onFilterChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setFilterValue(e.target.value), [])
+const items = [
+  {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
+  {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
+  {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
+  {leadingVisual: getColorCircle('#8dc6fc'), text: 'design', id: 4}
+]
+
+export function MultiSelectStory(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput[]>([items[0], items[1]])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
   const [open, setOpen] = useState(false)
-  const onOpen = useCallback(() => setOpen(true), [])
-  const onClose = useCallback(() => setOpen(false), [])
 
   return (
     <>
-      <h1>Label Select Panel</h1>
-      <div id="">Please select labels that describe your issue:</div>
+      <h1>Multi Select Panel</h1>
+      <div>Please select labels that describe your issue:</div>
       <SelectPanel
         renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
           <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
@@ -66,16 +60,42 @@ export function LabelStory(): JSX.Element {
         )}
         placeholderText="Filter Labels"
         open={open}
-        onOpen={onOpen}
-        onClose={onClose}
+        setOpen={setOpen}
         items={filteredItems}
-        selectedItems={selectedItems}
-        onChange={setSelectedItems}
-        filterValue={filterValue}
-        onFilterChange={onFilterChange}
-        selectionVariant="multiple"
+        selected={selected}
+        setSelected={setSelected}
+        setFilter={setFilter}
       />
     </>
   )
 }
-LabelStory.storyName = 'Label Multi-Select'
+MultiSelectStory.storyName = 'Multi Select'
+
+export function SingleSelectStory(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <h1>Single Select Panel</h1>
+      <div>Please select a label that describe your issue:</div>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={open}
+        setOpen={setOpen}
+        items={filteredItems}
+        selected={selected}
+        setSelected={setSelected}
+        setFilter={setFilter}
+      />
+    </>
+  )
+}
+SingleSelectStory.storyName = 'Single Select'

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -1,0 +1,81 @@
+import {Meta} from '@storybook/react'
+import React, {useCallback, useState} from 'react'
+import {theme, ThemeProvider} from '..'
+import {ItemInput} from '../ActionList/List'
+import BaseStyles from '../BaseStyles'
+import {DropdownButton} from '../DropdownMenu'
+import {SelectPanel} from '../SelectPanel'
+import {ItemProps} from '../ActionList'
+import BorderBox from '../BorderBox'
+
+const meta: Meta = {
+  title: 'Composite components/SelectPanel',
+  component: SelectPanel,
+  decorators: [
+    (Story: React.ComponentType): JSX.Element => {
+      return (
+        <ThemeProvider theme={theme}>
+          <BaseStyles>
+            <Story />
+          </BaseStyles>
+        </ThemeProvider>
+      )
+    }
+  ],
+  parameters: {
+    controls: {
+      disable: true
+    }
+  }
+}
+export default meta
+
+function getColorCircle(color: string) {
+  return function () {
+    return <BorderBox bg={color} borderColor={color} padding={2} borderRadius={10} />
+  }
+}
+
+export function LabelStory(): JSX.Element {
+  const items = React.useMemo(
+    (): ItemProps[] => [
+      {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
+      {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
+      {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
+      {leadingVisual: getColorCircle('#8dc6fc'), text: 'design', id: 4}
+    ],
+    []
+  )
+  const [selectedItems, setSelectedItems] = React.useState<ItemInput[]>([items[0], items[1]])
+  const [filterValue, setFilterValue] = React.useState('')
+  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filterValue.toLowerCase()))
+  const onFilterChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => setFilterValue(e.target.value), [])
+  const [open, setOpen] = useState(false)
+  const onOpen = useCallback(() => setOpen(true), [])
+  const onClose = useCallback(() => setOpen(false), [])
+
+  return (
+    <>
+      <h1>Label Select Panel</h1>
+      <div id="">Please select labels that describe your issue:</div>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={open}
+        onOpen={onOpen}
+        onClose={onClose}
+        items={filteredItems}
+        selectedItems={selectedItems}
+        onChange={setSelectedItems}
+        filterValue={filterValue}
+        onFilterChange={onFilterChange}
+        selectionVariant="multiple"
+      />
+    </>
+  )
+}
+LabelStory.storyName = 'Label Multi-Select'

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -60,11 +60,11 @@ export function MultiSelectStory(): JSX.Element {
         )}
         placeholderText="Filter Labels"
         open={open}
-        setOpen={setOpen}
+        onOpenChange={setOpen}
         items={filteredItems}
         selected={selected}
-        setSelected={setSelected}
-        setFilter={setFilter}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
       />
     </>
   )
@@ -89,11 +89,11 @@ export function SingleSelectStory(): JSX.Element {
         )}
         placeholderText="Filter Labels"
         open={open}
-        setOpen={setOpen}
+        onOpenChange={setOpen}
         items={filteredItems}
         selected={selected}
-        setSelected={setSelected}
-        setFilter={setFilter}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
       />
     </>
   )

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -45,7 +45,7 @@ const items = [
 export function MultiSelectStory(): JSX.Element {
   const [selected, setSelected] = React.useState<ItemInput[]>([items[0], items[1]])
   const [filter, setFilter] = React.useState('')
-  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
   const [open, setOpen] = useState(false)
 
   return (
@@ -74,7 +74,7 @@ MultiSelectStory.storyName = 'Multi Select'
 export function SingleSelectStory(): JSX.Element {
   const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])
   const [filter, setFilter] = React.useState('')
-  const filteredItems = items.filter(item => item.text?.toLowerCase().startsWith(filter.toLowerCase()))
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
   const [open, setOpen] = useState(false)
 
   return (


### PR DESCRIPTION
This is the initial pass at `SelectPanel` (#1071).  There are still a number of enhancements that will need to be made, to be implemented in subsequent PRs.  Basic scaffolding for docs and tests have been added since this component is `Alpha`.

Also including the `FilteredActionList` component.  We _could_ incorporate this component directly into the `SelectPanel`, but I think it's a little easier to separate responsibilities by pulling it out.  If we intend to use it elsewhere without `SelectPanel`, we will need to add additional docs and tests.

I'm definitely open to discussing the API and implementation.  The current API makes this component _ultra_ controlled, which means flexibility, but also a _lot_ of setup on the consumer side to use it.  I think this is evident if you look at the story and tests.  There are ~10 props required to use it properly.

### Screenshots
![image](https://user-images.githubusercontent.com/3026298/118079361-eaad5500-b36c-11eb-95d9-64faa03db836.png)

### Merge checklist
- [x] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge