### PR TITLE
feat(SelectPanel): allow `filterValue` to be provided

### DIFF
--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -7,10 +7,12 @@ import Spinner from '../Spinner'
 import {useFocusZone} from '../hooks/useFocusZone'
 import {uniqueId} from '../utils/uniqueId'
 import {itemActiveDescendantClass} from '../ActionList/Item'
+import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
   placeholderText: string
+  filterValue?: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>
 }
@@ -18,17 +20,20 @@ export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, 
 export function FilteredActionList({
   loading = false,
   placeholderText,
+  filterValue: externalFilterValue,
   onFilterChange,
   items,
   textInputProps,
   ...listProps
 }: FilteredActionListProps): JSX.Element {
+  const [filterValue, setInternalFilterValue] = useProvidedStateOrCreate(externalFilterValue, undefined, '')
   const onInputChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = e.target.value
       onFilterChange(value, e)
+      setInternalFilterValue(value)
     },
-    [onFilterChange]
+    [onFilterChange, setInternalFilterValue]
   )
 
   const containerRef = useRef<HTMLInputElement>(null)
@@ -80,6 +85,7 @@ export function FilteredActionList({
         block
         width="auto"
         color="text.primary"
+        value={filterValue}
         onChange={onInputChange}
         onKeyPress={onInputKeyPress}
         placeholder={placeholderText}


### PR DESCRIPTION
The current implementation of `SelectPanel` and `FilteredActionList` maintains the filter input value _internally_ in the `FilteredActionList`.  This creates a few problems:

1. Filter value cannot be maintained across close/re-open of a `SelectPanel`.  I had to add [extra work-arounds](https://github.com/primer/components/pull/1224/files#diff-684f564a94f8ff9be2098b19e8c6451b63a606aaf8ab2bba93cb9e1ecbd0db43R70-R77) to specifically handle this case in the original implementation since the `input` would be re-created on every open.
2. The solution to problem 1 introduced a scenario where `onFilterChange` in `SelectPanel` needed to be called _without_ and `event`.  Ideally we wouldn't need this extra prop type, and we could just inherit  `onFilterChange` from `FilteredActionList` with type differences.
3. An _initial_ filter value cannot be provided.  This is an issue where typing a character to open the `SelectPanel` is a desired behavior.  This has been requested on an internal GitHub project.

The solution here is to use the `useProvidedStateOrCreate` hook in both `SelectPanel` and `FilteredActionList`.  This solves problems 1 and 2 with _no changes_ from the consumer.  State is now maintained across re-opens by the state within `SelectPanel`.  Problem 3 is solved by the consumer adding a `filterValue` prop to their `SelectPanel` declaration, which they will need to keep up-to-date on `onFilterChange` calls (which they are presumable doing already for item filtering purposes).  Overall, this provides much more flexibility to consumers, while making the types better and functionality more intuitive.

### Screenshots
![CleanShot 2021-05-24 at 21 14 11](https://user-images.githubusercontent.com/3026298/119439810-fcc9b480-bcd7-11eb-8c46-f9c5264c2245.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
