### PR TITLE
feat(SelectPanel): active descendant focus

### DIFF
--- a/.changeset/odd-melons-rush.md
+++ b/.changeset/odd-melons-rush.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Use `active-descendant` to control focus in `SelectPanel`

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -8,6 +8,7 @@ import styled from 'styled-components'
 import {StyledHeader} from './Header'
 import {StyledDivider} from './Divider'
 import {useColorSchemeVar, useTheme} from '../ThemeProvider'
+import {uniqueId} from '../utils/uniqueId'
 
 /**
  * These colors are not yet in our default theme.  Need to remove this once they are added.
@@ -120,6 +121,8 @@ export interface ItemProps extends Omit<React.ComponentPropsWithoutRef<'div'>, '
   id?: number | string
 }
 
+export const itemActiveDescendantClass = `${uniqueId()}active-descendant`
+
 const getItemVariant = (variant = 'default', disabled?: boolean) => {
   if (disabled) {
     return {
@@ -191,9 +194,18 @@ const StyledItem = styled.div<
       border: 0 solid ${get('colors.selectMenu.borderSecondary')};
       border-top-width: ${({showDivider}) => (showDivider ? `1px` : '0')};
     }
+
+    // Override if current or previous item is active descendant
+    &.${itemActiveDescendantClass}, .${itemActiveDescendantClass} + & {
+      ${StyledItemContent}::before {
+        border-color: transparent;
+      }
+    }
   }
 
-  &:focus {
+  // Focused OR Active Descendant
+  &:focus,
+  &.${itemActiveDescendantClass} {
     background: ${({focusBackground}) => focusBackground};
     outline: none;
   }
@@ -215,7 +227,6 @@ const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled
   flex-shrink: 0;
   display: flex;
   flex-direction: column;
-  flex-shrink: 0;
   justify-content: center;
   margin-right: ${get('space.2')};
 `
@@ -244,6 +255,10 @@ const TrailingVisualContainer = styled(ColoredVisualContainer)`
 const DescriptionContainer = styled.span<{descriptionVariant: ItemProps['descriptionVariant']}>`
   color: ${get('colors.text.secondary')};
   margin-left: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? get('space.2') : 0)};
+`
+
+const MultiSelectInput = styled.input`
+  pointer-events: none;
 `
 
 /**
@@ -329,7 +344,15 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
                * readOnly is required because we are doing a one-way bind to `checked`.
                * aria-readonly="false" tells screen that they can still interact with the checkbox
                */}
-              <input type="checkbox" checked={selected} aria-label={text} readOnly aria-readonly="false" />
+              <MultiSelectInput
+                disabled={disabled}
+                tabIndex={-1}
+                type="checkbox"
+                checked={selected}
+                aria-label={text}
+                readOnly
+                aria-readonly="false"
+              />
             </>
           ) : (
             selected && <CheckIcon fill={theme?.colors.text.primary} />

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -25,6 +25,11 @@ export interface ListPropsBase {
   role?: AriaRole
 
   /**
+   * id to attach to the base DOM node of the list
+   */
+  id?: string
+
+  /**
    * A `List`-level custom `Item` renderer. Every `Item` within this `List`
    * without a `Group`-level or `Item`-level custom `Item` renderer will be
    * rendered using this function component.

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -1,10 +1,9 @@
 import React, {useCallback, useMemo, useRef} from 'react'
 import Overlay, {OverlayProps} from '../Overlay'
 import {useFocusTrap} from '../hooks/useFocusTrap'
-import {useFocusZone} from '../hooks/useFocusZone'
+import {FocusZoneHookSettings, useFocusZone} from '../hooks/useFocusZone'
 import {useAnchoredPosition, useRenderForcingRef} from '../hooks'
 import {uniqueId} from '../utils/uniqueId'
-import {FocusZoneSettings} from '../behaviors/focusZone'
 
 export interface AnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'width'> {
   /**
@@ -36,7 +35,7 @@ export interface AnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'wid
   /**
    * Settings to apply to the Focus Zone on the internal `Overlay` component.
    */
-  focusZoneSettings?: Partial<FocusZoneSettings>
+  focusZoneSettings?: Partial<FocusZoneHookSettings>
 }
 
 /**

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -1,9 +1,12 @@
-import React, {useCallback} from 'react'
+import React, {KeyboardEventHandler, useCallback, useMemo, useRef} from 'react'
 import {GroupedListProps, ListPropsBase} from '../ActionList/List'
 import TextInput, {TextInputProps} from '../TextInput'
 import Box from '../Box'
 import {ActionList} from '../ActionList'
 import Spinner from '../Spinner'
+import {useFocusZone} from '../hooks/useFocusZone'
+import {uniqueId} from '../utils/uniqueId'
+import {itemActiveDescendantClass} from '../ActionList/Item'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
@@ -28,15 +31,60 @@ export function FilteredActionList({
     [onFilterChange]
   )
 
+  const containerRef = useRef<HTMLInputElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const activeDescendantRef = useRef<HTMLElement>()
+  const listId = useMemo(uniqueId, [])
+  const onInputKeyPress: KeyboardEventHandler = useCallback(
+    event => {
+      if (event.key === 'Enter' && activeDescendantRef.current) {
+        event.preventDefault()
+        event.nativeEvent.stopImmediatePropagation()
+
+        // Forward Enter key press to active descendant so that item gets activated
+        const activeDescendantEvent = new KeyboardEvent(event.type, event.nativeEvent)
+        activeDescendantRef.current.dispatchEvent(activeDescendantEvent)
+      }
+    },
+    [activeDescendantRef]
+  )
+
+  useFocusZone({
+    containerRef,
+    focusOutBehavior: 'wrap',
+    focusableElementFilter: element => {
+      if (element instanceof HTMLInputElement) {
+        // No active-descendant focus on checkboxes in list items or filter input
+        return false
+      }
+      return true
+    },
+    activeDescendantFocus: inputRef,
+    onActiveDescendantChanged: (current, previous) => {
+      activeDescendantRef.current = current
+
+      if (previous) {
+        previous.classList.remove(itemActiveDescendantClass)
+      }
+
+      if (current) {
+        current.classList.add(itemActiveDescendantClass)
+      }
+    }
+  })
+
   return (
-    <>
+    <Box ref={containerRef} flexGrow={1} flexDirection="column">
       <TextInput
+        ref={inputRef}
         block
         width="auto"
         color="text.primary"
         onChange={onInputChange}
+        onKeyPress={onInputKeyPress}
         placeholder={placeholderText}
         aria-label={placeholderText}
+        aria-controls={listId}
         {...textInputProps}
       />
       <Box flexGrow={1} overflow="auto">
@@ -45,10 +93,10 @@ export function FilteredActionList({
             <Spinner />
           </Box>
         ) : (
-          <ActionList items={items} {...listProps} role="listbox" />
+          <ActionList items={items} {...listProps} role="listbox" id={listId} />
         )}
       </Box>
-    </>
+    </Box>
   )
 }
 

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -2,7 +2,7 @@ import React, {useCallback, useMemo} from 'react'
 import {FilteredActionList, FilteredActionListProps} from '../FilteredActionList'
 import {OverlayProps} from '../Overlay'
 import {ItemInput} from '../ActionList/List'
-import {FocusZoneSettings} from '../behaviors/focusZone'
+import {FocusZoneHookSettings} from '../hooks/useFocusZone'
 import {DropdownButton} from '../DropdownMenu'
 import {ItemProps} from '../ActionList'
 import {AnchoredOverlay, AnchoredOverlayProps} from '../AnchoredOverlay'
@@ -41,11 +41,9 @@ function isMultiSelectVariant(
   return Array.isArray(selected)
 }
 
-const focusZoneSettings: Partial<FocusZoneSettings> = {
-  focusOutBehavior: 'wrap',
-  focusableElementFilter: element => {
-    return !(element instanceof HTMLInputElement) || element.type !== 'checkbox'
-  }
+const focusZoneSettings: Partial<FocusZoneHookSettings> = {
+  // Let FilteredActionList handle focus zone
+  disabled: true
 }
 
 const textInputProps: Partial<TextInputProps> = {
@@ -104,7 +102,6 @@ export function SelectPanel({
           }
 
           if (isMultiSelectVariant(selected)) {
-            // multi select
             const otherSelectedItems = selected.filter(selectedItem => selectedItem !== item)
             const newSelectedItems = selected.includes(item) ? otherSelectedItems : [...otherSelectedItems, item]
 

--- a/src/__tests__/__snapshots__/ActionMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/ActionMenu.tsx.snap
@@ -70,9 +70,9 @@ exports[`ActionMenu renders consistently 1`] = `
 <button
   aria-haspopup="listbox"
   aria-label="menu"
-  aria-labelledby="__primer_id_10000"
+  aria-labelledby="__primer_id_10001"
   className="c0"
-  id="__primer_id_10000"
+  id="__primer_id_10001"
   onClick={[Function]}
   onKeyDown={[Function]}
   tabIndex={0}

--- a/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
+++ b/src/__tests__/__snapshots__/AnchoredOverlay.tsx.snap
@@ -69,9 +69,9 @@ exports[`AnchoredOverlay renders consistently 1`] = `
 
 <button
   aria-haspopup="listbox"
-  aria-labelledby="__primer_id_10000"
+  aria-labelledby="__primer_id_10001"
   className="c0"
-  id="__primer_id_10000"
+  id="__primer_id_10001"
   onClick={[Function]}
   onKeyDown={[Function]}
   tabIndex={0}

--- a/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
@@ -73,9 +73,9 @@ exports[`DropdownMenu renders consistently 1`] = `
 
 <button
   aria-haspopup="listbox"
-  aria-labelledby="__primer_id_10000"
+  aria-labelledby="__primer_id_10001"
   className="c0"
-  id="__primer_id_10000"
+  id="__primer_id_10001"
   onClick={[Function]}
   onKeyDown={[Function]}
   tabIndex={0}

--- a/src/__tests__/__snapshots__/SelectPanel.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.tsx.snap
@@ -85,9 +85,9 @@ exports[`SelectPanel renders consistently 1`] = `
 >
   <button
     aria-haspopup="listbox"
-    aria-labelledby="__primer_id_10000"
+    aria-labelledby="__primer_id_10001"
     className="c1"
-    id="__primer_id_10000"
+    id="__primer_id_10001"
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex={0}

--- a/src/hooks/useFocusTrap.ts
+++ b/src/hooks/useFocusTrap.ts
@@ -2,7 +2,7 @@ import React from 'react'
 import {focusTrap} from '../behaviors/focusTrap'
 import {useProvidedRefOrCreate} from './useProvidedRefOrCreate'
 
-interface FocusTrapHookSettings {
+export interface FocusTrapHookSettings {
   /**
    * Ref that will be used for the trapping container. If not provided, one will
    * be created by this hook and returned.

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -65,6 +65,7 @@ export function MultiSelectStory(): JSX.Element {
         selected={selected}
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
+        showItemDividers={true}
       />
     </>
   )
@@ -94,6 +95,7 @@ export function SingleSelectStory(): JSX.Element {
         selected={selected}
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
+        showItemDividers={true}
       />
     </>
   )


### PR DESCRIPTION
Within the `SelectPanel`, focus will now be controlled using `active-descendant` instead of true focus movement.  This allows the user to keep their cursor in the text input, while using <kbd>up</kbd>/<kbd>down</kbd>/<kbd>enter</kbd> keyboard navigation to select/deselect items.  

I had to make a few tweaks within `focusZone` to optimize behavior when items are filtered.  The original implementation didn't fully take changing DOM into account.

I also had to _disable_ the `focusZone` that is naturally created by `AnchoredOverlay` within `SelectPanel` because it was causing odd behavior due to the overlap in `focusZones`. It currently doesn't handle focus well if you _click_ on an item, because <kbd>up</kbd>/<kbd>down</kbd> arrows do nothing at that point, but hitting <kbd>tab</kbd> brings you right back to the text input.  We may need to revisit this down the road, but overall the new setup feels really good.


### Screenshots
![CleanShot 2021-05-20 at 21 15 23](https://user-images.githubusercontent.com/3026298/119081566-13f36400-b9b1-11eb-9c2f-d6deaaafbb31.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
