### PR TITLE
fix(ActionList): description font size and truncation

### DIFF
--- a/.changeset/sour-lamps-kick.md
+++ b/.changeset/sour-lamps-kick.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Truncate text within ActionList Items, and use correct font size for description

--- a/.changeset/sour-lamps-kick.md
+++ b/.changeset/sour-lamps-kick.md
@@ -2,4 +2,4 @@
 "@primer/components": patch
 ---
 
-Truncate text within ActionList Items, and use correct font size for description
+Correct font size and truncate for description within ActionList Items

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -2,7 +2,7 @@ import {CheckIcon, IconProps} from '@primer/octicons-react'
 import React, {useCallback} from 'react'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
-import Flex from '../Flex'
+import Truncate from '../Truncate'
 import {ItemInput} from './List'
 import styled from 'styled-components'
 import {StyledHeader} from './Header'
@@ -152,7 +152,9 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
 }
 
 const StyledItemContent = styled.div`
-  width: 100%;
+  display: flex;
+  overflow: hidden;
+  flex-grow: 1;
 `
 
 const StyledItem = styled.div<
@@ -215,6 +217,8 @@ const StyledItem = styled.div<
 
 const StyledTextContainer = styled.div<{descriptionVariant: ItemProps['descriptionVariant']}>`
   display: flex;
+  overflow: hidden;
+  flex-grow: 1;
   flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
 `
 
@@ -242,7 +246,7 @@ const LeadingVisualContainer = styled(ColoredVisualContainer)``
 
 const TrailingVisualContainer = styled(ColoredVisualContainer)`
   color: ${({variant, disabled}) => getItemVariant(variant, disabled).annotationColor}};
-  margin-left: auto;
+  margin-left: ${get('space.2')};
   margin-right: 0;
   div:nth-child(2) {
     margin-left: ${get('space.2')};
@@ -254,7 +258,10 @@ const TrailingVisualContainer = styled(ColoredVisualContainer)`
 
 const DescriptionContainer = styled.span<{descriptionVariant: ItemProps['descriptionVariant']}>`
   color: ${get('colors.text.secondary')};
+  font-size: ${get('fontSizes.0')};
   margin-left: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? get('space.2') : 0)};
+  overflow: hidden;
+  flex-grow: 1;
 `
 
 const MultiSelectInput = styled.input`
@@ -365,27 +372,33 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
         </LeadingVisualContainer>
       )}
       <StyledItemContent>
-        <Flex>
-          {children}
-          {(text || description) && (
-            <StyledTextContainer descriptionVariant={descriptionVariant}>
-              {text && <div>{text}</div>}
-              {description && (
-                <DescriptionContainer descriptionVariant={descriptionVariant}>{description}</DescriptionContainer>
-              )}
-            </StyledTextContainer>
-          )}
-          {(TrailingIcon || trailingText) && (
-            <TrailingVisualContainer variant={variant} disabled={disabled}>
-              {trailingText && <div>{trailingText}</div>}
-              {TrailingIcon && (
-                <div>
-                  <TrailingIcon />
-                </div>
-              )}
-            </TrailingVisualContainer>
-          )}
-        </Flex>
+        {children}
+        {(text || description) && (
+          <StyledTextContainer descriptionVariant={descriptionVariant}>
+            {text && <div>{text}</div>}
+            {description && (
+              <DescriptionContainer descriptionVariant={descriptionVariant}>
+                {descriptionVariant === 'block' ? (
+                  description
+                ) : (
+                  <Truncate title={description} inline={true} maxWidth="100%">
+                    {description}
+                  </Truncate>
+                )}
+              </DescriptionContainer>
+            )}
+          </StyledTextContainer>
+        )}
+        {(TrailingIcon || trailingText) && (
+          <TrailingVisualContainer variant={variant} disabled={disabled}>
+            {trailingText && <div>{trailingText}</div>}
+            {TrailingIcon && (
+              <div>
+                <TrailingIcon />
+              </div>
+            )}
+          </TrailingVisualContainer>
+        )}
       </StyledItemContent>
     </StyledItem>
   )

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -153,8 +153,9 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
 
 const StyledItemContent = styled.div`
   display: flex;
-  overflow: hidden;
+  min-width: 0;
   flex-grow: 1;
+  position: relative;
 `
 
 const StyledItem = styled.div<
@@ -190,7 +191,8 @@ const StyledItem = styled.div<
     ${StyledItemContent}::before {
       content: ' ';
       display: block;
-      position: relative;
+      position: absolute;
+      width: 100%;
       top: -7px;
       // NB: This 'get' won’t execute if it’s moved into the arrow function below.
       border: 0 solid ${get('colors.selectMenu.borderSecondary')};
@@ -217,7 +219,7 @@ const StyledItem = styled.div<
 
 const StyledTextContainer = styled.div<{descriptionVariant: ItemProps['descriptionVariant']}>`
   display: flex;
-  overflow: hidden;
+  min-width: 0;
   flex-grow: 1;
   flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
 `
@@ -260,7 +262,7 @@ const DescriptionContainer = styled.span<{descriptionVariant: ItemProps['descrip
   color: ${get('colors.text.secondary')};
   font-size: ${get('fontSizes.0')};
   margin-left: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? get('space.2') : 0)};
-  overflow: hidden;
+  min-width: 0;
   flex-grow: 1;
   flex-basis: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 0 : 'auto')};
 `

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -262,6 +262,7 @@ const DescriptionContainer = styled.span<{descriptionVariant: ItemProps['descrip
   margin-left: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? get('space.2') : 0)};
   overflow: hidden;
   flex-grow: 1;
+  flex-basis: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 0 : 'auto')};
 `
 
 const MultiSelectInput = styled.input`

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -222,6 +222,7 @@ const StyledTextContainer = styled.div<{descriptionVariant: ItemProps['descripti
   min-width: 0;
   flex-grow: 1;
   flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
+  align-items: baseline;
 `
 
 const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled?: boolean}>`
@@ -261,6 +262,9 @@ const TrailingVisualContainer = styled(ColoredVisualContainer)`
 const DescriptionContainer = styled.span<{descriptionVariant: ItemProps['descriptionVariant']}>`
   color: ${get('colors.text.secondary')};
   font-size: ${get('fontSizes.0')};
+  // TODO: When rem-based spacing on a 4px scale lands, replace
+  // hardcoded '16px' with '${get('lh-12')}'.
+  line-height: 16px;
   margin-left: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? get('space.2') : 0)};
   min-width: 0;
   flex-grow: 1;

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -376,11 +376,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
         {children}
         {(text || description) && (
           <StyledTextContainer descriptionVariant={descriptionVariant}>
-            {text && (
-              <Truncate title={text} inline={true} maxWidth="100%">
-                {text}
-              </Truncate>
-            )}
+            {text && <div>{text}</div>}
             {description && (
               <DescriptionContainer descriptionVariant={descriptionVariant}>
                 {descriptionVariant === 'block' ? (

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -375,7 +375,11 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
         {children}
         {(text || description) && (
           <StyledTextContainer descriptionVariant={descriptionVariant}>
-            {text && <div>{text}</div>}
+            {text && (
+              <Truncate title={text} inline={true} maxWidth="100%">
+                {text}
+              </Truncate>
+            )}
             {description && (
               <DescriptionContainer descriptionVariant={descriptionVariant}>
                 {descriptionVariant === 'block' ? (

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -335,7 +335,7 @@ export function SizeStressTestingStory(): JSX.Element {
           items={[
             {
               leadingVisual: ArrowRightIcon,
-              text: 'Block Description',
+              text: 'Block Description.  Long text should wrap',
               description: 'This description is long, but it is block so it wraps',
               descriptionVariant: 'block',
               trailingIcon: ArrowLeftIcon,
@@ -351,7 +351,7 @@ export function SizeStressTestingStory(): JSX.Element {
             },
             {
               leadingVisual: ArrowRightIcon,
-              text: 'Really long text without a description',
+              text: 'Really long text without a description should wrap',
               trailingIcon: ArrowLeftIcon,
               showDivider: true
             }

--- a/src/stories/ActionList.stories.tsx
+++ b/src/stories/ActionList.stories.tsx
@@ -44,10 +44,11 @@ const meta: Meta = {
 }
 export default meta
 
-const ErsatzOverlay = styled.div`
+const ErsatzOverlay = styled.div<{maxWidth?: string}>`
   border-radius: 12px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 8px 24px rgba(149, 157, 165, 0.2);
   overflow: hidden;
+  max-width: ${({maxWidth}) => maxWidth || 'none'};
 `
 
 export function ActionsStory(): JSX.Element {
@@ -324,3 +325,40 @@ export function CustomItemChildren(): JSX.Element {
   )
 }
 CustomItemChildren.storyName = 'Custom Item Children'
+
+export function SizeStressTestingStory(): JSX.Element {
+  return (
+    <>
+      <h1>Size Stress Testing</h1>
+      <ErsatzOverlay maxWidth="300px">
+        <ActionList
+          items={[
+            {
+              leadingVisual: ArrowRightIcon,
+              text: 'Block Description',
+              description: 'This description is long, but it is block so it wraps',
+              descriptionVariant: 'block',
+              trailingIcon: ArrowLeftIcon,
+
+              showDivider: true
+            },
+            {
+              leadingVisual: ArrowRightIcon,
+              text: 'Inline Description',
+              description: 'This description gets truncated because it is inline',
+              trailingIcon: ArrowLeftIcon,
+              showDivider: true
+            },
+            {
+              leadingVisual: ArrowRightIcon,
+              text: 'Really long text without a description',
+              trailingIcon: ArrowLeftIcon,
+              showDivider: true
+            }
+          ]}
+        />
+      </ErsatzOverlay>
+    </>
+  )
+}
+SizeStressTestingStory.storyName = 'Size Stress Testing'


### PR DESCRIPTION
Fixing a couple small issues with `ActionList.Item` styles:

* Description font size should be 12px instead of 14px
* Inline descriptions should be truncated with ellipsis, rather than wrapping.  I had to redo the flex styles a bit to make the main text area grow properly.  

Also added a new story for stress testing these styles

### Screenshots
![image](https://user-images.githubusercontent.com/3026298/119573403-0ea76800-bd69-11eb-9c43-9a5f81d45199.png)

### Merge checklist
- [ ] Added/updated tests
- [x] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
