### PR TITLE
data-test-id can be used with OverlayProps

### DIFF
--- a/.changeset/cool-rocks-drive.md
+++ b/.changeset/cool-rocks-drive.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+data props can be used in overlayProps.

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -65,6 +65,7 @@ export type OverlayProps = {
   onClickOutside: (e: TouchOrMouseEvent) => void
   onEscape: (e: KeyboardEvent) => void
   visibility?: 'visible' | 'hidden'
+  'data-test-id'?: string
 } & Omit<ComponentProps<typeof StyledOverlay>, 'visibility' | keyof SystemPositionProps>
 
 /**

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -65,7 +65,7 @@ export type OverlayProps = {
   onClickOutside: (e: TouchOrMouseEvent) => void
   onEscape: (e: KeyboardEvent) => void
   visibility?: 'visible' | 'hidden'
-  'data-test-id'?: string
+  [additionalKey: string]: unknown
 } & Omit<ComponentProps<typeof StyledOverlay>, 'visibility' | keyof SystemPositionProps>
 
 /**

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -97,6 +97,7 @@ export function SimpleListStory(): JSX.Element {
           onAction={onAction}
           anchorContent="Menu"
           overlayProps={{
+            'data-test-id': 'some_test_id',
             onMouseDown: (e: React.MouseEvent) =>
               // eslint-disable-next-line no-console
               console.log('onMouseDown in the internal Overlay can be useful for controlling event interactions', e)


### PR DESCRIPTION
This is a simple fix to https://github.com/github/primer/issues/162 to enable `data-test-id` to be used in OverlayProps.

Curious if there might be some better solutions here, it seems like it would be better to have a way to add all `data-*` props to the OverlayProps.