### PR TITLE
Revert "chore(deps-dev): bump typescript from 4.2.2 to 4.3.2 (#1302)"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25164,9 +25164,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.2.tgz",
-      "integrity": "sha512-zZ4hShnmnoVnAHpVHWpTcxdv7dWP60S2FsydQLV8V5PbS3FifjWFFRiHSWpDJahly88PRyV5teTSLoq4eG7mKw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.2.tgz",
+      "integrity": "sha512-tbb+NVrLfnsJy3M59lsDgrzWIflR4d4TIUjz+heUnHZwdF7YsrMTKoRERiIvI2lvBG95dfpLxB21WZhys1bgaQ==",
       "dev": true
     },
     "typical": {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "rollup-plugin-visualizer": "5.5.0",
     "semver": "7.3.5",
     "styled-components": "4.4.1",
-    "typescript": "4.3.2"
+    "typescript": "4.2.2"
   },
   "peerDependencies": {
     "react": "^17.0.0",


### PR DESCRIPTION
This reverts commit 0b8dc48f

I mentioned this in #1292, but there is currently a bug with `react-docgen-typescript` (https://github.com/styleguidist/react-docgen-typescript/issues/356) if you update TypeScript beyond `4.2.2`.  This only bug only shows up when you run storybook, which is why CI passed in #1302.
