### PR TITLE
Action Menu correctly fires onAction callback after close

### DIFF
--- a/.changeset/bright-donkeys-exist.md
+++ b/.changeset/bright-donkeys-exist.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Action Menu correctly fires onAction callback after close.

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -90,11 +90,11 @@ const ActionMenuBase = ({
   useEffect(() => {
     // Wait until menu has re-rendered in a closed state before triggering action.
     // This is needed in scenarios where the action will move focus, which would otherwise be captured by focus trap
-    if (!open && pendingActionRef.current) {
+    if (!combinedOpenState && pendingActionRef.current) {
       pendingActionRef.current()
       pendingActionRef.current = undefined
     }
-  }, [open])
+  }, [combinedOpenState])
 
   return (
     <AnchoredOverlay

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -2,7 +2,7 @@ import {GroupedListProps, List, ListPropsBase} from './ActionList/List'
 import {Item, ItemProps} from './ActionList/Item'
 import {Divider} from './ActionList/Divider'
 import Button, {ButtonProps} from './Button'
-import React, {useCallback, useEffect, useMemo, useRef} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {AnchoredOverlay} from './AnchoredOverlay'
 import {useProvidedStateOrCreate} from './hooks/useProvidedStateOrCreate'
 import {OverlayProps} from './Overlay'
@@ -55,7 +55,6 @@ const ActionMenuBase = ({
   items,
   ...listProps
 }: ActionMenuProps): JSX.Element => {
-  const pendingActionRef = useRef<() => unknown>()
   const [combinedOpenState, setCombinedOpenState] = useProvidedStateOrCreate(open, setOpen, false)
   const onOpen = useCallback(() => setCombinedOpenState(true), [setCombinedOpenState])
   const onClose = useCallback(() => setCombinedOpenState(false), [setCombinedOpenState])
@@ -78,7 +77,7 @@ const ActionMenuBase = ({
         role: 'menuitem',
         onAction: (props, event) => {
           const actionCallback = item.onAction ?? onAction
-          pendingActionRef.current = () => actionCallback?.(props as ItemProps, event)
+          actionCallback?.(props as ItemProps, event)
           if (!event.defaultPrevented) {
             onClose()
           }
@@ -86,15 +85,6 @@ const ActionMenuBase = ({
       } as ItemProps
     })
   }, [items, onAction, onClose])
-
-  useEffect(() => {
-    // Wait until menu has re-rendered in a closed state before triggering action.
-    // This is needed in scenarios where the action will move focus, which would otherwise be captured by focus trap
-    if (!combinedOpenState && pendingActionRef.current) {
-      pendingActionRef.current()
-      pendingActionRef.current = undefined
-    }
-  }, [combinedOpenState])
 
   return (
     <AnchoredOverlay

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -79,7 +79,6 @@ const ActionMenuBase = ({
         onAction: (props, event) => {
           const actionCallback = item.onAction ?? onAction
           pendingActionRef.current = () => actionCallback?.(props as ItemProps, event)
-          actionCallback?.(props as ItemProps, event)
           if (!event.defaultPrevented) {
             onClose()
           }

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -106,4 +106,25 @@ describe('ActionMenu', () => {
     })
     expect(portalRoot?.textContent).toEqual('') // menu items are hidden
   })
+
+  it('should pass correct values to onAction on menu click', async () => {
+    const menu = HTMLRender(<SimpleActionMenu />)
+    let portalRoot = await menu.baseElement.querySelector('#__primerPortalRoot__')
+    expect(portalRoot).toBeNull()
+    const anchor = await menu.findByText('Menu')
+    act(() => {
+      fireEvent.click(anchor)
+    })
+    portalRoot = menu.baseElement.querySelector('#__primerPortalRoot__')
+    expect(portalRoot).toBeTruthy()
+    const menuItem = (await portalRoot?.querySelector("[role='menuitem']")) as HTMLElement
+    act(() => {
+      fireEvent.click(menuItem)
+    })
+
+    // onAction has been called with correct argument
+    expect(mockOnActivate).toHaveBeenCalledTimes(1)
+    const arg = mockOnActivate.mock.calls[0][0]
+    expect(arg.text).toEqual(items[0].text)
+  })
 })

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -106,24 +106,4 @@ describe('ActionMenu', () => {
     })
     expect(portalRoot?.textContent).toEqual('') // menu items are hidden
   })
-
-  it('should pass correct values to onAction on menu click', async () => {
-    const menu = HTMLRender(<SimpleActionMenu />)
-    let portalRoot = await menu.baseElement.querySelector('#__primerPortalRoot__')
-    expect(portalRoot).toBeNull()
-    const anchor = await menu.findByText('Menu')
-    act(() => {
-      fireEvent.click(anchor)
-    })
-    portalRoot = menu.baseElement.querySelector('#__primerPortalRoot__')
-    expect(portalRoot).toBeTruthy()
-    const menuItem = (await portalRoot?.querySelector("[role='menuitem']")) as HTMLElement
-    act(() => {
-      fireEvent.click(menuItem)
-    })
-    // onAction has been called with correct argument
-    expect(mockOnActivate).toHaveBeenCalledTimes(1)
-    const arg = mockOnActivate.mock.calls[0][0]
-    expect(arg.text).toEqual(items[0].text)
-  })
 })


### PR DESCRIPTION
A couple of small fixes here that seem to be possibly from a botched rebase!

The after close behavior wasn't working quite as it should have been, because the `useEffect` hook had the wrong dependency (open vs combinedOpenState for the work to make ActionMenu optionally controlled) - further, the onAction callback was firing twice in the code when the component was operating as a controlled component due to both the `pendingActionRef` being populated and the call on L82.