### PR TITLE
 fix(SelectPanel): auto scroll when list overflows

### DIFF
--- a/.changeset/soft-schools-nail.md
+++ b/.changeset/soft-schools-nail.md
@@ -2,4 +2,4 @@
 "@primer/components": patch
 ---
 
-Handle overflow and active-decendant scrolling within `SelectPanel`
+Handle overflow and active-descendant scrolling within `SelectPanel`

--- a/.changeset/soft-schools-nail.md
+++ b/.changeset/soft-schools-nail.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Handle overflow and active-decendant scrolling within `SelectPanel`

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -10,7 +10,7 @@ A `SelectPanel` provides an anchor that will open an overlay with a list of sele
 ```javascript live noinline
 function getColorCircle(color) {
   return function () {
-    return <BorderBox bg={color} borderColor={color} padding={2} borderRadius={10} />
+    return <BorderBox bg={color} borderColor={color} width={14} height={14} borderRadius={10} margin="auto" />
   }
 }
 

--- a/docs/content/SelectPanel.mdx
+++ b/docs/content/SelectPanel.mdx
@@ -7,4 +7,50 @@ A `SelectPanel` provides an anchor that will open an overlay with a list of sele
 
 ## Example
 
+```javascript live noinline
+function getColorCircle(color) {
+  return function () {
+    return <BorderBox bg={color} borderColor={color} padding={2} borderRadius={10} />
+  }
+}
+
+const items = [
+  {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
+  {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
+  {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
+  {leadingVisual: getColorCircle('#ffd78e'), text: 'design', id: 4},
+  {leadingVisual: getColorCircle('#ff0000'), text: 'blocker', id: 5},
+  {leadingVisual: getColorCircle('#a4f287'), text: 'backend', id: 6},
+  {leadingVisual: getColorCircle('#8dc6fc'), text: 'frontend', id: 7}
+]
+
+function DemoComponent() {
+const [selected, setSelected] = React.useState([items[0], items[1]])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <SelectPanel
+      renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+        <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+          {children || 'Select Labels'}
+        </DropdownButton>
+      )}
+      placeholderText="Filter Labels"
+      open={open}
+      onOpenChange={setOpen}
+      items={filteredItems}
+      selected={selected}
+      onSelectedChange={setSelected}
+      onFilterChange={setFilter}
+      showItemDividers={true}
+      overlayProps={{width: 'small', height: 'xsmall'}}
+    />
+  )
+}
+
+render(<DemoComponent />)
+```
+
 ## Component props

--- a/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/live-code-scope.js
@@ -23,6 +23,7 @@ import State from '../../../components/State'
 import {Dialog as Dialog2} from '../../../../src/Dialog/Dialog'
 import {AnchoredOverlay} from '../../../../src/AnchoredOverlay'
 import {ConfirmationDialog, useConfirm} from '../../../../src/Dialog/ConfirmationDialog'
+import {SelectPanel} from '../../../../src/SelectPanel/SelectPanel'
 
 export default {
   ...doctocatComponents,
@@ -48,5 +49,6 @@ export default {
   Dialog2,
   ConfirmationDialog,
   useConfirm,
-  AnchoredOverlay
+  AnchoredOverlay,
+  SelectPanel
 }

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -8,6 +8,8 @@ import Spinner from '../Spinner'
 import {useFocusZone} from '../hooks/useFocusZone'
 import {uniqueId} from '../utils/uniqueId'
 import {itemActiveDescendantClass} from '../ActionList/Item'
+import styled from 'styled-components'
+import {get} from '../constants'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
@@ -38,6 +40,11 @@ function scrollIntoViewingArea(
 
   // either completely in view or outside viewing area on both ends, don't scroll
 }
+
+const StyledHeader = styled.div`
+  box-shadow: 0 1px 0 ${get('colors.border.primary')};
+  z-index: 1;
+`
 
 export function FilteredActionList({
   loading = false,
@@ -111,18 +118,20 @@ export function FilteredActionList({
 
   return (
     <Flex ref={containerRef} flexDirection="column" overflow="hidden">
-      <TextInput
-        ref={inputRef}
-        block
-        width="auto"
-        color="text.primary"
-        onChange={onInputChange}
-        onKeyPress={onInputKeyPress}
-        placeholder={placeholderText}
-        aria-label={placeholderText}
-        aria-controls={listId}
-        {...textInputProps}
-      />
+      <StyledHeader>
+        <TextInput
+          ref={inputRef}
+          block
+          width="auto"
+          color="text.primary"
+          onChange={onInputChange}
+          onKeyPress={onInputKeyPress}
+          placeholder={placeholderText}
+          aria-label={placeholderText}
+          aria-controls={listId}
+          {...textInputProps}
+        />
+      </StyledHeader>
       <Box ref={scrollContainerRef} overflow="auto">
         {loading ? (
           <Box width="100%" display="flex" flexDirection="row" justifyContent="center" pt={6} pb={7}>

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -1,7 +1,8 @@
-import React, {KeyboardEventHandler, useCallback, useMemo, useRef} from 'react'
+import React, {KeyboardEventHandler, useCallback, useEffect, useMemo, useRef} from 'react'
 import {GroupedListProps, ListPropsBase} from '../ActionList/List'
 import TextInput, {TextInputProps} from '../TextInput'
 import Box from '../Box'
+import Flex from '../Flex'
 import {ActionList} from '../ActionList'
 import Spinner from '../Spinner'
 import {useFocusZone} from '../hooks/useFocusZone'
@@ -69,12 +70,18 @@ export function FilteredActionList({
 
       if (current) {
         current.classList.add(itemActiveDescendantClass)
+        current.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'})
       }
     }
   })
 
+  useEffect(() => {
+    // if items changed, we want to instantly move active descendant into view
+    activeDescendantRef.current?.scrollIntoView({block: 'center', inline: 'center'})
+  }, [items])
+
   return (
-    <Box ref={containerRef} flexGrow={1} flexDirection="column">
+    <Flex ref={containerRef} flexDirection="column" overflow="hidden">
       <TextInput
         ref={inputRef}
         block
@@ -87,7 +94,7 @@ export function FilteredActionList({
         aria-controls={listId}
         {...textInputProps}
       />
-      <Box flexGrow={1} overflow="auto">
+      <Box overflow="auto">
         {loading ? (
           <Box width="100%" display="flex" flexDirection="row" justifyContent="center" pt={6} pb={7}>
             <Spinner />
@@ -96,7 +103,7 @@ export function FilteredActionList({
           <ActionList items={items} {...listProps} role="listbox" id={listId} />
         )}
       </Box>
-    </Box>
+    </Flex>
   )
 }
 

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -70,14 +70,14 @@ export function FilteredActionList({
 
       if (current) {
         current.classList.add(itemActiveDescendantClass)
-        current.scrollIntoView({behavior: 'smooth', block: 'center', inline: 'center'})
+        current.scrollIntoView({behavior: 'smooth', block: 'nearest', inline: 'nearest'})
       }
     }
   })
 
   useEffect(() => {
     // if items changed, we want to instantly move active descendant into view
-    activeDescendantRef.current?.scrollIntoView({block: 'center', inline: 'center'})
+    activeDescendantRef.current?.scrollIntoView({block: 'nearest', inline: 'nearest'})
   }, [items])
 
   return (

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -39,7 +39,10 @@ const items = [
   {leadingVisual: getColorCircle('#a2eeef'), text: 'enhancement', id: 1},
   {leadingVisual: getColorCircle('#d73a4a'), text: 'bug', id: 2},
   {leadingVisual: getColorCircle('#0cf478'), text: 'good first issue', id: 3},
-  {leadingVisual: getColorCircle('#8dc6fc'), text: 'design', id: 4}
+  {leadingVisual: getColorCircle('#ffd78e'), text: 'design', id: 4},
+  {leadingVisual: getColorCircle('#ff0000'), text: 'blocker', id: 5},
+  {leadingVisual: getColorCircle('#a4f287'), text: 'backend', id: 6},
+  {leadingVisual: getColorCircle('#8dc6fc'), text: 'frontend', id: 7}
 ]
 
 export function MultiSelectStory(): JSX.Element {
@@ -66,6 +69,7 @@ export function MultiSelectStory(): JSX.Element {
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
         showItemDividers={true}
+        overlayProps={{width: 'small', height: 'xsmall'}}
       />
     </>
   )
@@ -96,6 +100,7 @@ export function SingleSelectStory(): JSX.Element {
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
         showItemDividers={true}
+        overlayProps={{width: 'small', height: 'xsmall'}}
       />
     </>
   )

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -31,7 +31,7 @@ export default meta
 
 function getColorCircle(color: string) {
   return function () {
-    return <BorderBox bg={color} borderColor={color} padding={2} borderRadius={10} />
+    return <BorderBox bg={color} borderColor={color} width={14} height={14} borderRadius={10} margin="auto" />
   }
 }
 


### PR DESCRIPTION
Currently, SelectPanel is allowing the list contents to overflow.  This change brings back `overflow: auto` behavior.  It also adds `scrollIntoView` that will trigger when active descendant changes, so that selection is always in view.  I also added an example to the docs so that behavior can be tested in Vercel.

Closes https://github.com/github/primer/issues/169

### Screenshots
![CleanShot 2021-05-24 at 20 38 54](https://user-images.githubusercontent.com/3026298/119436279-b91f7c80-bcd0-11eb-8c00-b11682e6cfd2.gif)


### Merge checklist
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
