### PR TITLE
feat: When clicking an 'AnchoredOverlay' trigger, don’t close—then immediately reopen—the 'AnchoredOverlay'

### DIFF
--- a/.changeset/smart-hats-kiss.md
+++ b/.changeset/smart-hats-kiss.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Ensure clicking an `AnchoredOverlay`’s trigger allows it to close without immediately reopening.

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -46,7 +46,7 @@ interface AnchoredOverlayBaseProps extends Pick<OverlayProps, 'height' | 'width'
   /**
    * A callback which is called whenever the overlay is currently open and a "close gesture" is detected.
    */
-  onClose?: (gesture: 'click-outside' | 'escape') => unknown
+  onClose?: (gesture: 'anchor-click' | 'click-outside' | 'escape') => unknown
 
   /**
    * Props to be spread on the internal `Overlay` component.
@@ -110,7 +110,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
       if (!open) {
         onOpen?.('anchor-click')
       } else {
-        onClose?.('click-outside')
+        onClose?.('anchor-click')
       }
     },
     [open, onOpen, onClose]

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -104,11 +104,16 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   )
   const onAnchorClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      if (!event.defaultPrevented && event.button === 0 && !open) {
+      if (event.defaultPrevented || event.button !== 0) {
+        return
+      }
+      if (!open) {
         onOpen?.('anchor-click')
+      } else {
+        onClose?.('click-outside')
       }
     },
-    [open, onOpen]
+    [open, onOpen, onClose]
   )
 
   const {position} = useAnchoredPosition(
@@ -145,6 +150,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
         <Overlay
           returnFocusRef={anchorRef}
           onClickOutside={onClickOutside}
+          ignoreClickRefs={[anchorRef]}
           onEscape={onEscape}
           ref={updateOverlayRef}
           role="listbox"

--- a/src/SelectPanel/SelectPanel.tsx
+++ b/src/SelectPanel/SelectPanel.tsx
@@ -76,7 +76,7 @@ export function SelectPanel({
 
   const onOpen: AnchoredOverlayProps['onOpen'] = useCallback(gesture => onOpenChange(true, gesture), [onOpenChange])
   const onClose = useCallback(
-    (gesture: 'click-outside' | 'escape' | 'selection') => {
+    (gesture: Parameters<Exclude<AnchoredOverlayProps['onClose'], undefined>>[0] | 'selection') => {
       onOpenChange(false, gesture)
     },
     [onOpenChange]

--- a/src/stories/ActionMenu.stories.tsx
+++ b/src/stories/ActionMenu.stories.tsx
@@ -14,11 +14,12 @@ import {Meta} from '@storybook/react'
 import React, {useCallback, useState, useRef} from 'react'
 import styled from 'styled-components'
 import {ThemeProvider} from '..'
-import {ActionMenu} from '../ActionMenu'
+import {ActionMenu, ActionMenuProps} from '../ActionMenu'
 import Link, {LinkProps} from '../Link'
 import Button from '../Button'
 import {ActionList, ItemProps} from '../ActionList'
 import BaseStyles from '../BaseStyles'
+import {DropdownButton} from '../DropdownMenu'
 
 const meta: Meta = {
   title: 'Composite components/ActionMenu',
@@ -272,3 +273,50 @@ export function ActionMenuWithExternalAnchor(): JSX.Element {
     </>
   )
 }
+
+const DoubleClickableAnchor: Exclude<ActionMenuProps['renderAnchor'], null | undefined> = ({
+  onClick: callback,
+  ...rest
+}) => {
+  const onClick = useCallback(
+    (event: React.MouseEvent<HTMLButtonElement>) => {
+      if (event.detail === 2) {
+        event.preventDefault()
+      }
+      callback?.(event)
+    },
+    [callback]
+  )
+  return <DropdownButton onClick={onClick} {...rest} />
+}
+export function ActionMenuWithDoubleClickStory(): JSX.Element {
+  return (
+    <>
+      <h1>Actions</h1>
+      <ErsatzOverlay>
+        <ActionMenu
+          renderAnchor={DoubleClickableAnchor}
+          anchorContent={<ServerIcon />}
+          items={[
+            {
+              leadingVisual: ServerIcon,
+              text: 'Open current Codespace',
+              description:
+                "Your existing Codespace will be opened to its previous state, and you'll be asked to manually switch to new-branch.",
+              descriptionVariant: 'block',
+              trailingText: '⌘O'
+            },
+            {
+              leadingVisual: PlusCircleIcon,
+              text: 'Create new Codespace',
+              description: 'Create a brand new Codespace with a fresh image and checkout this branch.',
+              descriptionVariant: 'block',
+              trailingText: '⌘C'
+            }
+          ]}
+        />
+      </ErsatzOverlay>
+    </>
+  )
+}
+ActionMenuWithDoubleClickStory.storyName = 'ActionMenu with double-clickable anchor'


### PR DESCRIPTION
Fixes https://github.com/github/primer/issues/218

### Screen recordings
| Before | After |
|:---:|:---:|
| ![Screen recording demonstrating that clicking the trigger closes then undesirably reopens the menu](https://user-images.githubusercontent.com/3104489/122322840-1c798480-cef4-11eb-9dd2-16cc2a2d4464.gif) | ![Screen recording demonstrating that clicking the trigger either closes or opens the menu, as expected](https://user-images.githubusercontent.com/3104489/122322848-1daab180-cef4-11eb-8b7f-3f58a2b5f37f.gif) |

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
