### PR TITLE
fix: Don’t focus first 'Item' of 'DropdownMenu' and 'SelectMenu' on open

### DIFF
--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo, useRef} from 'react'
 import Overlay, {OverlayProps} from '../Overlay'
-import {useFocusTrap} from '../hooks/useFocusTrap'
+import {FocusTrapHookSettings, useFocusTrap} from '../hooks/useFocusTrap'
 import {FocusZoneHookSettings, useFocusZone} from '../hooks/useFocusZone'
 import {useAnchoredPosition, useRenderForcingRef} from '../hooks'
 import {uniqueId} from '../utils/uniqueId'
@@ -35,6 +35,11 @@ export interface AnchoredOverlayProps extends Pick<OverlayProps, 'height' | 'wid
   /**
    * Settings to apply to the Focus Zone on the internal `Overlay` component.
    */
+  focusTrapSettings?: Partial<FocusTrapHookSettings>
+
+  /**
+   * Settings to apply to the Focus Zone on the internal `Overlay` component.
+   */
   focusZoneSettings?: Partial<FocusZoneHookSettings>
 }
 
@@ -51,6 +56,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   height,
   width,
   overlayProps,
+  focusTrapSettings,
   focusZoneSettings
 }) => {
   const anchorRef = useRef<HTMLElement>(null)
@@ -96,7 +102,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
     disabled: !open || !position,
     ...focusZoneSettings
   })
