### PR TITLE
Hide overflow from Overlay

### DIFF
--- a/.changeset/gorgeous-cooks-thank.md
+++ b/.changeset/gorgeous-cooks-thank.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Hide overflow from `Overlay`

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -41,6 +41,7 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
   height: ${props => heightMap[props.height || 'auto']};
   width: ${props => widthMap[props.width || 'auto']};
   border-radius: 12px;
+  overflow: hidden;
   animation: overlay-appear 200ms ${get('animation.easeOutCubic')};
 
   @keyframes overlay-appear {

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -47,9 +47,7 @@ export default meta
 const ErsatzOverlay = styled.div`
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 8px 24px rgba(149, 157, 165, 0.2);
-  position: absolute;
-  min-width: 192px;
-  max-width: 640px;
+  overflow: hidden;
 `
 
 export function ActionsStory(): JSX.Element {


### PR DESCRIPTION
This partially reverts commit 681bbe6e. I talked through these changes at length with @smockle, but wanted to document some of the main points here.

The new `Dialog` component is intentionally allowing overflow (no `overflow: hidden`) because the main use case, `ConfirmationDialog`, has buttons that go right to the edge of the `Dialog`.  When those buttons are focused, the default browser `outline` falls _outside_ the `Dialog`.  If `overflow: hidden` is set, the outlines get chopped off.  The only way to fix this specific issue is by allowing overflow. See #1203 for more details.

| Overflow Hidden | Overflow Allowed |
|:---:|:---:|
| ![before](https://user-images.githubusercontent.com/3104489/116756437-15e18d00-a9da-11eb-8f21-8a6c3af32c29.gif) | ![after](https://user-images.githubusercontent.com/3104489/116756439-1712ba00-a9da-11eb-918e-95b37582148a.gif) |

In 681bbe6e, we decided to make a similar adjustment to the `Overlay` component.  The driving factor at the time was `outline` clipping, similar to what we saw in `Dialog`, but specifically when `ActionList.Item`s were focused within an `Overlay`.  Additionally, we wanted consistency between `Dialog` and `Overlay`. 

After some new use cases have come up, such as scroll bars in `SelectPanel`, it's becoming clear that the overflow content will often cause the bottom corners to lose the correct border-radius, like this:

![image](https://user-images.githubusercontent.com/3026298/119414593-b0b14c80-bca4-11eb-811b-85b6afd26cb9.png)

Rather than expecting `Overlay` consumers to round their corners to perfectly match the `Overlay` border radius, @smockle and I concluded it would be best to bring back `overflow: hidden` in the `Overlay`.  This gives us accurate border-radius, and ensures that `Overlay` contents aren't otherwise spilling out.  We discussed some upcoming use cases, such as `Tooltip`s in `Overlay`s, or nested `ActionMenu`s as counter scenarios where overflow might be desirable.  In all the cases we could think of, the _real_ solution is to have those new overlaying elements be created in a `Portal`, as the `Overlay` is now.  If portaled, those child elements will actually be outside the `Overlay` in the DOM, and won't be restricted in any way by the `overflow: hidden`.
