### PR TITLE
implement Scroll flash into SelectPanel

### DIFF
--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -11,6 +11,7 @@ import {itemActiveDescendantClass} from '../ActionList/Item'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import styled from 'styled-components'
 import {get} from '../constants'
+import useScrollFlash from '../hooks/useScrollFlash'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
   loading?: boolean
@@ -120,6 +121,8 @@ export function FilteredActionList({
       scrollIntoViewingArea(activeDescendantRef.current, scrollContainerRef.current, undefined, 'auto')
     }
   }, [items])
+
+  useScrollFlash(scrollContainerRef)
 
   return (
     <Flex ref={containerRef} flexDirection="column" overflow="hidden">

--- a/src/hooks/useScrollFlash.ts
+++ b/src/hooks/useScrollFlash.ts
@@ -17,8 +17,5 @@ export default function useScrollFlash(scrollContainerRef: React.RefObject<HTMLE
 
     scrollContainer.scrollTop = altScroll
     scrollContainer.scrollTop = currentScroll
-
-    const flashScrollersEvent = new Event('flashScrollers')
-    scrollContainer.dispatchEvent(flashScrollersEvent)
   }, [scrollContainerRef])
 }

--- a/src/hooks/useScrollFlash.ts
+++ b/src/hooks/useScrollFlash.ts
@@ -1,0 +1,27 @@
+import React, {useEffect} from 'react'
+/**
+ * This hook will flash the scrollbars for a ref of a container that has scrollable overflow
+ * @param scrollContainerRef The ref of the scrollable content
+ */
+export default function useScrollFlash(scrollContainerRef: React.RefObject<HTMLElement>) {
+  // https://adxlv.computer/projects/flash-scrollers/
+  useEffect(() => {
+    const scrollContainer = scrollContainerRef.current
+    if (!scrollContainer) {
+      return
+    }
+    const currentScroll = scrollContainer.scrollTop
+    const maxScroll = scrollContainer.scrollHeight
+
+    const altScroll = (() => {
+      if (currentScroll < 1 || currentScroll < maxScroll) return currentScroll + 1
+      else return currentScroll - 1
+    })()
+
+    scrollContainer.scrollTop = altScroll
+    scrollContainer.scrollTop = currentScroll
+
+    const flashScrollersEvent = new Event('flashScrollers')
+    scrollContainer.dispatchEvent(flashScrollersEvent)
+  }, [scrollContainerRef])
+}

--- a/src/hooks/useScrollFlash.ts
+++ b/src/hooks/useScrollFlash.ts
@@ -13,10 +13,7 @@ export default function useScrollFlash(scrollContainerRef: React.RefObject<HTMLE
     const currentScroll = scrollContainer.scrollTop
     const maxScroll = scrollContainer.scrollHeight
 
-    const altScroll = currentScroll < Math.min(1, maxScroll) ? currentScroll + 1 : currentScroll - 1;
-      if (currentScroll < 1 || currentScroll < maxScroll) return currentScroll + 1
-      else return currentScroll - 1
-    })()
+    const altScroll = currentScroll < Math.min(1, maxScroll) ? currentScroll + 1 : currentScroll - 1
 
     scrollContainer.scrollTop = altScroll
     scrollContainer.scrollTop = currentScroll

--- a/src/hooks/useScrollFlash.ts
+++ b/src/hooks/useScrollFlash.ts
@@ -13,7 +13,7 @@ export default function useScrollFlash(scrollContainerRef: React.RefObject<HTMLE
     const currentScroll = scrollContainer.scrollTop
     const maxScroll = scrollContainer.scrollHeight
 
-    const altScroll = (() => {
+    const altScroll = currentScroll < Math.min(1, maxScroll) ? currentScroll + 1 : currentScroll - 1;
       if (currentScroll < 1 || currentScroll < maxScroll) return currentScroll + 1
       else return currentScroll - 1
     })()


### PR DESCRIPTION
Closes https://github.com/github/primer/issues/183

`useScrollFlash` takes in a ref and implements https://adxlv.computer/projects/flash-scrollers/

The issue implies that this should be a global solution for overlay components, but I think we will want to implement it in the specific use cases of Overlay being used - this is because the scrollable container itself is implemented in the specific use cases of `Overlay` rather than globally on overlay itself.

Looking at the issue, it seems the primary place where this was needed was SelectPanel, but we can easily put it elsewhere just by using the hook!

### Screenshots

![scroll-flash](https://user-images.githubusercontent.com/16739070/120516750-50519780-c395-11eb-80a5-330469900688.gif)


### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge

