### PR TITLE
Revert "fix: Don’t focus first 'Item' of 'DropdownMenu' and 'SelectMenu' on open"

### DIFF
--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo} from 'react'
 import Overlay, {OverlayProps} from '../Overlay'
-import {FocusTrapHookSettings, useFocusTrap} from '../hooks/useFocusTrap'
+import {useFocusTrap} from '../hooks/useFocusTrap'
 import {FocusZoneHookSettings, useFocusZone} from '../hooks/useFocusZone'
 import {useAnchoredPosition, useProvidedRefOrCreate, useRenderForcingRef} from '../hooks'
 import {uniqueId} from '../utils/uniqueId'
@@ -56,11 +56,6 @@ interface AnchoredOverlayBaseProps extends Pick<OverlayProps, 'height' | 'width'
   /**
    * Settings to apply to the Focus Zone on the internal `Overlay` component.
    */
-  focusTrapSettings?: Partial<FocusTrapHookSettings>
-
-  /**
-   * Settings to apply to the Focus Zone on the internal `Overlay` component.
-   */
   focusZoneSettings?: Partial<FocusZoneHookSettings>
 }
 
@@ -81,7 +76,6 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   height,
   width,
   overlayProps,
-  focusTrapSettings,
   focusZoneSettings
 }) => {
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)
@@ -127,7 +121,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
     disabled: !open || !position,
     ...focusZoneSettings
   })
-  useFocusTrap({containerRef: overlayRef, disabled: !open || !position, ...focusTrapSettings})
+  useFocusTrap({containerRef: overlayRef, disabled: !open || !position})
 
   return (
     <>

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -11,7 +11,6 @@ import {itemActiveDescendantClass} from '../ActionList/Item'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import styled from 'styled-components'
 import {get} from '../constants'
-import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
 import useScrollFlash from '../hooks/useScrollFlash'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
@@ -20,7 +19,6 @@ export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, 
   filterValue?: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>
-  inputRef?: React.RefObject<HTMLInputElement>
 }
 
 function scrollIntoViewingArea(
@@ -58,7 +56,6 @@ export function FilteredActionList({
   onFilterChange,
   items,
   textInputProps,
-  inputRef: providedInputRef,
   ...listProps
 }: FilteredActionListProps): JSX.Element {
   const [filterValue, setInternalFilterValue] = useProvidedStateOrCreate(externalFilterValue, undefined, '')
@@ -73,7 +70,7 @@ export function FilteredActionList({
 
   const containerRef = useRef<HTMLInputElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
+  const inputRef = useRef<HTMLInputElement>(null)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useMemo(uniqueId, [])
   const onInputKeyPress: KeyboardEventHandler = useCallback(

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -54,9 +54,6 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
     }
   }
   visibility: ${props => props.visibility || 'visible'};
-  :focus {
-    outline: none;
-  }
   ${COMMON};
   ${POSITION};
   ${sx};

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -127,11 +127,6 @@ export function SelectPanel({
     })
   }, [onClose, onSelectedChange, items, selected])
 
-  const inputRef = React.useRef<HTMLInputElement>(null)
-  const focusTrapSettings = {
-    initialFocusRef: inputRef
-  }
-
   return (
     <AnchoredOverlay
       renderAnchor={renderMenuAnchor}
@@ -139,7 +134,6 @@ export function SelectPanel({
       onOpen={onOpen}
       onClose={onClose}
       overlayProps={overlayProps}
-      focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >
       <Flex flexDirection="column" width="100%" height="100%">
@@ -151,7 +145,6 @@ export function SelectPanel({
           items={itemsToRender}
           selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
           textInputProps={textInputProps}
-          inputRef={inputRef}
         />
       </Flex>
     </AnchoredOverlay>

--- a/src/__tests__/behaviors/focusTrap.tsx
+++ b/src/__tests__/behaviors/focusTrap.tsx
@@ -22,7 +22,7 @@ beforeAll(() => {
   }
 })
 
-it('Should initially focus the container when activated', () => {
+it('Should initially focus the first focusable element when activated', () => {
   const {container} = render(
     <div>
       <button tabIndex={0}>Bad Apple</button>
@@ -35,8 +35,9 @@ it('Should initially focus the container when activated', () => {
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const firstButton = trapContainer.querySelector('button')!
   const controller = focusTrap(trapContainer)
-  expect(document.activeElement).toEqual(trapContainer)
+  expect(document.activeElement).toEqual(firstButton)
 
   controller.abort()
 })
@@ -73,12 +74,13 @@ it('Should prevent focus from exiting the trap, returns focus to previously-focu
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
+  const firstButton = trapContainer.querySelector('button')!
   const secondButton = trapContainer.querySelectorAll('button')[1]!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
+  expect(document.activeElement).toEqual(firstButton)
 
   focus(secondButton)
   expect(document.activeElement).toEqual(secondButton)
@@ -155,11 +157,12 @@ it('Should should release the trap when the signal is aborted', async () => {
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
+  const firstButton = trapContainer.querySelector('button')!
 
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
+  expect(document.activeElement).toEqual(firstButton)
 
   controller.abort()
 
@@ -186,7 +189,7 @@ it('Should should release the trap when the container is removed from the DOM', 
   focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(trapContainer)
+  expect(document.activeElement).toEqual(firstButton)
 
   // empty trap and remove it from the DOM
   trapContainer.removeChild(firstButton)

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -68,7 +68,8 @@ export function focusTrap(
   // Ensure focus remains in the trap zone by checking that a given recently-focused
   // element is inside the trap zone. If it isn't, redirect focus to a suitable
   // element within the trap zone. If need to redirect focus and a suitable element
-  // is not found, focus the container.
+  // is not found, blur the recently-focused element so that focus doesn't leave the
+  // trap zone.
   function ensureTrapZoneHasFocus(focusedElement: EventTarget | null) {
     if (focusedElement instanceof HTMLElement && document.contains(container)) {
       if (container.contains(focusedElement)) {
@@ -79,19 +80,16 @@ export function focusTrap(
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
           lastFocusedChild.focus()
           return
-        } else if (initialFocus && container.contains(initialFocus)) {
-          initialFocus.focus()
-          return
         } else {
-          const containerNeedsTemporaryTabIndex = container.getAttribute('tabindex') === null
-          if (containerNeedsTemporaryTabIndex) {
-            container.setAttribute('tabindex', '-1')
+          const toFocus = initialFocus && container.contains(initialFocus) ? initialFocus : getFocusableChild(container)
+          if (toFocus) {
+            toFocus.focus()
+            return
+          } else {
+            // no element focusable within trap, blur the external element instead
+            // eslint-disable-next-line github/no-blur
+            focusedElement.blur()
           }
-          container.focus()
-          if (containerNeedsTemporaryTabIndex) {
-            container.removeAttribute('tabindex')
-          }
-          return
         }
       }
     }

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -588,9 +588,7 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     const focusedIndex = focusableElements.indexOf(currentFocusedElement)
-    const fallbackIndex = currentFocusedElement === container ? -1 : 0
-
-    return focusedIndex !== -1 ? focusedIndex : fallbackIndex
+    return focusedIndex === -1 ? 0 : focusedIndex
   }
 
   // "keydown" is the event that triggers DOM focus change, so that is what we use here


### PR DESCRIPTION
Reverts primer/components#1270

Keyboard navigation is working in Safari but not in Chrome in `main`, and @VanAnderson traced that behavior to PR #1270. Reverting until we can investigate further.