-  useFocusTrap({containerRef: overlayRef, disabled: !open || !position})
+  useFocusTrap({containerRef: overlayRef, disabled: !open || !position, ...focusTrapSettings})
 
   return (
     <>

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -11,6 +11,7 @@ import {itemActiveDescendantClass} from '../ActionList/Item'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import styled from 'styled-components'
 import {get} from '../constants'
+import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
@@ -18,6 +19,7 @@ export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, 
   filterValue?: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>
+  inputRef?: React.RefObject<HTMLInputElement>
 }
 
 function scrollIntoViewingArea(
@@ -55,6 +57,7 @@ export function FilteredActionList({
   onFilterChange,
   items,
   textInputProps,
+  inputRef: providedInputRef,
   ...listProps
 }: FilteredActionListProps): JSX.Element {
   const [filterValue, setInternalFilterValue] = useProvidedStateOrCreate(externalFilterValue, undefined, '')
@@ -69,7 +72,7 @@ export function FilteredActionList({
 
   const containerRef = useRef<HTMLInputElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useMemo(uniqueId, [])
   const onInputKeyPress: KeyboardEventHandler = useCallback(

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -54,6 +54,9 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
     }
   }
   visibility: ${props => props.visibility || 'visible'};
+  :focus {
+    outline: none;
+  }
   ${COMMON};
   ${POSITION};
   ${sx};

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -127,6 +127,11 @@ export function SelectPanel({
     })
   }, [onClose, onSelectedChange, items, selected])
 
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const focusTrapSettings = {
+    initialFocusRef: inputRef
+  }
+
   return (
     <AnchoredOverlay
       renderAnchor={renderMenuAnchor}
@@ -134,6 +139,7 @@ export function SelectPanel({
       onOpen={onOpen}
       onClose={onClose}
       overlayProps={overlayProps}
+      focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >
       <Flex flexDirection="column" width="100%" height="100%">
@@ -145,6 +151,7 @@ export function SelectPanel({
           items={itemsToRender}
           selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
           textInputProps={textInputProps}
+          inputRef={inputRef}
         />
       </Flex>
     </AnchoredOverlay>

--- a/src/__tests__/behaviors/focusTrap.tsx
+++ b/src/__tests__/behaviors/focusTrap.tsx
@@ -22,7 +22,7 @@ beforeAll(() => {
   }
 })
 
-it('Should initially focus the first focusable element when activated', () => {
+it('Should initially focus the container when activated', () => {
   const {container} = render(
     <div>
       <button tabIndex={0}>Bad Apple</button>
@@ -35,9 +35,8 @@ it('Should initially focus the first focusable element when activated', () => {
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const firstButton = trapContainer.querySelector('button')!
   const controller = focusTrap(trapContainer)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   controller.abort()
 })
@@ -74,13 +73,12 @@ it('Should prevent focus from exiting the trap, returns focus to previously-focu
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const firstButton = trapContainer.querySelector('button')!
   const secondButton = trapContainer.querySelectorAll('button')[1]!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   focus(secondButton)
   expect(document.activeElement).toEqual(secondButton)
@@ -157,12 +155,11 @@ it('Should should release the trap when the signal is aborted', async () => {
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
-  const firstButton = trapContainer.querySelector('button')!
 
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   controller.abort()
 
@@ -189,7 +186,7 @@ it('Should should release the trap when the container is removed from the DOM', 
   focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   // empty trap and remove it from the DOM
   trapContainer.removeChild(firstButton)

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -68,8 +68,7 @@ export function focusTrap(
   // Ensure focus remains in the trap zone by checking that a given recently-focused
   // element is inside the trap zone. If it isn't, redirect focus to a suitable
   // element within the trap zone. If need to redirect focus and a suitable element
-  // is not found, blur the recently-focused element so that focus doesn't leave the
-  // trap zone.
+  // is not found, focus the container.
   function ensureTrapZoneHasFocus(focusedElement: EventTarget | null) {
     if (focusedElement instanceof HTMLElement && document.contains(container)) {
       if (container.contains(focusedElement)) {
@@ -80,16 +79,14 @@ export function focusTrap(
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
           lastFocusedChild.focus()
           return
+        } else if (initialFocus && container.contains(initialFocus)) {
+          initialFocus.focus()
+          return
         } else {
-          const toFocus = initialFocus && container.contains(initialFocus) ? initialFocus : getFocusableChild(container)
-          if (toFocus) {
-            toFocus.focus()
-            return
-          } else {
-            // no element focusable within trap, blur the external element instead
-            // eslint-disable-next-line github/no-blur
-            focusedElement.blur()
-          }
+          container.setAttribute('tabindex', '-1')
+          container.focus()
+          container.removeAttribute('tabindex')
+          return
         }
       }
     }

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -83,9 +83,14 @@ export function focusTrap(
           initialFocus.focus()
           return
         } else {
-          container.setAttribute('tabindex', '-1')
+          const containerNeedsTemporaryTabIndex = container.getAttribute('tabindex') === null
+          if (containerNeedsTemporaryTabIndex) {
+            container.setAttribute('tabindex', '-1')
+          }
           container.focus()
-          container.removeAttribute('tabindex')
+          if (containerNeedsTemporaryTabIndex) {
+            container.removeAttribute('tabindex')
+          }
           return
         }
       }

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -619,7 +619,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
               nextElementToFocus = settings.getNextFocusable(direction, document.activeElement ?? undefined, event)
             }
             if (!nextElementToFocus) {
-              const lastFocusedIndex = getCurrentFocusedIndex()
+              const lastFocusedIndex = currentFocusedElement === container ? -1 : getCurrentFocusedIndex()
               let nextFocusedIndex = lastFocusedIndex
               if (direction === 'previous') {
                 nextFocusedIndex -= 1

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -587,12 +587,10 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
       return 0
     }
 
-    if (currentFocusedElement === container) {
-      return -1
-    }
-
     const focusedIndex = focusableElements.indexOf(currentFocusedElement)
-    return focusedIndex === -1 ? 0 : focusedIndex
+    const fallbackIndex = currentFocusedElement === container ? -1 : 0
+
+    return focusedIndex !== -1 ? focusedIndex : fallbackIndex
   }
 
   // "keydown" is the event that triggers DOM focus change, so that is what we use here

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -587,6 +587,10 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
       return 0
     }
 
+    if (currentFocusedElement === container) {
+      return -1
+    }
+
     const focusedIndex = focusableElements.indexOf(currentFocusedElement)
     return focusedIndex === -1 ? 0 : focusedIndex
   }
@@ -619,7 +623,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
               nextElementToFocus = settings.getNextFocusable(direction, document.activeElement ?? undefined, event)
             }
             if (!nextElementToFocus) {
-              const lastFocusedIndex = currentFocusedElement === container ? -1 : getCurrentFocusedIndex()
+              const lastFocusedIndex = getCurrentFocusedIndex()
               let nextFocusedIndex = lastFocusedIndex
               if (direction === 'previous') {
                 nextFocusedIndex -= 1


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/188

### Screenshots

Note that the first `Item` is no longer focused for `DropdownMenu` or `ActionMenu` when the components open:

**`DropdownMenu`**
![DropdownMenu](https://user-images.githubusercontent.com/3104489/120046686-b5496e00-bfe0-11eb-9b7f-2e86097d9242.gif)

**`ActionMenu`**
![ActionMenu](https://user-images.githubusercontent.com/3104489/120046676-b1b5e700-bfe0-11eb-9cc0-bc90672ded76.gif)

Note that the filter is still focused when a `SelectPanel` opens:

**`SelectPanel`**
![SelectPanel](https://user-images.githubusercontent.com/3104489/120046687-b5e20480-bfe0-11eb-8207-670cfc32e131.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
