### PR TITLE
RefAnchoredOverlay composes AnchoredOverlay

### DIFF
--- a/.changeset/weak-oranges-provide.md
+++ b/.changeset/weak-oranges-provide.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+RefAnchoredOverlay composes AnchoredOverlay.

--- a/src/AnchoredOverlay/RefAnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/RefAnchoredOverlay.tsx
@@ -1,0 +1,94 @@
+import React, {useCallback, useMemo} from 'react'
+import Overlay, {OverlayProps} from '../Overlay'
+import {useFocusTrap} from '../hooks/useFocusTrap'
+import {FocusZoneHookSettings, useFocusZone} from '../hooks/useFocusZone'
+import {useAnchoredPosition, useRenderForcingRef} from '../hooks'
+
+export interface RefAnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'width'> {
+  /**
+   * A ref to the anchor that the overlay will dock to
+   */
+  anchorRef: React.RefObject<HTMLElement>
+
+  /**
+   * Determines whether the overlay portion of the component should be shown or not
+   */
+  open: boolean
+
+  /**
+   * A callback which is called whenever the overlay is currently closed and an "open gesture" is detected.
+   */
+  onOpen?: (gesture: 'anchor-click' | 'anchor-key-press') => unknown
+
+  /**
+   * A callback which is called whenever the overlay is currently open and a "close gesture" is detected.
+   */
+  onClose?: (gesture: 'click-outside' | 'escape') => unknown
+
+  /**
+   * Props to be spread on the internal `Overlay` component.
+   */
+  overlayProps?: Partial<OverlayProps>
+
+  /**
+   * Settings to apply to the Focus Zone on the internal `Overlay` component.
+   */
+  focusZoneSettings?: Partial<FocusZoneHookSettings>
+}
+
+/**
+ * An `AnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor.
+ * The overlay can be opened and navigated using keyboard or mouse.
+ */
+export const RefAnchoredOverlay: React.FC<RefAnchoredOverlayProps> = ({
+  anchorRef,
+  children,
+  open,
+  onClose,
+  height,
+  width,
+  overlayProps,
+  focusZoneSettings
+}) => {
+  const [overlayRef, updateOverlayRef] = useRenderForcingRef<HTMLDivElement>()
+
+  const onClickOutside = useCallback(() => onClose?.('click-outside'), [onClose])
+  const onEscape = useCallback(() => onClose?.('escape'), [onClose])
+
+  const {position} = useAnchoredPosition(
+    {
+      anchorElementRef: anchorRef,
+      floatingElementRef: overlayRef
+    },
+    [overlayRef.current]
+  )
+  const overlayPosition = useMemo(() => {
+    return position && {top: `${position.top}px`, left: `${position.left}px`}
+  }, [position])
+
+  useFocusZone({
+    containerRef: overlayRef,
+    disabled: !open || !position,
+    ...focusZoneSettings
+  })
+  useFocusTrap({containerRef: overlayRef, disabled: !open || !position})
+
+  return open ? (
+    <Overlay
+      returnFocusRef={anchorRef}
+      onClickOutside={onClickOutside}
+      onEscape={onEscape}
+      ref={updateOverlayRef}
+      role="listbox"
+      visibility={position ? 'visible' : 'hidden'}
+      height={height}
+      width={width}
+      {...overlayPosition}
+      {...overlayProps}
+    >
+      {children}
+    </Overlay>
+  ) : null
+}
+
+RefAnchoredOverlay.displayName = 'AnchoredOverlay'

--- a/src/AnchoredOverlay/RefAnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/RefAnchoredOverlay.tsx
@@ -37,7 +37,7 @@ export interface RefAnchoredOverlayProps extends Pick<OverlayProps, 'height' | '
 }
 
 /**
- * An `AnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor.
+ * An `RefAnchoredOverlay` provides an anchor that will open a floating overlay positioned relative to the anchor ref.
  * The overlay can be opened and navigated using keyboard or mouse.
  */
 export const RefAnchoredOverlay: React.FC<RefAnchoredOverlayProps> = ({
@@ -91,4 +91,4 @@ export const RefAnchoredOverlay: React.FC<RefAnchoredOverlayProps> = ({
   ) : null
 }
 
-RefAnchoredOverlay.displayName = 'AnchoredOverlay'
+RefAnchoredOverlay.displayName = 'RefAnchoredOverlay'

--- a/src/stories/RefAnchoredOverlay.stories.tsx
+++ b/src/stories/RefAnchoredOverlay.stories.tsx
@@ -1,0 +1,44 @@
+import React, {useState, useRef} from 'react'
+import {Button, Text, ButtonDanger, Position, Flex, BaseStyles, ThemeProvider} from '..'
+import {Meta} from '@storybook/react'
+import {RefAnchoredOverlay} from '../AnchoredOverlay/RefAnchoredOverlay'
+
+export default {
+  title: 'Internal components/RefAnchoredOverlay',
+  component: RefAnchoredOverlay,
+  decorators: [
+    Story => {
+      return (
+        <ThemeProvider>
+          <BaseStyles>
+            <Story />
+          </BaseStyles>
+        </ThemeProvider>
+      )
+    }
+  ]
+} as Meta
+
+export const RefAnchoredOverlayStory = () => {
+  const [isOpen, setIsOpen] = useState(false)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+  const confirmButtonRef = useRef<HTMLButtonElement>(null)
+  const anchorRef = useRef<HTMLDivElement>(null)
+  const closeOverlay = () => setIsOpen(false)
+  return (
+    <Position position="absolute" top={0} left={0} bottom={0} right={0} ref={anchorRef}>
+      <Button ref={buttonRef} onClick={() => setIsOpen(!isOpen)}>
+        open overlay
+      </Button>
+      <RefAnchoredOverlay onClose={closeOverlay} anchorRef={buttonRef} open={isOpen} width="small">
+        <Flex flexDirection="column" p={2}>
+          <Text>Are you sure?</Text>
+          <ButtonDanger onClick={closeOverlay}>Cancel</ButtonDanger>
+          <Button onClick={closeOverlay} ref={confirmButtonRef}>
+            Confirm
+          </Button>
+        </Flex>
+      </RefAnchoredOverlay>
+    </Position>
+  )
+}


### PR DESCRIPTION
RefAnchoredOverlay is a composable piece to AnchoredOverlay that can be used independently in situations where the anchor is not a simple inline component. 