### PR TITLE
feat: Skip canary deploys for Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: npm run test
 
       - name: Create .npmrc
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
         run: |
           cat << EOF > "$HOME/.npmrc"
             //registry.npmjs.org/:_authToken=$NPM_TOKEN
@@ -35,7 +35,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_AUTH_TOKEN_SHARED }}
 
       - name: Publish canary version
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
         run: |
           echo "$( jq '.version = "0.0.0"' package.json )" > package.json
           echo -e "---\n'@primer/components': patch\n---\n\nFake entry to force publishing" > .changeset/force-snapshot-release.md
@@ -45,7 +45,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Output canary version number
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
         run: |
           name=$(jq -r .name package.json)
           version=$(jq -r .version package.json)


### PR DESCRIPTION
CI runs initiated by Dependabot don’t have access to secrets (details below), so attempts to publish canary packages were failing (example: https://github.com/primer/components/pull/1264/checks?check_run_id=2688372121). This PR skips steps related to publishing canary packages for Dependabot-initiated CI runs.

Details:
- [GitHub Actions: Workflows triggered by Dependabot PRs will run with read-only permissions](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)
- [Keeping your GitHub Actions and workflows secure: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)