### PR TITLE
Fix Check Spacing on selected items

### DIFF
--- a/.changeset/serious-eagles-behave.md
+++ b/.changeset/serious-eagles-behave.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix check Spacing on selected items for ActionList components.

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -173,6 +173,7 @@ const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled
   // hardcoded '20px' with '${get('space.s20')}'.
   height: 20px;
   width: ${get('space.3')};
+  flex-shrink: 0;
   display: flex;
   flex-direction: column;
   justify-content: center;


### PR DESCRIPTION
This was @dmarcey's suggestion for fixing spacing issues with ActionList based components that have both a leading visual and a selected check mark.

Before (bug):

![image](https://user-images.githubusercontent.com/16739070/119002661-afa1b780-b952-11eb-9687-adaa48564a34.png)

After:

![image](https://user-images.githubusercontent.com/16739070/119002805-cb0cc280-b952-11eb-93c0-5e6d8a9f8c97.png)
