### PR TITLE
Restore "fix: Don’t focus first 'Item' of 'DropdownMenu' and 'SelectMenu' on open"

### DIFF
--- a/.changeset/good-grapes-collect.md
+++ b/.changeset/good-grapes-collect.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Restore "fix: Don’t focus first 'Item' of 'DropdownMenu' and 'SelectMenu' on open" by deferring the removal of a temporary `tabIndex` until focus moves within the container.

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback, useMemo} from 'react'
 import Overlay, {OverlayProps} from '../Overlay'
-import {useFocusTrap} from '../hooks/useFocusTrap'
+import {FocusTrapHookSettings, useFocusTrap} from '../hooks/useFocusTrap'
 import {FocusZoneHookSettings, useFocusZone} from '../hooks/useFocusZone'
 import {useAnchoredPosition, useProvidedRefOrCreate, useRenderForcingRef} from '../hooks'
 import {uniqueId} from '../utils/uniqueId'
@@ -56,6 +56,11 @@ interface AnchoredOverlayBaseProps extends Pick<OverlayProps, 'height' | 'width'
   /**
    * Settings to apply to the Focus Zone on the internal `Overlay` component.
    */
+  focusTrapSettings?: Partial<FocusTrapHookSettings>
+
+  /**
+   * Settings to apply to the Focus Zone on the internal `Overlay` component.
+   */
   focusZoneSettings?: Partial<FocusZoneHookSettings>
 }
 
@@ -76,6 +81,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   height,
   width,
   overlayProps,
+  focusTrapSettings,
   focusZoneSettings
 }) => {
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)
@@ -121,7 +127,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
     disabled: !open || !position,
     ...focusZoneSettings
   })
