### PR TITLE
docs: Add a story demoing height-after-fetch

### DIFF
--- a/src/stories/SelectPanel.stories.tsx
+++ b/src/stories/SelectPanel.stories.tsx
@@ -1,3 +1,4 @@
+import type {OverlayProps} from '../Overlay'
 import {Meta} from '@storybook/react'
 import React, {useState} from 'react'
 import {theme, ThemeProvider} from '..'
@@ -169,3 +170,49 @@ export function SelectPanelHeightInitialWithUnderflowingItemsStory(): JSX.Elemen
   )
 }
 SelectPanelHeightInitialWithUnderflowingItemsStory.storyName = 'SelectPanel, Height: Initial, Underflowing Items'
+
+export function SelectPanelHeightInitialWithUnderflowingItemsAfterFetch(): JSX.Element {
+  const [selected, setSelected] = React.useState<ItemInput | undefined>(items[0])
+  const [filter, setFilter] = React.useState('')
+  const [fetchedItems, setFetchedItems] = useState<typeof items>([])
+  const filteredItems = React.useMemo(
+    () => fetchedItems.filter(item => item.text.toLowerCase().startsWith(filter.toLowerCase())),
+    [fetchedItems, filter]
+  )
+  const [open, setOpen] = useState(false)
+  const [height, setHeight] = useState<OverlayProps['height']>('auto')
+
+  const onOpenChange = () => {
+    setOpen(!open)
+    setTimeout(() => {
+      setFetchedItems([items[0], items[1]])
+      setHeight('initial')
+    }, 1500)
+  }
+
+  return (
+    <>
+      <h1>Single Select Panel</h1>
+      <div>Please select a label that describe your issue:</div>
+      <SelectPanel
+        renderAnchor={({children, 'aria-labelledby': ariaLabelledBy, ...anchorProps}) => (
+          <DropdownButton aria-labelledby={` ${ariaLabelledBy}`} {...anchorProps}>
+            {children ?? 'Select Labels'}
+          </DropdownButton>
+        )}
+        placeholderText="Filter Labels"
+        open={open}
+        onOpenChange={onOpenChange}
+        loading={filteredItems.length === 0}
+        items={filteredItems}
+        selected={selected}
+        onSelectedChange={setSelected}
+        onFilterChange={setFilter}
+        showItemDividers={true}
+        overlayProps={{width: 'small', height, maxHeight: 'xsmall'}}
+      />
+    </>
+  )
+}
+SelectPanelHeightInitialWithUnderflowingItemsAfterFetch.storyName =
+  'SelectPanel, Height: Initial, Underflowing Items (After Fetch)'


### PR DESCRIPTION
Follow-up to https://github.com/primer/components/pull/1287. From that PR’s description:
> Sidebar: The asynchronously-fetch case is partially-supported [Ed: It is—in fact—fully-supported]: A component consumer can initially (before items have been retrieved) pass `height="auto"` then (once items are retrieved) pass `height="initial"`. Because `heightKey` is a dependency of the `useEffect`, the height-after-fetch can be set using this approach.

This PR adds a story demonstrating this pattern.

https://github.com/github/primer/issues/161 described two cases:
1. A `SelectPanel` whose `Item`s are known during the initial render
2. A `SelectPanel` whose `Item`s are asynchronously fetched

This story demonstrates that the `Overlay` component supports content-matched height in both cases (regardless of whether the content is initially available or fetched), so https://github.com/github/primer/issues/161 can considered addressed. Fixes https://github.com/github/primer/issues/161.

### Screen recording
![2021-06-14 15 29 06](https://user-images.githubusercontent.com/3104489/121948501-5183ac80-cd25-11eb-8166-43cf6d19dc4c.gif)

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
