### PR TITLE
fix: Hide intra-'Item' dividers on ':hover' and ':focus'

### DIFF
--- a/.changeset/wet-toes-retire.md
+++ b/.changeset/wet-toes-retire.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Hide intra-'Item' dividers on ':hover' and ':focus'

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -198,13 +198,25 @@ const StyledItem = styled.div<
       border: 0 solid ${get('colors.selectMenu.borderSecondary')};
       border-top-width: ${({showDivider}) => (showDivider ? `1px` : '0')};
     }
+  }
 
-    // Override if current or previous item is active descendant
-    &.${itemActiveDescendantClass}, .${itemActiveDescendantClass} + & {
-      ${StyledItemContent}::before {
-        border-color: transparent;
-      }
-    }
+  // Item dividers should not be visible:
+  // - above Hovered
+  &:hover ${StyledItemContent}::before,
+  // - below Hovered
+  // '*' instead of '&' because '&' maps to separate class names depending on 'variant'
+  :hover + * ${StyledItemContent}::before,
+  // - above Focused
+  &:focus ${StyledItemContent}::before,
+  // - below Focused
+  // '*' instead of '&' because '&' maps to separate class names depending on 'variant'
+  :focus + * ${StyledItemContent}::before,
+  // - above Active Descendent
+  &.${itemActiveDescendantClass} ${StyledItemContent}::before,
+  // - below Active Descendent
+  .${itemActiveDescendantClass} + & ${StyledItemContent}::before {
+    // '!important' because all the ':not's above give higher specificity
+    border-color: transparent !important;
   }
 
   // Focused OR Active Descendant


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/180

### Screenshots

**`:hover`**
![Screen recording of disappearing dividers when 'Item's are hovered](https://user-images.githubusercontent.com/3104489/119884276-72af6500-befe-11eb-8d4b-debc01a113a2.gif)

**`:focus`**
![Screen recording of disappearing dividers when 'Item's are focused](https://user-images.githubusercontent.com/3104489/119884281-7511bf00-befe-11eb-9be9-07f193c5a6db.gif)

**All `ActionList` stories**
![Screen recording of disappearing dividers in every 'ActionList' story](https://user-images.githubusercontent.com/3104489/119884352-88bd2580-befe-11eb-80ad-4ae2bd64a010.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
