### PR TITLE
fix: Correct `role`s and add missing attributes

### DIFF
--- a/.changeset/light-rats-enjoy.md
+++ b/.changeset/light-rats-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+fix: Correct `role`s and add missing attributes to improve `DropdownMenu`, `SelectMenu`, and `ActionMenu` accessibility.

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -151,9 +151,13 @@ const getItemVariant = (variant = 'default', disabled?: boolean) => {
   }
 }
 
-const StyledItemContent = styled.div`
+const StyledItemContent = styled.div<{
+  descriptionVariant: ItemProps['descriptionVariant']
+}>`
+  align-items: baseline;
   display: flex;
   min-width: 0;
+  flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
   flex-grow: 1;
   position: relative;
 `
@@ -229,16 +233,9 @@ const StyledItem = styled.div<
   ${sx}
 `
 
-export const TextContainer = styled.div<{
+export const TextContainer = styled.span<{
   dangerouslySetInnerHtml?: React.DOMAttributes<HTMLDivElement>['dangerouslySetInnerHTML']
-  descriptionVariant: ItemProps['descriptionVariant']
-}>`
-  display: flex;
-  min-width: 0;
-  flex-grow: 1;
-  flex-direction: ${({descriptionVariant}) => (descriptionVariant === 'inline' ? 'row' : 'column')};
-  align-items: baseline;
-`
+}>``
 
 const BaseVisualContainer = styled.div<{variant?: ItemProps['variant']; disabled?: boolean}>`
   // Match visual height to adjacent text line height.
@@ -310,7 +307,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     onKeyPress,
     children,
     onClick,
-    id,
+    id = uniqueId(),
     ...props
   } = itemProps
 
@@ -358,6 +355,8 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
       variant={variant}
       showDivider={showDivider}
       aria-selected={selected}
+      aria-labelledby={text ? `${id}-label` : undefined}
+      aria-describedby={text ? `${id}-description` : undefined}
       {...props}
       data-id={id}
       onKeyPress={keyPressHandler}
@@ -393,35 +392,31 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
           <LeadingVisual />
         </LeadingVisualContainer>
       )}
-      <StyledItemContent>
+      <StyledItemContent descriptionVariant={descriptionVariant}>
         {children}
-        {(text || description) && (
-          <TextContainer descriptionVariant={descriptionVariant}>
-            {text && <div>{text}</div>}
-            {description && (
-              <DescriptionContainer descriptionVariant={descriptionVariant}>
-                {descriptionVariant === 'block' ? (
-                  description
-                ) : (
-                  <Truncate title={description} inline={true} maxWidth="100%">
-                    {description}
-                  </Truncate>
-                )}
-              </DescriptionContainer>
+        {text ? <TextContainer id={`${id}-label`}>{text}</TextContainer> : null}
+        {description ? (
+          <DescriptionContainer id={`${id}-description`} descriptionVariant={descriptionVariant}>
+            {descriptionVariant === 'block' ? (
+              description
+            ) : (
+              <Truncate title={description} inline={true} maxWidth="100%">
+                {description}
+              </Truncate>
             )}
-          </TextContainer>
-        )}
-        {(TrailingIcon || trailingText) && (
-          <TrailingVisualContainer variant={variant} disabled={disabled}>
-            {trailingText && <div>{trailingText}</div>}
-            {TrailingIcon && (
-              <div>
-                <TrailingIcon />
-              </div>
-            )}
-          </TrailingVisualContainer>
-        )}
+          </DescriptionContainer>
+        ) : null}
       </StyledItemContent>
+      {(TrailingIcon || trailingText) && (
+        <TrailingVisualContainer variant={variant} disabled={disabled}>
+          {trailingText && <div>{trailingText}</div>}
+          {TrailingIcon && (
+            <div>
+              <TrailingIcon />
+            </div>
+          )}
+        </TrailingVisualContainer>
+      )}
     </StyledItem>
   )
 }

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -356,7 +356,7 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
       showDivider={showDivider}
       aria-selected={selected}
       aria-labelledby={text ? `${id}-label` : undefined}
-      aria-describedby={text ? `${id}-description` : undefined}
+      aria-describedby={description ? `${id}-description` : undefined}
       {...props}
       data-id={id}
       onKeyPress={keyPressHandler}

--- a/src/ActionList/Item.tsx
+++ b/src/ActionList/Item.tsx
@@ -1,5 +1,5 @@
 import {CheckIcon, IconProps} from '@primer/octicons-react'
-import React, {useCallback} from 'react'
+import React, {useCallback, useMemo} from 'react'
 import {get} from '../constants'
 import sx, {SxProp} from '../sx'
 import Truncate from '../Truncate'
@@ -307,9 +307,11 @@ export function Item(itemProps: Partial<ItemProps> & {item?: ItemInput}): JSX.El
     onKeyPress,
     children,
     onClick,
-    id = uniqueId(),
+    id: _id,
     ...props
   } = itemProps
+
+  const id = useMemo(() => _id ?? uniqueId(), [_id])
 
   const keyPressHandler = useCallback(
     event => {

--- a/src/ActionList/List.tsx
+++ b/src/ActionList/List.tsx
@@ -132,7 +132,7 @@ function useListVariant(variant: ListProps['variant'] = 'inset'): {
 /**
  * Lists `Item`s, either grouped or ungrouped, with a `Divider` between each `Group`.
  */
-export function List(props: ListProps): JSX.Element {
+export const List = React.forwardRef<HTMLDivElement, ListProps>((props, ref): JSX.Element => {
   // Get `sx` prop values for `List` children matching the given `List` style variation.
   const {firstGroupStyle, lastGroupStyle, headerStyle, itemStyle} = useListVariant(props.variant)
 
@@ -216,7 +216,7 @@ export function List(props: ListProps): JSX.Element {
   }
 
   return (
-    <StyledList {...props}>
+    <StyledList {...props} ref={ref}>
       {groups.map(({header, ...groupProps}, index) => {
         const hasFilledHeader = header?.variant === 'filled'
         const shouldShowDivider = index > 0 && !hasFilledHeader
@@ -242,4 +242,4 @@ export function List(props: ListProps): JSX.Element {
       })}
     </StyledList>
   )
-}
+})

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -92,7 +92,6 @@ const ActionMenuBase = ({
     }
     return <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
       return renderAnchor({
-        'aria-label': 'menu',
         children: anchorContent,
         ...props
       })
@@ -122,7 +121,7 @@ const ActionMenuBase = ({
       open={combinedOpenState}
       onOpen={onOpen}
       onClose={onClose}
-      overlayProps={overlayProps}
+      overlayProps={{...overlayProps, role: 'menu'}}
     >
       <List {...listProps} role="menu" items={itemsToRender} />
     </AnchoredOverlay>

--- a/src/ActionMenu.tsx
+++ b/src/ActionMenu.tsx
@@ -93,7 +93,8 @@ const ActionMenuBase = ({
     return <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
       return renderAnchor({
         children: anchorContent,
-        ...props
+        ...props,
+        'aria-haspopup': 'menu'
       })
     }
   }, [anchorContent, renderAnchor])

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -143,6 +143,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
           id: anchorId,
           'aria-labelledby': anchorId,
           'aria-haspopup': true,
+          'aria-expanded': open,
           'aria-controls': overlayId,
           tabIndex: 0,
           onClick: onAnchorClick,

--- a/src/AnchoredOverlay/AnchoredOverlay.tsx
+++ b/src/AnchoredOverlay/AnchoredOverlay.tsx
@@ -87,6 +87,7 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
   const anchorRef = useProvidedRefOrCreate(externalAnchorRef)
   const [overlayRef, updateOverlayRef] = useRenderForcingRef<HTMLDivElement>()
   const anchorId = useMemo(uniqueId, [])
+  const overlayId = useMemo(() => `${anchorId}-overlay`, [anchorId])
 
   const onClickOutside = useCallback(() => onClose?.('click-outside'), [onClose])
   const onEscape = useCallback(() => onClose?.('escape'), [onClose])
@@ -141,19 +142,22 @@ export const AnchoredOverlay: React.FC<AnchoredOverlayProps> = ({
           ref: anchorRef,
           id: anchorId,
           'aria-labelledby': anchorId,
-          'aria-haspopup': 'listbox',
+          'aria-haspopup': true,
+          'aria-controls': overlayId,
           tabIndex: 0,
           onClick: onAnchorClick,
           onKeyDown: onAnchorKeyDown
         })}
       {open ? (
         <Overlay
+          id={overlayId}
           returnFocusRef={anchorRef}
           onClickOutside={onClickOutside}
           ignoreClickRefs={[anchorRef]}
           onEscape={onEscape}
           ref={updateOverlayRef}
-          role="listbox"
+          role="dialog"
+          aria-labelledby={anchorId}
           visibility={position ? 'visible' : 'hidden'}
           height={height}
           width={width}

--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -7,7 +7,7 @@ export type DropdownButtonProps = ButtonProps
 
 export const DropdownButton = React.forwardRef<HTMLElement, React.PropsWithChildren<DropdownButtonProps>>(
   ({children, ...props}: React.PropsWithChildren<DropdownButtonProps>, ref): JSX.Element => (
-    <Button ref={ref} {...props}>
+    <Button ref={ref} type="button" {...props}>
       {children}
       <StyledOcticon icon={TriangleDownIcon} ml={1} />
     </Button>

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -57,7 +57,8 @@ export function DropdownMenu({
     <T extends React.HTMLAttributes<HTMLElement>>(props: T) => {
       return renderAnchor({
         ...props,
-        children: selectedItem?.text ?? placeholder
+        children: selectedItem?.text ?? placeholder,
+        'aria-haspopup': 'listbox'
       })
     },
     [placeholder, renderAnchor, selectedItem?.text]

--- a/src/DropdownMenu/DropdownMenu.tsx
+++ b/src/DropdownMenu/DropdownMenu.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState, useRef} from 'react'
 import {List, GroupedListProps, ListPropsBase, ItemInput} from '../ActionList/List'
 import {DropdownButton, DropdownButtonProps} from './DropdownButton'
 import {ItemProps} from '../ActionList/Item'
@@ -84,6 +84,8 @@ export function DropdownMenu({
     })
   }, [items, onChange, onClose, selectedItem])
 
+  const listRef = useRef<HTMLDivElement>(null)
+
   return (
     <AnchoredOverlay
       renderAnchor={renderMenuAnchor}
@@ -91,8 +93,9 @@ export function DropdownMenu({
       onOpen={onOpen}
       onClose={onClose}
       overlayProps={overlayProps}
+      focusTrapSettings={{initialFocusRef: listRef}}
     >
-      <List {...listProps} role="listbox" items={itemsToRender} />
+      <List {...listProps} ref={listRef} role="listbox" items={itemsToRender} />
     </AnchoredOverlay>
   )
 }


### PR DESCRIPTION
Partial fix for https://github.com/github/primer/issues/217

- `<button>` element (from `<DropdownButton>`) should have `type="button"`
- `<Overlay>` (from `<AnchoredOverlay>`) should have `role="dialog"` or `role="menu"`, not `role="listbox"`
- `<Item>`s should have separate labels and descriptions

### Screenshot

**No visual change for `<Item descriptionVariant={"inline"} />`**
| `main` branch | This PR |
|:---:|:---:|
| <img width="671" alt="main-inline" src="https://user-images.githubusercontent.com/3104489/122604425-f19e4600-d043-11eb-99f7-4a8f87e0a5cc.png"> | <img width="671" alt="PR-inline" src="https://user-images.githubusercontent.com/3104489/122604435-f3680980-d043-11eb-8de3-0d610e114ae2.png"> |

**No visual change for `<Item descriptionVariant={"block"} />`**
| `main` branch | This PR |
|:---:|:---:|
| <img width="671" alt="main-block" src="https://user-images.githubusercontent.com/3104489/122604441-f531cd00-d043-11eb-9621-ddc0297d8773.png"> | <img width="671" alt="PR-block" src="https://user-images.githubusercontent.com/3104489/122604445-f6fb9080-d043-11eb-8f9b-140c164cf7d7.png"> |

**Improved `label` for `menuitem` node**
| `main` branch | This PR |
|:---:|:---:|
| <img width="1216" alt="main-AT" src="https://user-images.githubusercontent.com/3104489/122604597-31fdc400-d044-11eb-94b6-1fce36f35284.png"> | <img width="1216" alt="PR-AT" src="https://user-images.githubusercontent.com/3104489/122604599-33c78780-d044-11eb-9269-2747ac3e044f.png"> |

### Merge checklist
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Tested in Chrome
- [ ] Tested in Firefox
- [x] Tested in Safari
- [ ] Tested in Edge
