### PR TITLE
SideNav: adding box-shadow under focus pseudo selector (#1219)

### DIFF
--- a/.changeset/dull-radios-shave.md
+++ b/.changeset/dull-radios-shave.md
@@ -2,4 +2,4 @@
 '@primer/components': patch
 ---
 
-brings `SideNav` closer to the Primer CSS proposal to use state-focus-shadow for the component `SideNavLink` focus state
+Change focus state style of `SideNav.Link`

--- a/.changeset/dull-radios-shave.md
+++ b/.changeset/dull-radios-shave.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+brings `SideNav` closer to the Primer CSS proposal to use state-focus-shadow for the component `SideNavLink` focus state

--- a/src/SideNav.tsx
+++ b/src/SideNav.tsx
@@ -1,13 +1,15 @@
-import classnames from 'classnames'
 // eslint-disable-next-line import/no-namespace
 import * as History from 'history'
-import React from 'react'
-import styled, {css} from 'styled-components'
-import BorderBox from './BorderBox'
+
 import {COMMON, get} from './constants'
-import Link from './Link'
-import sx from './sx'
+import styled, {css} from 'styled-components'
+
+import BorderBox from './BorderBox'
 import {ComponentProps} from './utils/types'
+import Link from './Link'
+import React from 'react'
+import classnames from 'classnames'
+import sx from './sx'
 
 type SideNavBaseProps = {
   variant?: 'lightweight' | 'normal'
@@ -52,6 +54,20 @@ type StyledSideNavLinkProps = {
   variant?: 'full' | 'normal'
 }
 
+// used for variant normal hover, focus pseudo selectors
+const CommonAccessibilityVariantNormalStyles = css`
+  background-color: ${get('colors.state.hover.secondaryBg')};
+  outline: none;
+  text-decoration: none;
+`
+
+// used for light weight hover, focus pseudo selectors
+const CommonAccessibilityVariantLightWeightStyles = css`
+  color: ${get('colors.text.primary')};
+  text-decoration: none;
+  outline: none;
+`
+
 const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
   const isReactRouter = typeof props.to === 'string'
   if (isReactRouter || props.selected) {
@@ -79,16 +95,6 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
     border-bottom: none;
   }
 
-  &:first-child {
-    border-top-right-radius: ${get('radii.2')};
-    border-top-left-radius: ${get('radii.2')};
-  }
-
-  &:last-child {
-    border-bottom-right-radius: ${get('radii.2')};
-    border-bottom-left-radius: ${get('radii.2')};
-  }
-
   ${SideNav}.variant-normal > & {
     color: ${get('colors.text.primary')};
     padding: ${get('space.3')};
@@ -97,6 +103,13 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
 
     &:first-child {
       border-top: 0;
+      border-top-right-radius: ${get('radii.2')};
+      border-top-left-radius: ${get('radii.2')};
+    }
+
+    &:last-child {
+      border-bottom-right-radius: ${get('radii.2')};
+      border-bottom-left-radius: ${get('radii.2')};
     }
 
     // Bar on the left
@@ -111,11 +124,14 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
       content: '';
     }
 
-    &:hover,
+    &:hover {
+      ${CommonAccessibilityVariantNormalStyles}
+    }
+
     &:focus {
-      text-decoration: none;
-      background-color: ${get('colors.state.hover.secondaryBg')};
-      outline: none;
+      ${CommonAccessibilityVariantNormalStyles}
+      box-shadow: ${get('shadows.state.focus.shadow')};
+      z-index: 1;
     }
 
     &[aria-current='page'],
@@ -133,11 +149,14 @@ const SideNavLink = styled(Link).attrs<StyledSideNavLinkProps>(props => {
     padding: ${get('space.1')} 0;
     color: ${get('colors.text.link')};
 
-    &:hover,
+    &:hover {
+      ${CommonAccessibilityVariantLightWeightStyles}
+    }
+
     &:focus {
-      color: ${get('colors.text.primary')};
-      text-decoration: none;
-      outline: none;
+      ${CommonAccessibilityVariantLightWeightStyles}
+      box-shadow: ${get('shadows.state.focus.shadow')};
+      z-index: 1;
     }
 
     &[aria-current='page'],

--- a/src/__tests__/__snapshots__/SideNav.tsx.snap
+++ b/src/__tests__/__snapshots__/SideNav.tsx.snap
@@ -38,16 +38,6 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
   border-bottom: none;
 }
 
-.c0:first-child {
-  border-top-right-radius: 6px;
-  border-top-left-radius: 6px;
-}
-
-.c0:last-child {
-  border-bottom-right-radius: 6px;
-  border-bottom-left-radius: 6px;
-}
-
 .c1.variant-normal > .c0 {
   color: #24292e;
   padding: 16px;
@@ -57,6 +47,13 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
 
 .c1.variant-normal > .c0:first-child {
   border-top: 0;
+  border-top-right-radius: 6px;
+  border-top-left-radius: 6px;
+}
+
+.c1.variant-normal > .c0:last-child {
+  border-bottom-right-radius: 6px;
+  border-bottom-left-radius: 6px;
 }
 
 .c1.variant-normal > .c0::before {
@@ -70,12 +67,20 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
   content: '';
 }
 
-.c1.variant-normal > .c0:hover,
-.c1.variant-normal > .c0:focus {
-  -webkit-text-decoration: none;
-  text-decoration: none;
+.c1.variant-normal > .c0:hover {
   background-color: #f6f8fa;
   outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+}
+
+.c1.variant-normal > .c0:focus {
+  background-color: #f6f8fa;
+  outline: none;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  z-index: 1;
 }
 
 .c1.variant-normal > .c0[aria-current='page'],
@@ -93,12 +98,20 @@ exports[`SideNav SideNav.Link renders consistently 1`] = `
   color: #0366d6;
 }
 
-.c1.variant-lightweight > .c0:hover,
+.c1.variant-lightweight > .c0:hover {
+  color: #24292e;
+  -webkit-text-decoration: none;
+  text-decoration: none;
+  outline: none;
+}
+
 .c1.variant-lightweight > .c0:focus {
   color: #24292e;
   -webkit-text-decoration: none;
   text-decoration: none;
   outline: none;
+  box-shadow: 0 0 0 3px rgba(3,102,214,0.3);
+  z-index: 1;
 }
 
 .c1.variant-lightweight > .c0[aria-current='page'],


### PR DESCRIPTION
Describe your changes here.

Closes #1219 - `SideNav` focus state is hard to see, the purpose of this PR is to bring the component closer to the Primer CSS proposal to use `state-focus-shadow` to add a blue `box-shadow` instead of the subtle background color. For more details on the merged proposal please see primer/css#1391

### Screenshots

Before:

https://user-images.githubusercontent.com/6519974/118313173-424fdb80-b4a7-11eb-800b-3ce4364eec4c.mov


After: 

https://user-images.githubusercontent.com/6519974/118313146-3a903700-b4a7-11eb-970f-a97dcde12752.mov

 

### Merge checklist
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox - primer component example needs tab index
- [x] Tested in Safari - primer component example needs tab index
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
