### PR TITLE
fix(focusTrap): prevent blur if trap container is not in DOM

### DIFF
--- a/.changeset/tall-pianos-agree.md
+++ b/.changeset/tall-pianos-agree.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+prevent focusTrap from causing a `blur` if trap container is not in DOM

--- a/src/__tests__/behaviors/focusTrap.tsx
+++ b/src/__tests__/behaviors/focusTrap.tsx
@@ -170,6 +170,35 @@ it('Should should release the trap when the signal is aborted', async () => {
   expect(document.activeElement).toEqual(durianButton)
 })
 
+it('Should should release the trap when the container is removed from the DOM', async () => {
+  const {container} = render(
+    <div>
+      <div id="trapContainer">
+        <button tabIndex={0}>Apple</button>
+      </div>
+      <button id="durian" tabIndex={0}>
+        Durian
+      </button>
+    </div>
+  )
+
+  const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const durianButton = container.querySelector<HTMLElement>('#durian')!
+  const firstButton = trapContainer.querySelector('button')!
+
+  focusTrap(trapContainer)
+
+  focus(durianButton)
+  expect(document.activeElement).toEqual(firstButton)
+
+  // empty trap and remove it from the DOM
+  trapContainer.removeChild(firstButton)
+  trapContainer.parentElement?.removeChild(trapContainer)
+
+  focus(durianButton)
+  expect(document.activeElement).toEqual(durianButton)
+})
+
 it('Should handle dynamic content', async () => {
   const {container} = render(
     <div>

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -71,7 +71,7 @@ export function focusTrap(
   // is not found, blur the recently-focused element so that focus doesn't leave the
   // trap zone.
   function ensureTrapZoneHasFocus(focusedElement: EventTarget | null) {
-    if (focusedElement instanceof HTMLElement) {
+    if (focusedElement instanceof HTMLElement && document.contains(container)) {
       if (container.contains(focusedElement)) {
         // If a child of the trap zone was focused, remember it
         lastFocusedChild = focusedElement


### PR DESCRIPTION
There are some `AnchoredOverlay` use cases where the consumer moves focus to another element upon closing the overlay.  Currently, it's common that they move focus after closing the overlay, but the `focusTrap` has not yet been disabled because of the execution order of the effects.  In these cases, the `focusTrap` `container` is not physically present in the DOM at the time of moving focus.  This solution has `focusTrap` ensure that it is still actually in the DOM before trying to trap focus. 

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] Tested in Edge


Take a look at the [What we look for in reviews](https://github.com/primer/components/blob/main/contributor-docs/CONTRIBUTING.md#what-we-look-for-in-reviews) section of the contributing guidelines for more information on how we review PRs.
