### PR TITLE
Improve treeshaking by setting package.json sideEffects

### DIFF
--- a/.changeset/beige-years-notice.md
+++ b/.changeset/beige-years-notice.md
@@ -1,0 +1,5 @@
+---
+'@primer/components': patch
+---
+
+Side effects are properly declared in package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@primer/components",
-  "version": "28.2.3",
+  "version": "28.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
+  "sideEffects": [],
   "scripts": {
     "start": "cd docs && npm run develop",
     "predist": "rm -rf dist & rm -rf lib & rm -rf lib-esm",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
   "sideEffects": [
-    "(lib|lib-esm)/BaseStyles.js",
     "(lib|lib-esm)/behaviors/focusZone.js",
     "(lib|lib-esm)/behaviors/focusTrap.js"
   ],

--- a/package.json
+++ b/package.json
@@ -6,12 +6,9 @@
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
   "sideEffects": [
-    "lib/BaseStyles.js",
-    "lib-esm/BaseStyles.js",
-    "lib/behaviors/focusZone.js",
-    "lib-esm/behaviors/focusZone.js",
-    "lib/behaviors/focusTrap.js",
-    "lib-esm/behaviors/focusTrap.js"
+    "(lib|lib-esm)/BaseStyles.js",
+    "(lib|lib-esm)/behaviors/focusZone.js",
+    "(lib|lib-esm)/behaviors/focusTrap.js"
   ],
   "scripts": {
     "start": "cd docs && npm run develop",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,14 @@
   "main": "lib/index.js",
   "module": "lib-esm/index.js",
   "typings": "lib/index.d.ts",
-  "sideEffects": [],
+  "sideEffects": [
+    "lib/BaseStyles.js",
+    "lib-esm/BaseStyles.js",
+    "lib/behaviors/focusZone.js",
+    "lib-esm/behaviors/focusZone.js",
+    "lib/behaviors/focusTrap.js",
+    "lib-esm/behaviors/focusTrap.js"
+  ],
   "scripts": {
     "start": "cd docs && npm run develop",
     "predist": "rm -rf dist & rm -rf lib & rm -rf lib-esm",


### PR DESCRIPTION
Adds a `sideEffects` declaration in package.json to ensure that bundlers can effectively treeshake unused code.

This is especially useful for treeshaking files that simply re-export other files, such as the index.ts entries. Without this change, everything exported in this way is included in the final minified build, since bundlers cannot determine whether it's safe to treeshake those re-exports

2 files seems to contain side effects, related to initializing a polyfill, in focusTrap and focusZone. I added in line comments to this pr denoting those areas

Closes #1331 

### Merge checklist
- [ ] Added/updated tests (N/A)
- [ ] Added/updated documentation (N/A)
- [x] Tested in Chrome
- [x] Tested in Firefox
- [x] Tested in Safari
- [x] Tested in Edge

I tested this by installing in my project, making these changes locally and then generating a tar from this project and consuming that in my project, verifying that everything seems to work as intended.  I don't consume every component though, so additional testing with a canary build would be best to ensure compatibility across the board

Analyzed outputs from my consuming project using `source-map-explorer`

Before:

<img width="1027" alt="Screen Shot 2021-07-17 at 10 27 32 AM" src="https://user-images.githubusercontent.com/8616962/126040180-ce209765-0747-462a-8a2e-636d3b0dee44.png">

After: 

<img width="984" alt="Screen Shot 2021-07-17 at 10 26 29 AM" src="https://user-images.githubusercontent.com/8616962/126040184-e8d4f3fb-3297-4543-b25e-7d1bf8914a5e.png">
