### PR TITLE
Add `no-unnecessary-condition` lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -79,6 +79,9 @@
     },
     // rules which apply only to TS
     {
+      "parserOptions": {
+        "project": "tsconfig.json"
+      },
       "files": [
         "**/*.ts",
         "**/*.tsx"
@@ -88,6 +91,7 @@
       ],
       "rules": {
         "@typescript-eslint/no-explicit-any": 2,
+        "@typescript-eslint/no-unnecessary-condition": 2,
         "@typescript-eslint/explicit-module-boundary-types": 0,
         "@typescript-eslint/no-unused-vars": [
           "error",

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -152,6 +152,7 @@ export function List(props: ListProps): JSX.Element {
    * or the default `Item` renderer.
    */
   const renderItem = (itemProps: ItemInput, item: ItemInput) => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const ItemComponent = ('renderItem' in itemProps && itemProps.renderItem) || props.renderItem || Item
     const key = itemProps.key ?? itemProps.id?.toString() ?? uniqueId()
     return (
@@ -176,7 +177,7 @@ export function List(props: ListProps): JSX.Element {
 
   if (!isGroupedListProps(props)) {
     // When no `groupMetadata`s is provided, collect rendered `Item`s into a single anonymous `Group`.
-    groups = [{items: props.items?.map(item => renderItem(item, item)), groupId: singleGroupId}]
+    groups = [{items: props.items.map(item => renderItem(item, item)), groupId: singleGroupId}]
   } else {
     // When `groupMetadata` is provided, collect rendered `Item`s into their associated `Group`s.
 
@@ -214,7 +215,7 @@ export function List(props: ListProps): JSX.Element {
 
   return (
     <StyledList {...props}>
-      {groups?.map(({header, ...groupProps}, index) => {
+      {groups.map(({header, ...groupProps}, index) => {
         const hasFilledHeader = header?.variant === 'filled'
         const shouldShowDivider = index > 0 && !hasFilledHeader
         return (
@@ -229,7 +230,7 @@ export function List(props: ListProps): JSX.Element {
               ...(header && {
                 header: {
                   ...header,
-                  sx: {...headerStyle, ...header?.sx}
+                  sx: {...headerStyle, ...header.sx}
                 }
               }),
               ...groupProps

--- a/src/Caret.tsx
+++ b/src/Caret.tsx
@@ -33,12 +33,12 @@ const perpendicularEdge = {
   left: 'Top'
 }
 
-function getEdgeAlign(location: Location): Alignment[] {
+function getEdgeAlign(location: Location) {
   const [edge, align] = location.split('-')
-  return [edge as Alignment, align as Alignment]
+  return [edge as Alignment, align as Alignment | undefined] as const
 }
 
-function getPosition(edge: Alignment, align: Alignment, spacing: number) {
+function getPosition(edge: Alignment, align: Alignment | undefined, spacing: number) {
   const opposite = oppositeEdge[edge].toLowerCase()
   const perp = perpendicularEdge[edge].toLowerCase()
   return {

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -7,6 +7,7 @@ import useDialog from './hooks/useDialog'
 import sx, {SxProp} from './sx'
 import Text from './Text'
 import {ComponentProps} from './utils/types'
+import {useCombinedRefs} from './hooks/useCombinedRefs'
 
 const noop = () => null
 
@@ -78,7 +79,6 @@ const Overlay = styled.span`
     right: 0;
     bottom: 0;
     left: 0;
-    z-index: 80;
     display: block;
     cursor: default;
     content: ' ';
@@ -95,14 +95,10 @@ type InternalDialogProps = {
   returnFocusRef?: React.RefObject<HTMLElement>
 } & ComponentProps<typeof DialogBase>
 
-const Dialog = forwardRef<HTMLElement, InternalDialogProps>(
-  (
-    {children, onDismiss = noop, isOpen, initialFocusRef, returnFocusRef, ...props},
-    forwardedRef: React.ForwardedRef<HTMLElement>
-  ) => {
-    const backupRef = useRef(null)
+const Dialog = forwardRef<HTMLDivElement, InternalDialogProps>(
+  ({children, onDismiss = noop, isOpen, initialFocusRef, returnFocusRef, ...props}, forwardedRef) => {
     const overlayRef = useRef(null)
-    const modalRef = (forwardedRef as React.RefObject<HTMLDivElement>) ?? backupRef
+    const modalRef = useCombinedRefs(forwardedRef)
     const closeButtonRef = useRef(null)
 
     const onCloseClick = () => {

--- a/src/Portal/Portal.tsx
+++ b/src/Portal/Portal.tsx
@@ -4,7 +4,7 @@ import {createPortal} from 'react-dom'
 const PRIMER_PORTAL_ROOT_ID = '__primerPortalRoot__'
 const DEFAULT_PORTAL_CONTAINER_NAME = '__default__'
 
-const portalRootRegistry: {[key: string]: Element} = {}
+const portalRootRegistry: Partial<Record<string, Element>> = {}
 
 /**
  * Register a container to serve as a portal root.
@@ -20,10 +20,8 @@ export function registerPortalRoot(root: Element, name = DEFAULT_PORTAL_CONTAINE
 // with id __primerPortalRoot__, allow that element to serve as the default portal root.
 // Otherwise, create that element and attach it to the end of document.body.
 function ensureDefaultPortal() {
-  if (
-    !(DEFAULT_PORTAL_CONTAINER_NAME in portalRootRegistry) ||
-    !document.body.contains(portalRootRegistry[DEFAULT_PORTAL_CONTAINER_NAME])
-  ) {
+  const existingDefaultPortalContainer = portalRootRegistry[DEFAULT_PORTAL_CONTAINER_NAME]
+  if (!existingDefaultPortalContainer || !document.body.contains(existingDefaultPortalContainer)) {
     let defaultPortalContainer = document.getElementById(PRIMER_PORTAL_ROOT_ID)
     if (!(defaultPortalContainer instanceof Element)) {
       defaultPortalContainer = document.createElement('div')

--- a/src/StateLabel.tsx
+++ b/src/StateLabel.tsx
@@ -96,6 +96,7 @@ function StateLabel({children, status, variant: variantProp, ...rest}: StateLabe
   const octiconProps = variantProp === 'small' ? {width: '1em'} : {}
   return (
     <StateLabelBase {...rest} variant={variantProp} status={status}>
+      {/* eslint-disable-next-line @typescript-eslint/no-unnecessary-condition */}
       {status && <StyledOcticon mr={1} {...octiconProps} icon={octiconMap[status] || QuestionIcon} />}
       {children}
     </StateLabelBase>

--- a/src/ThemeProvider.tsx
+++ b/src/ThemeProvider.tsx
@@ -90,7 +90,7 @@ export function useTheme() {
   return React.useContext(ThemeContext)
 }
 
-export function useColorSchemeVar(values: Record<string, string>, fallback?: string) {
+export function useColorSchemeVar(values: Partial<Record<string, string>>, fallback?: string) {
   const {colorScheme = ''} = useTheme()
   return values[colorScheme] ?? fallback
 }
@@ -99,6 +99,7 @@ function useSystemColorMode() {
   const [systemColorMode, setSystemColorMode] = React.useState(getSystemColorMode)
 
   React.useEffect(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     const media = window?.matchMedia?.('(prefers-color-scheme: dark)')
 
     function handleChange(event: MediaQueryListEvent) {
@@ -106,9 +107,11 @@ function useSystemColorMode() {
       setSystemColorMode(isNight ? 'night' : 'day')
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     media?.addEventListener('change', handleChange)
 
     return function cleanup() {
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       media?.removeEventListener('change', handleChange)
     }
   }, [])
@@ -117,6 +120,7 @@ function useSystemColorMode() {
 }
 
 function getSystemColorMode(): ColorMode {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
   if (typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)')?.matches) {
     return 'night'
   }

--- a/src/__tests__/.eslintrc.json
+++ b/src/__tests__/.eslintrc.json
@@ -2,6 +2,9 @@
   "extends": [
     "plugin:jest/recommended"
   ],
+  "parserOptions": {
+    "project": "../../tsconfig.json"
+  },
   "rules": {
     "@typescript-eslint/no-non-null-assertion": 0
   }

--- a/src/__tests__/ActionList.tsx
+++ b/src/__tests__/ActionList.tsx
@@ -28,7 +28,12 @@ function SimpleActionList(): JSX.Element {
 }
 
 describe('ActionList', () => {
-  behavesAsComponent({Component: ActionList, systemPropArray: [COMMON], options: {skipAs: true, skipSx: true}})
+  behavesAsComponent({
+    Component: ActionList,
+    systemPropArray: [COMMON],
+    options: {skipAs: true, skipSx: true},
+    toRender: () => <ActionList items={[]} />
+  })
 
   checkExports('ActionList', {
     default: undefined,

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -67,7 +67,9 @@ describe('ActionMenu', () => {
     expect(portalRoot).toBeTruthy()
     const itemText = items
       .map((i: ItemProps) => {
-        if (i.hasOwnProperty('text')) return i?.text
+        if (i.hasOwnProperty('text')) {
+          return i.text
+        }
       })
       .join('')
     expect(portalRoot?.textContent?.trim()).toEqual(itemText)

--- a/src/__tests__/DropdownMenu.tsx
+++ b/src/__tests__/DropdownMenu.tsx
@@ -69,7 +69,9 @@ describe('DropdownMenu', () => {
     expect(portalRoot).toBeTruthy()
     const itemText = items
       .map((i: ItemInput) => {
-        if (i.hasOwnProperty('text')) return i?.text
+        if (i.hasOwnProperty('text')) {
+          return i.text
+        }
       })
       .join('')
     expect(portalRoot?.textContent?.trim()).toEqual(itemText)
@@ -107,7 +109,7 @@ describe('DropdownMenu', () => {
     act(() => {
       fireEvent.click(menuItem as Element)
     })
-    expect(anchor?.textContent).toEqual('Baz')
+    expect(anchor.textContent).toEqual('Baz')
   })
 
   it('should dismiss the overlay on clicking outside overlay', async () => {

--- a/src/__tests__/__snapshots__/Dialog.tsx.snap
+++ b/src/__tests__/__snapshots__/Dialog.tsx.snap
@@ -51,7 +51,6 @@ Array [
   right: 0;
   bottom: 0;
   left: 0;
-  z-index: 80;
   display: block;
   cursor: default;
   content: ' ';

--- a/src/behaviors/anchoredPosition.ts
+++ b/src/behaviors/anchoredPosition.ts
@@ -354,7 +354,8 @@ function calculatePosition(
       left = anchorPosition.left + alignmentOffset
     } else if (align === 'center') {
       left = anchorPosition.left - (elementDimensions.width - anchorPosition.width) / 2 + alignmentOffset
-    } else if (align === 'end') {
+    } else {
+      // end
       left = anchorRight - elementDimensions.width - alignmentOffset
     }
   }
@@ -364,7 +365,8 @@ function calculatePosition(
       top = anchorPosition.top + alignmentOffset
     } else if (align === 'center') {
       top = anchorPosition.top - (elementDimensions.height - anchorPosition.height) / 2 + alignmentOffset
-    } else if (align === 'end') {
+    } else {
+      // end
       top = anchorBottom - elementDimensions.height - alignmentOffset
     }
   }
@@ -386,7 +388,8 @@ function calculatePosition(
       left = anchorPosition.left + alignmentOffset
     } else if (align === 'center') {
       left = anchorPosition.left - (elementDimensions.width - anchorPosition.width) / 2 + alignmentOffset
-    } else if (align === 'end') {
+    } else {
+      // end
       left = anchorRight - elementDimensions.width - alignmentOffset
     }
   } else if (side === 'inside-left' || side === 'inside-right' || side === 'inside-center') {
@@ -394,7 +397,8 @@ function calculatePosition(
       top = anchorPosition.top + alignmentOffset
     } else if (align === 'center') {
       top = anchorPosition.top - (elementDimensions.height - anchorPosition.height) / 2 + alignmentOffset
-    } else if (align === 'end') {
+    } else {
+      // end
       top = anchorBottom - elementDimensions.height - alignmentOffset
     }
   }

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -607,7 +607,8 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
                 currentFocusedIndex = 0
               } else if (direction === 'next') {
                 currentFocusedIndex += 1
-              } else if (direction === 'end') {
+              } else {
+                // end
                 currentFocusedIndex = focusableElements.length - 1
               }
 

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -519,7 +519,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
                 // focusInStrategy is set to "first", lastKeyboardFocusDirection will always
                 // be undefined.
                 const targetElementIndex = lastKeyboardFocusDirection === 'previous' ? focusableElements.length - 1 : 0
-                const targetElement = focusableElements[targetElementIndex]
+                const targetElement = focusableElements[targetElementIndex] as HTMLElement | undefined
                 targetElement?.focus()
                 return
               } else {

--- a/src/hooks/useDialog.ts
+++ b/src/hooks/useDialog.ts
@@ -64,7 +64,7 @@ function useDialog({
 
   const getFocusableItem = useCallback(
     (e: Event, movement: number) => {
-      if (modalRef && modalRef.current) {
+      if (modalRef.current) {
         const items = Array.from(modalRef.current.querySelectorAll('*')).filter(focusable)
         if (items.length === 0) return
         e.preventDefault()

--- a/src/hooks/useFocusZone.ts
+++ b/src/hooks/useFocusZone.ts
@@ -33,7 +33,7 @@ export function useFocusZone(
       ? undefined
       : settings.activeDescendantFocus
   const activeDescendantControlRef = useProvidedRefOrCreate(passedActiveDescendantRef)
-  const disabled = settings?.disabled
+  const disabled = settings.disabled
   const abortController = React.useRef<AbortController>()
 
   useEffect(

--- a/src/hooks/useOnEscapePress.ts
+++ b/src/hooks/useOnEscapePress.ts
@@ -10,6 +10,7 @@ function handleEscape(event: KeyboardEvent) {
   if (event.key === 'Escape' && !event.defaultPrevented) {
     for (let i = handlers.length - 1; i >= 0; --i) {
       handlers[i](event)
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       if (event.defaultPrevented) {
         break
       }

--- a/src/hooks/useOnOutsideClick.tsx
+++ b/src/hooks/useOnOutsideClick.tsx
@@ -28,7 +28,7 @@ const shouldCallClickHandler = ({ignoreClickRefs, containerRef, e}: ShouldCallCl
     // don't call handler if click happened on an ignored ref
   } else if (ignoreClickRefs) {
     for (const ignoreRef of ignoreClickRefs) {
-      if (ignoreRef && ignoreRef.current?.contains(e.target as Node)) {
+      if (ignoreRef.current?.contains(e.target as Node)) {
         shouldCallHandler = false
         // if we encounter one, break early, we don't need to go through the rest
         break

--- a/src/hooks/useOpenAndCloseFocus.ts
+++ b/src/hooks/useOpenAndCloseFocus.ts
@@ -16,7 +16,7 @@ export function useOpenAndCloseFocus({
     const returnRef = returnFocusRef.current
     if (initialFocusRef && initialFocusRef.current) {
       initialFocusRef.current.focus()
-    } else if (containerRef && containerRef.current) {
+    } else if (containerRef.current) {
       const firstItem = iterateFocusableElements(containerRef.current).next().value
       firstItem?.focus()
     }

--- a/src/stories/useAnchoredPosition.stories.tsx
+++ b/src/stories/useAnchoredPosition.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Meta} from '@storybook/react'
 import {BaseStyles, Box, ButtonPrimary, Position, Relative, ThemeProvider} from '..'
-import {useAnchoredPosition} from '../hooks/useAnchoredPosition'
+import {useAnchoredPosition} from '../hooks'
 import styled from 'styled-components'
 import {get} from '../constants'
 import {AnchorSide} from '../behaviors/anchoredPosition'
@@ -93,8 +93,8 @@ export const UseAnchoredPosition = (args: any) => {
     {
       side: `${args.anchorPosition ?? 'outside'}-${args.anchorSide ?? 'bottom'}` as AnchorSide,
       align: args.anchorAlignment ?? 'start',
-      anchorOffset: args.anchorOffset && (parseInt(args.anchorOffset, 10) ?? undefined),
-      alignmentOffset: args.alignmentOffset && (parseInt(args.alignmentOffset, 10) ?? undefined),
+      anchorOffset: args.anchorOffset && parseInt(args.anchorOffset, 10),
+      alignmentOffset: args.alignmentOffset && parseInt(args.alignmentOffset, 10),
       allowOutOfBounds: args.allowOutOfBounds ?? undefined
     },
     [args]

--- a/src/utils/test-matchers.tsx
+++ b/src/utils/test-matchers.tsx
@@ -48,7 +48,7 @@ expect.extend({
     const elem = React.cloneElement(element, {sx: sxPropValue})
 
     function checkStylesDeep(rendered: ReactTestRendererJSON): boolean {
-      const className = rendered?.props ? rendered.props.className : ''
+      const className = rendered.props.className
       const styles = getComputedStyles(className)
       const mediaStyles = styles[mediaKey] as Nullish<Record<string, string>>
       if (mediaStyles && mediaStyles.color) {


### PR DESCRIPTION
Adding `no-unnecessary-condition` lint rule, prompted by this comment: https://github.com/primer/components/pull/1229/files#r632874879.  This rule _does_ require types to be generated by eslint, so lint is slightly slower.  My local went from 11s to 16s, so it's not terrible.  Happy to discuss if anyone thinks that's a bad idea.


### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge
