### PR TITLE
fix: allow focus to move from overlay on mousedown

### DIFF
--- a/.changeset/nine-boxes-change.md
+++ b/.changeset/nine-boxes-change.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Allow focus to move to an input outside an overlay on mousedown

--- a/src/__tests__/ActionMenu.tsx
+++ b/src/__tests__/ActionMenu.tsx
@@ -104,7 +104,7 @@ describe('ActionMenu', () => {
     expect(portalRoot).toBeTruthy()
     const somethingElse = (await menu.baseElement.querySelector('#something-else')) as HTMLElement
     act(() => {
-      fireEvent.click(somethingElse)
+      fireEvent.mouseDown(somethingElse)
     })
     expect(portalRoot?.textContent).toEqual('') // menu items are hidden
   })

--- a/src/__tests__/AnchoredOverlay.tsx
+++ b/src/__tests__/AnchoredOverlay.tsx
@@ -110,7 +110,7 @@ describe('AnchoredOverlay', () => {
         onCloseCallback={mockCloseCallback}
       />
     )
-    fireEvent.click(anchoredOverlay.baseElement)
+    fireEvent.mouseDown(anchoredOverlay.baseElement)
 
     expect(mockOpenCallback).toHaveBeenCalledTimes(0)
     expect(mockCloseCallback).toHaveBeenCalledTimes(1)

--- a/src/__tests__/DropdownMenu.tsx
+++ b/src/__tests__/DropdownMenu.tsx
@@ -124,7 +124,7 @@ describe('DropdownMenu', () => {
     expect(portalRoot).toBeTruthy()
     const somethingElse = (await menu.baseElement.querySelector('#something-else')) as HTMLElement
     act(() => {
-      fireEvent.click(somethingElse)
+      fireEvent.mouseDown(somethingElse)
     })
     // portal is closed after click
     expect(portalRoot?.textContent).toEqual('') // menu items are hidden

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -142,11 +142,12 @@ export function focusTrap(
 
   // Prevent focus leaving the trap container
   document.addEventListener(
-    'focusin',
-    (event: FocusEvent) => {
+    'focus',
+    event => {
       ensureTrapZoneHasFocus(event.target)
     },
-    {signal: wrappingController.signal}
+    // use capture to ensure we get all events.  focus events do not bubble
+    {signal: wrappingController.signal, capture: true}
   )
 
   // focus the first element

--- a/src/hooks/useOnOutsideClick.tsx
+++ b/src/hooks/useOnOutsideClick.tsx
@@ -49,9 +49,10 @@ export const useOnOutsideClick = ({containerRef, ignoreClickRefs, onClickOutside
   )
 
   useEffect(() => {
-    document.addEventListener('click', onOutsideClickInternal)
+    // use capture to ensure we get all events
+    document.addEventListener('mousedown', onOutsideClickInternal, {capture: true})
     return () => {
-      document.removeEventListener('click', onOutsideClickInternal)
+      document.removeEventListener('mousedown', onOutsideClickInternal, {capture: true})
     }
   }, [onOutsideClickInternal])
 }

--- a/src/stories/DropdownMenu.stories.tsx
+++ b/src/stories/DropdownMenu.stories.tsx
@@ -4,6 +4,7 @@ import {theme, ThemeProvider} from '..'
 import {ItemInput} from '../ActionList/List'
 import BaseStyles from '../BaseStyles'
 import {DropdownMenu, DropdownButton} from '../DropdownMenu'
+import TextInput from '../TextInput'
 
 const meta: Meta = {
   title: 'Composite components/DropdownMenu',
@@ -34,6 +35,7 @@ export function FavoriteColorStory(): JSX.Element {
   return (
     <>
       <h1>Favorite Color</h1>
+      <TextInput placeholder="Input for focus testing" mb={2} />
       <div id="favorite-color-label">Please select your favorite color:</div>
       <DropdownMenu
         renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (


### PR DESCRIPTION
All components built on `AnchoredOverlay` currently prevent the user from clicking into an input _outside_ the overlay and keeping focus there.  As soon as you click, the focus trap pulls focus back into the overlay, and then the overlay closes and focus moves to the anchor ref.  The only change needed to make this happen was to use `mousedown` instead of `click` to detect intent to close the overlay.  `mousedown` happens _before_ the `focus` event, but `click` happens _after_.  This means we can detect the `mousedown` and close the overlay + disable the `focusTrap` before the browser tries to move focus to an input outside of the overlay. 

Some additional changes I made here:
* Use `focus` instead of `focusin` to detect focus movement in `focusTrap`.  This isn't _required_, but it should be more reliable.  One note here, `focus` does not bubble, so we have to add the event listener to the `capture` phase.
* Use `capture` for the `mousedown` event as well, which prevents some other callback from using `stopPropagation` and accidentally keeping the overlay open.


Closes #1236

### Screenshots
#### Click Outside Moves Focus
![CleanShot 2021-05-21 at 09 21 43](https://user-images.githubusercontent.com/3026298/119168933-4c795900-ba16-11eb-835b-49d6e3ebcc9b.gif)

#### Close with Escape Moves To Anchor
![CleanShot 2021-05-21 at 09 22 51](https://user-images.githubusercontent.com/3026298/119168985-5c913880-ba16-11eb-825c-3df26f0ca026.gif)


### Merge checklist
- [x] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