-  useFocusTrap({containerRef: overlayRef, disabled: !open || !position})
+  useFocusTrap({containerRef: overlayRef, disabled: !open || !position, ...focusTrapSettings})
 
   return (
     <>

--- a/src/FilteredActionList/FilteredActionList.tsx
+++ b/src/FilteredActionList/FilteredActionList.tsx
@@ -11,6 +11,7 @@ import {itemActiveDescendantClass} from '../ActionList/Item'
 import {useProvidedStateOrCreate} from '../hooks/useProvidedStateOrCreate'
 import styled from 'styled-components'
 import {get} from '../constants'
+import {useProvidedRefOrCreate} from '../hooks/useProvidedRefOrCreate'
 import useScrollFlash from '../hooks/useScrollFlash'
 
 export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, keyof ListPropsBase>>, ListPropsBase {
@@ -19,6 +20,7 @@ export interface FilteredActionListProps extends Partial<Omit<GroupedListProps, 
   filterValue?: string
   onFilterChange: (value: string, e: React.ChangeEvent<HTMLInputElement>) => void
   textInputProps?: Partial<Omit<TextInputProps, 'onChange'>>
+  inputRef?: React.RefObject<HTMLInputElement>
 }
 
 function scrollIntoViewingArea(
@@ -56,6 +58,7 @@ export function FilteredActionList({
   onFilterChange,
   items,
   textInputProps,
+  inputRef: providedInputRef,
   ...listProps
 }: FilteredActionListProps): JSX.Element {
   const [filterValue, setInternalFilterValue] = useProvidedStateOrCreate(externalFilterValue, undefined, '')
@@ -70,7 +73,7 @@ export function FilteredActionList({
 
   const containerRef = useRef<HTMLInputElement>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
+  const inputRef = useProvidedRefOrCreate<HTMLInputElement>(providedInputRef)
   const activeDescendantRef = useRef<HTMLElement>()
   const listId = useMemo(uniqueId, [])
   const onInputKeyPress: KeyboardEventHandler = useCallback(

--- a/src/Overlay.tsx
+++ b/src/Overlay.tsx
@@ -54,6 +54,9 @@ const StyledOverlay = styled.div<StyledOverlayProps & SystemCommonProps & System
     }
   }
   visibility: ${props => props.visibility || 'visible'};
+  :focus {
+    outline: none;
+  }
   ${COMMON};
   ${POSITION};
   ${sx};

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -127,6 +127,11 @@ export function SelectPanel({
     })
   }, [onClose, onSelectedChange, items, selected])
 
+  const inputRef = React.useRef<HTMLInputElement>(null)
+  const focusTrapSettings = {
+    initialFocusRef: inputRef
+  }
+
   return (
     <AnchoredOverlay
       renderAnchor={renderMenuAnchor}
@@ -134,6 +139,7 @@ export function SelectPanel({
       onOpen={onOpen}
       onClose={onClose}
       overlayProps={overlayProps}
+      focusTrapSettings={focusTrapSettings}
       focusZoneSettings={focusZoneSettings}
     >
       <Flex flexDirection="column" width="100%" height="100%">
@@ -145,6 +151,7 @@ export function SelectPanel({
           items={itemsToRender}
           selectionVariant={isMultiSelectVariant(selected) ? 'multiple' : 'single'}
           textInputProps={textInputProps}
+          inputRef={inputRef}
         />
       </Flex>
     </AnchoredOverlay>

--- a/src/__tests__/behaviors/focusTrap.tsx
+++ b/src/__tests__/behaviors/focusTrap.tsx
@@ -22,7 +22,7 @@ beforeAll(() => {
   }
 })
 
-it('Should initially focus the first focusable element when activated', () => {
+it('Should initially focus the container when activated', () => {
   const {container} = render(
     <div>
       <button tabIndex={0}>Bad Apple</button>
@@ -35,9 +35,8 @@ it('Should initially focus the first focusable element when activated', () => {
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const firstButton = trapContainer.querySelector('button')!
   const controller = focusTrap(trapContainer)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   controller.abort()
 })
@@ -74,13 +73,12 @@ it('Should prevent focus from exiting the trap, returns focus to previously-focu
   )
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
-  const firstButton = trapContainer.querySelector('button')!
   const secondButton = trapContainer.querySelectorAll('button')[1]!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   focus(secondButton)
   expect(document.activeElement).toEqual(secondButton)
@@ -157,12 +155,11 @@ it('Should should release the trap when the signal is aborted', async () => {
 
   const trapContainer = container.querySelector<HTMLElement>('#trapContainer')!
   const durianButton = container.querySelector<HTMLElement>('#durian')!
-  const firstButton = trapContainer.querySelector('button')!
 
   const controller = focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   controller.abort()
 
@@ -189,7 +186,7 @@ it('Should should release the trap when the container is removed from the DOM', 
   focusTrap(trapContainer)
 
   focus(durianButton)
-  expect(document.activeElement).toEqual(firstButton)
+  expect(document.activeElement).toEqual(trapContainer)
 
   // empty trap and remove it from the DOM
   trapContainer.removeChild(firstButton)

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -68,8 +68,7 @@ export function focusTrap(
   // Ensure focus remains in the trap zone by checking that a given recently-focused
   // element is inside the trap zone. If it isn't, redirect focus to a suitable
   // element within the trap zone. If need to redirect focus and a suitable element
-  // is not found, blur the recently-focused element so that focus doesn't leave the
-  // trap zone.
+  // is not found, focus the container.
   function ensureTrapZoneHasFocus(focusedElement: EventTarget | null) {
     if (focusedElement instanceof HTMLElement && document.contains(container)) {
       if (container.contains(focusedElement)) {
@@ -80,16 +79,19 @@ export function focusTrap(
         if (lastFocusedChild && isTabbable(lastFocusedChild) && container.contains(lastFocusedChild)) {
           lastFocusedChild.focus()
           return
+        } else if (initialFocus && container.contains(initialFocus)) {
+          initialFocus.focus()
+          return
         } else {
-          const toFocus = initialFocus && container.contains(initialFocus) ? initialFocus : getFocusableChild(container)
-          if (toFocus) {
-            toFocus.focus()
-            return
-          } else {
-            // no element focusable within trap, blur the external element instead
-            // eslint-disable-next-line github/no-blur
-            focusedElement.blur()
+          const containerNeedsTemporaryTabIndex = container.getAttribute('tabindex') === null
+          if (containerNeedsTemporaryTabIndex) {
+            container.setAttribute('tabindex', '-1')
           }
+          container.focus()
+          if (containerNeedsTemporaryTabIndex) {
+            container.removeAttribute('tabindex')
+          }
+          return
         }
       }
     }

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -94,24 +94,12 @@ export function focusTrap(
           container.focus()
           // If a temporary `tabIndex` was provided, remove it.
           if (containerNeedsTemporaryTabIndex) {
-            const blurController = new AbortController()
-            container.addEventListener(
-              'blur',
-              () => {
-                // Once focus has moved from the container to a child within the FocusTrap,
-                // the container can be made un-refocusable by removing `tabIndex`.
-                container.removeAttribute('tabindex')
-                // NB: If `tabIndex` was removed *before* `blur`, then certain browsers (e.g. Chrome)
-                // would consider `body` the `activeElement`, and as a result, keyboard navigation
-                // between children would break, since `body` is outside the `FocusTrap`.
-
-                // Stop listening, so `tabIndex` is only removed once.
-                blurController.abort()
-              },
-              {
-                signal: blurController.signal
-              }
-            )
+            // Once focus has moved from the container to a child within the FocusTrap,
+            // the container can be made un-refocusable by removing `tabIndex`.
+            container.addEventListener('blur', () => container.removeAttribute('tabindex'), {once: true})
+            // NB: If `tabIndex` was removed *before* `blur`, then certain browsers (e.g. Chrome)
+            // would consider `body` the `activeElement`, and as a result, keyboard navigation
+            // between children would break, since `body` is outside the `FocusTrap`.
           }
           return
         }

--- a/src/behaviors/focusTrap.ts
+++ b/src/behaviors/focusTrap.ts
@@ -83,13 +83,35 @@ export function focusTrap(
           initialFocus.focus()
           return
         } else {
+          // Ensure the container is focusable:
+          // - Either the container already has a `tabIndex`
+          // - Or provide a temporary `tabIndex`
           const containerNeedsTemporaryTabIndex = container.getAttribute('tabindex') === null
           if (containerNeedsTemporaryTabIndex) {
             container.setAttribute('tabindex', '-1')
           }
+          // Focus the container.
           container.focus()
+          // If a temporary `tabIndex` was provided, remove it.
           if (containerNeedsTemporaryTabIndex) {
-            container.removeAttribute('tabindex')
+            const blurController = new AbortController()
+            container.addEventListener(
+              'blur',
+              () => {
+                // Once focus has moved from the container to a child within the FocusTrap,
+                // the container can be made un-refocusable by removing `tabIndex`.
+                container.removeAttribute('tabindex')
+                // NB: If `tabIndex` was removed *before* `blur`, then certain browsers (e.g. Chrome)
+                // would consider `body` the `activeElement`, and as a result, keyboard navigation
+                // between children would break, since `body` is outside the `FocusTrap`.
+
+                // Stop listening, so `tabIndex` is only removed once.
+                blurController.abort()
+              },
+              {
+                signal: blurController.signal
+              }
+            )
           }
           return
         }

--- a/src/behaviors/focusZone.ts
+++ b/src/behaviors/focusZone.ts
@@ -588,7 +588,9 @@ export function focusZone(container: HTMLElement, settings?: FocusZoneSettings):
     }
 
     const focusedIndex = focusableElements.indexOf(currentFocusedElement)
-    return focusedIndex === -1 ? 0 : focusedIndex
+    const fallbackIndex = currentFocusedElement === container ? -1 : 0
+
+    return focusedIndex !== -1 ? focusedIndex : fallbackIndex
   }
 
   // "keydown" is the event that triggers DOM focus change, so that is what we use here


### PR DESCRIPTION
Reverts primer/components#1291, restoring primer/components#1270

When [these lines](https://github.com/primer/components/blob/9fe54d65863cdfe97df770321f77233324ca4e32/src/behaviors/focusTrap.ts#L91-L93) (from primer/components#1270) removed temporary `tabIndex` from the `container`, certain browsers (e.g. Chrome) (but not others, e.g. Safari) set `body` as the `activeElement`. Because `body` is outside `FocusTrap` (and `FocusZone`), keyboard navigation between the `container`’s children was no longer possible.

By deferring the removal of the temporary `tabIndex` until the `container` has already lost focus, we avoid focusing `body`, and so we avoid breaking keyboard navigation. I added code comments in this PR to explain this slightly-more-complicated codepath and the scenario it prevents.

ℹ️ [Reviewing this commit](https://github.com/primer/components/commit/b343d47c064ee304c0147411cc4b0888152993a9) may help clarify the difference between this PR’s approach and that in primer/components#1270: https://github.com/primer/components/commit/b343d47c064ee304c0147411cc4b0888152993a9

### Screen recordings

**Safari**
![safari](https://user-images.githubusercontent.com/3104489/121731753-59421780-cabf-11eb-98c8-872139571bcd.gif)

**Chrome**
![chrome](https://user-images.githubusercontent.com/3104489/121731764-5e06cb80-cabf-11eb-82f5-056557331a3d.gif)

### Checklist

- [x] Tested in Safari
- [x] Tested in Chrome 