### PR TITLE
fix: Type 'DropdownButton' as 'button'

### DIFF
--- a/src/DropdownMenu/DropdownButton.tsx
+++ b/src/DropdownMenu/DropdownButton.tsx
@@ -7,7 +7,7 @@ export type DropdownButtonProps = ButtonProps
 
 export const DropdownButton = React.forwardRef<HTMLElement, React.PropsWithChildren<DropdownButtonProps>>(
   ({children, ...props}: React.PropsWithChildren<DropdownButtonProps>, ref): JSX.Element => (
-    <Button ref={ref} {...props}>
+    <Button ref={ref} type="button" {...props}>
       {children}
       <StyledOcticon icon={TriangleDownIcon} ml={1} />
     </Button>

--- a/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
+++ b/src/__tests__/__snapshots__/DropdownMenu.tsx.snap
@@ -79,6 +79,7 @@ exports[`DropdownMenu renders consistently 1`] = `
   onClick={[Function]}
   onKeyDown={[Function]}
   tabIndex={0}
+  type="button"
 >
   <svg
     aria-hidden="true"

--- a/src/__tests__/__snapshots__/SelectPanel.tsx.snap
+++ b/src/__tests__/__snapshots__/SelectPanel.tsx.snap
@@ -91,6 +91,7 @@ exports[`SelectPanel renders consistently 1`] = `
     onClick={[Function]}
     onKeyDown={[Function]}
     tabIndex={0}
+    type="button"
   >
     Select Items
     <svg


### PR DESCRIPTION
Split from #1314

`<button>` elements in `<form>` contexts get `type="submit"` [by default](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type), but clicking a `<DropdownButton>` should never submit a `<form>`, so this PR passes `type="button"`, which indicates “client-side scripts listen to the element's events”.

This PR has no visual changes.