### PR TITLE
feat: Add `height="initial"` to `Overlay`

### DIFF
--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -10,7 +10,7 @@ import {useCombinedRefs} from './hooks/useCombinedRefs'
 type StyledOverlayProps = {
   width?: keyof typeof widthMap
   height?: keyof typeof heightMap
-  maxHeight?: keyof typeof heightMap
+  maxHeight?: keyof Omit<typeof heightMap, 'auto' | 'initial'>
   visibility?: 'visible' | 'hidden'
 }
 

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -19,7 +19,8 @@ const heightMap = {
   medium: '320px',
   large: '432px',
   xlarge: '600px',
-  auto: 'auto'
+  auto: 'auto',
+  initial: 'auto' // Passing 'initial' initially applies 'auto'
 }
 
 const widthMap = {
@@ -68,7 +69,7 @@ export type OverlayProps = {
   onClickOutside: (e: TouchOrMouseEvent) => void
   onEscape: (e: KeyboardEvent) => void
   visibility?: 'visible' | 'hidden'
-  height?: keyof typeof heightMap | 'initial'
+  height?: keyof typeof heightMap
   [additionalKey: string]: unknown
 } & Omit<ComponentProps<typeof StyledOverlay>, 'height' | 'visibility' | keyof SystemPositionProps>
 
@@ -103,7 +104,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>(
     const overlayRef = useRef<HTMLDivElement>(null)
     const combinedRef = useCombinedRefs(overlayRef, forwardedRef)
 
-    const overlayProps = useOverlay({
+    useOverlay({
       overlayRef,
       returnFocusRef,
       onEscape,
@@ -112,18 +113,16 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>(
       initialFocusRef
     })
 
-    const initialHeight = useRef<string>('auto')
     useEffect(() => {
-      if (overlayRef.current?.clientHeight) {
-        initialHeight.current = `${overlayRef.current.clientHeight}px`
+      if (heightKey === 'initial' && combinedRef.current?.clientHeight) {
+        combinedRef.current.style.height = `${combinedRef.current.clientHeight}px`
       }
-    }, [overlayRef])
-    const height = heightKey === 'initial' ? initialHeight.current : heightMap[heightKey || 'auto']
+    }, [heightKey, combinedRef])
+    const height = heightMap[heightKey || 'auto']
 
     return (
       <Portal>
         <StyledOverlay
-          {...overlayProps}
           aria-modal="true"
           role={role}
           height={height}

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -9,7 +9,7 @@ import {useCombinedRefs} from './hooks/useCombinedRefs'
 
 type StyledOverlayProps = {
   width?: keyof typeof widthMap
-  height?: string
+  height?: keyof typeof heightMap
   visibility?: 'visible' | 'hidden'
 }
 
@@ -39,7 +39,7 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
   position: absolute;
   min-width: 192px;
   max-width: 640px;
-  height: ${props => props.height};
+  height: ${props => heightMap[props.height || 'auto']};
   width: ${props => widthMap[props.width || 'auto']};
   border-radius: 12px;
   overflow: hidden;
@@ -69,9 +69,8 @@ export type OverlayProps = {
   onClickOutside: (e: TouchOrMouseEvent) => void
   onEscape: (e: KeyboardEvent) => void
   visibility?: 'visible' | 'hidden'
-  height?: keyof typeof heightMap
   [additionalKey: string]: unknown
-} & Omit<ComponentProps<typeof StyledOverlay>, 'height' | 'visibility' | keyof SystemPositionProps>
+} & Omit<ComponentProps<typeof StyledOverlay>, 'visibility' | keyof SystemPositionProps>
 
 /**
  * An `Overlay` is a flexible floating surface, used to display transient content such as menus,
@@ -96,7 +95,7 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>(
       ignoreClickRefs,
       onEscape,
       visibility,
-      height: heightKey,
+      height,
       ...rest
     },
     forwardedRef
@@ -114,11 +113,10 @@ const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>(
     })
 
     useEffect(() => {
-      if (heightKey === 'initial' && combinedRef.current?.clientHeight) {
+      if (height === 'initial' && combinedRef.current?.clientHeight) {
         combinedRef.current.style.height = `${combinedRef.current.clientHeight}px`
       }
-    }, [heightKey, combinedRef])
-    const height = heightMap[heightKey || 'auto']
+    }, [height, combinedRef])
 
     return (
       <Portal>

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -10,6 +10,7 @@ import {useCombinedRefs} from './hooks/useCombinedRefs'
 type StyledOverlayProps = {
   width?: keyof typeof widthMap
   height?: keyof typeof heightMap
+  maxHeight?: keyof typeof heightMap
   visibility?: 'visible' | 'hidden'
 }
 
@@ -40,6 +41,7 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
   min-width: 192px;
   max-width: 640px;
   height: ${props => heightMap[props.height || 'auto']};
+  max-height: ${props => props.maxHeight && heightMap[props.maxHeight]};
   width: ${props => widthMap[props.width || 'auto']};
   border-radius: 12px;
   overflow: hidden;

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -85,6 +85,7 @@ export type OverlayProps = {
  * @param onEscape Required. Function to call when user presses `Escape`. Typically this function sets the `Overlay` visibility state to `false`.
  * @param width Sets the width of the `Overlay`, pick from our set list of widths, or pass `auto` to automatically set the width based on the content of the `Overlay`. `small` corresponds to `256px`, `medium` corresponds to `320px`, `large` corresponds to `480px`, `xlarge` corresponds to `640px`, `xxlarge` corresponds to `960px`.
  * @param height Sets the height of the `Overlay`, pick from our set list of heights, or pass `auto` to automatically set the height based on the content of the `Overlay`, or pass `initial` to set the height based on the initial content of the `Overlay` (i.e. ignoring content changes). `xsmall` corresponds to `192px`, `small` corresponds to `256px`, `medium` corresponds to `320px`, `large` corresponds to `432px`, `xlarge` corresponds to `600px`.
+ * @param maxHeight Sets the maximum height of the `Overlay`, pick from our set list of heights. `xsmall` corresponds to `192px`, `small` corresponds to `256px`, `medium` corresponds to `320px`, `large` corresponds to `432px`, `xlarge` corresponds to `600px`.
  * @param visibility Sets the visibility of the `Overlay`
  */
 const Overlay = React.forwardRef<HTMLDivElement, OverlayProps>(

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -131,7 +131,7 @@ export function SelectPanelHeightInitialWithOverflowingItemsStory(): JSX.Element
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
         showItemDividers={true}
-        overlayProps={{width: 'small', height: 'initial', sx: {maxHeight: '192px'}}}
+        overlayProps={{width: 'small', height: 'initial', maxHeight: 'xsmall'}}
       />
     </>
   )
@@ -163,7 +163,7 @@ export function SelectPanelHeightInitialWithUnderflowingItemsStory(): JSX.Elemen
         onSelectedChange={setSelected}
         onFilterChange={setFilter}
         showItemDividers={true}
-        overlayProps={{width: 'small', height: 'initial', sx: {maxHeight: '192px'}}}
+        overlayProps={{width: 'small', height: 'initial', maxHeight: 'xsmall'}}
       />
     </>
   )

--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -106,3 +106,66 @@ export function SingleSelectStory(): JSX.Element {
   )
 }
 SingleSelectStory.storyName = 'Single Select'
+
+export function SelectPanelHeightInitialWithOverflowingItemsStory(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = items.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <h1>Single Select Panel</h1>
+      <div>Please select a label that describe your issue:</div>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{width: 'small', height: 'initial', sx: {maxHeight: '192px'}}}
+      />
+    </>
+  )
+}
+SelectPanelHeightInitialWithOverflowingItemsStory.storyName = 'SelectPanel, Height: Initial, Overflowing Items'
+
+export function SelectPanelHeightInitialWithUnderflowingItemsStory(): JSX.Element {
+  const underflowingItems = [items[0], items[1]]
+  const [selected, setSelected] = React.useState<ItemInput | undefined>(underflowingItems[0])
+  const [filter, setFilter] = React.useState('')
+  const filteredItems = underflowingItems.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase()))
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <h1>Single Select Panel</h1>
+      <div>Please select a label that describe your issue:</div>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={open}
+        onOpenChange={setOpen}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{width: 'small', height: 'initial', sx: {maxHeight: '192px'}}}
+      />
+    </>
+  )
+}
+SelectPanelHeightInitialWithUnderflowingItemsStory.storyName = 'SelectPanel, Height: Initial, Underflowing Items'


### PR DESCRIPTION
Partial-fix for https://github.com/github/primer/issues/161. Specifically, this fixes the case where `SelectPanel` items are available initially (i.e. not asynchronously fetched).

This PR adds an `"initial"` value to `Overlay`’s `height` prop, which cause the component height to fit contents initially (like `"auto"`), then be fixed at that initial height, so that as contents change (e.g. by filtering), the container remains at the initial height (unlike, and preferred to, `"auto"`).

Sidebar: The asynchronously-fetch case is partially-supported: A component consumer can initially (before items have been retrieved) pass `height="auto"` then (once items are retrieved) pass `height="initial"`. Because `heightKey` is a dependency of the `useEffect`, the height-after-fetch can be set using this approach.

### Screen recordings
**Overflowing items**
The following recording demonstrates that an `Overlay` with `height="initial"` initially opens shorter than its contents (which are scrollable, because they do not fit within the `Overlay`’s `max-height`), and remains at this height as contents are filtered. This is functionally identical to `height="XSmall"` when items overflow.
![2021-06-10 17 16 22](https://user-images.githubusercontent.com/3104489/121599161-aa470280-ca10-11eb-87d1-9910d1b1245d.gif)

**Underflowing items**
The following recording demonstrates that an `Overlay` with `height="initial"` initially opens exactly as large as its contents (which are not scrollable, because they fit within the `Overlay`’s `max-height`), and remains at this height as contents are filtered. This is superior to both `height="XSmall"` (which, with this few items, would undesirably include empty space underneath them when the `Overlay` opens) and `height="auto"` (which would remove empty space after filtering, undesirably varying the `Overlay` height).
![2021-06-10 17 16 37](https://user-images.githubusercontent.com/3104489/121599168-ac10c600-ca10-11eb-92db-6fd1ef7e505b.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
