### PR TITLE
chore: Skip bundle size checks for Dependabot PRs

### DIFF
--- a/.github/workflows/bundlesize.yml
+++ b/.github/workflows/bundlesize.yml
@@ -8,6 +8,7 @@ jobs:
   bundlesize:
     name: Check Bundle Size
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' && github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -18,6 +19,6 @@ jobs:
           path: 'new'
 
       - name: Check Bundle Size Change
-        uses: "BinaryMuse/action-bundlesize@master"
+        uses: 'BinaryMuse/action-bundlesize@master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Follow-up to https://github.com/primer/components/pull/1265

Part of https://github.com/github/primer/issues/181

Details in https://github.com/github/primer/discussions/187

This PR skips bundle size checks for Dependabot PRs (which are [currently failing](https://github.com/primer/components/actions/runs/883518388) because of read-only tokens).