### PR TITLE
Use item index as fallback key within groups

### DIFF
--- a/.changeset/lucky-ducks-camp.md
+++ b/.changeset/lucky-ducks-camp.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Use `Item` `index` as fallback key within `List` groups


### PR DESCRIPTION
The current implementation for List `Item` rendering will use `uniqueId()` as a fallback for `key` within a group.  While this suppresses the warning from `React` that a key should be supplied, it also has the negative side effect that React will _always_ re-render items that use the fallback key.  Instead, we can fairly reliably use the item `index` from the list of items in each group to determine a decent `key` value. While this isn't as good as using a unique `key` for each item taken from outside context, it is a much better fallback than `uniqueId`.  

I also removed the `uniqueId` for single group `groupId`.  It doesn't really matter what the `key` is in this case because there is only one group to render, so `'0'` is just as effective.

I was able to test these changes with the `SelectPanel` story, which verified that the DOM elements are indeed not re-rendered if the contents of the list don't change.  

### Screenshots
Please provide before/after screenshots for any visual changes

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge