### PR TITLE
fix(focusZone): handle complex child reordering

### DIFF
--- a/.changeset/yellow-dolphins-grin.md
+++ b/.changeset/yellow-dolphins-grin.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+handle complex child reordering within a focusZone

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -440,15 +440,18 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
   // If the DOM structure of the container changes, make sure we keep our state up-to-date
   // with respect to the focusable elements cache and its order
   const observer = new MutationObserver(mutations => {
+    // Perform all removals first, in case element order has simply changed
+    for (const mutation of mutations) {
+      for (const removedNode of mutation.removedNodes) {
+        if (removedNode instanceof HTMLElement) {
+          endFocusManagement(...iterateFocusableElements(removedNode))
+        }
+      }
+    }
     for (const mutation of mutations) {
       for (const addedNode of mutation.addedNodes) {
         if (addedNode instanceof HTMLElement) {
           beginFocusManagement(...iterateFocusableElements(addedNode))
-        }
-      }
-      for (const removedNode of mutation.removedNodes) {
-        if (removedNode instanceof HTMLElement) {
-          endFocusManagement(...iterateFocusableElements(removedNode))
         }
       }
     }


### PR DESCRIPTION
Using `focusZone` in `SelectPanel`, I have noticed scenarios where filtering causes items to still be present, but reorder based on similarity to the filter.  In these scenarios, focusZone currently has a tendency to mix up the focus order.  This happens when two items are moved, but put back in opposite order.  To avoid this confusion, we can simply handle all removals _first_, then handle additions.

### Merge checklist
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge