### PR TITLE
fix(ConfirmationDialog): use correct border radius on buttons

### DIFF
--- a/.changeset/thirty-lies-try.md
+++ b/.changeset/thirty-lies-try.md
@@ -2,4 +2,4 @@
 "@primer/components": patch
 ---
 
-Fix border radius on ConfirmationDialog buttons
+Fix border radius on buttons and title `font-weight` in ConfirmationDialog

--- a/.changeset/thirty-lies-try.md
+++ b/.changeset/thirty-lies-try.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Fix border radius on ConfirmationDialog buttons

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -80,6 +80,7 @@ const StyledConfirmationFooter = styled(Box)`
     border-bottom: 0;
     margin: 0;
     border-right: 0;
+    border-radius: 12px;
     &:first-child {
       border-left: 0;
     }

--- a/src/Dialog/ConfirmationDialog.tsx
+++ b/src/Dialog/ConfirmationDialog.tsx
@@ -47,7 +47,7 @@ const StyledConfirmationHeader = styled.header`
 `
 const StyledTitle = styled(Box)`
   font-size: ${get('fontSizes.3')};
-  font-weight: 700;
+  font-weight: ${get('fontWeights.bold')};
   padding: 6px ${get('space.2')};
   flex-grow: 1;
 `


### PR DESCRIPTION
Because the `Dialog` now allows overflow (From #1203), the smaller border radius from the `button`s is overflowing past the larger border radius of the overlay, causing a different appearance in the header vs the footer.  This change puts the same border radius on the buttons as what is used in the Dialog so that they match

Second, the `ConfirmationDialog` title had a hard-coded `font-weight` of `700`.  This likely came from the Overaly Prototype, but it is not the correct value.  Switching to `fontWeights.bold` which is `600`.

Closes #1239

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/3026298/119183301-bf8bcb00-ba28-11eb-8dba-c84a5d026c9b.png)

#### After
![image](https://user-images.githubusercontent.com/3026298/119189316-c1598c80-ba30-11eb-806f-f2b575f6c513.png)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge