### PR TITLE
Fix navigation dropdowns

### DIFF
--- a/docs/src/@primer/gatsby-theme-doctocat/components/nav-dropdown.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/nav-dropdown.js
@@ -3,7 +3,7 @@ import {TriangleDownIcon} from '@primer/octicons-react'
 import React from 'react'
 import styled from 'styled-components'
 
-// Temporarily shadowing this component until Doctocat is updated to the
+// Temporarily shadowing this component until Doctocat uses the
 // latest version of the Details or ActionMenu component
 
 function NavDropdown({title, children}) {

--- a/docs/src/@primer/gatsby-theme-doctocat/components/nav-dropdown.js
+++ b/docs/src/@primer/gatsby-theme-doctocat/components/nav-dropdown.js
@@ -1,0 +1,48 @@
+import {Box, StyledOcticon, Details, useDetails, Text, themeGet} from '@primer/components'
+import {TriangleDownIcon} from '@primer/octicons-react'
+import React from 'react'
+import styled from 'styled-components'
+
+// Temporarily shadowing this component until Doctocat is updated to the
+// latest version of the Details or ActionMenu component
+
+function NavDropdown({title, children}) {
+  const {getDetailsProps} = useDetails({closeOnOutsideClick: true})
+  return (
+    <Details {...getDetailsProps()}>
+      <summary style={{cursor: 'pointer'}}>
+        <Text>{title}</Text>
+        <StyledOcticon icon={TriangleDownIcon} ml={1} />
+      </summary>
+      <Box position="absolute">
+        <Box
+          color="white"
+          bg="gray.8"
+          py={1}
+          mt={2}
+          boxShadow="medium"
+          borderWidth="1px"
+          borderStyle="solid"
+          borderColor="gray.7"
+          borderRadius={2}
+        >
+          {children}
+        </Box>
+      </Box>
+    </Details>
+  )
+}
+
+export const NavDropdownItem = styled.a`
+  display: block;
+  padding: ${themeGet('space.2')} ${themeGet('space.3')};
+  color: inherit;
+  text-decoration: none;
+  &:hover {
+    color: ${themeGet('colors.white')};
+    background-color: ${themeGet('colors.blue.5')};
+    text-decoration: none;
+  }
+`
+
+export default NavDropdown


### PR DESCRIPTION
Fixes the navigation dropdowns on https://primer.style/components

## Before

![CleanShot 2021-07-26 at 14 48 36](https://user-images.githubusercontent.com/4608155/127063590-00fdc99a-082b-4851-a5f5-0575f111c387.gif)

## After

![CleanShot 2021-07-26 at 14 49 13](https://user-images.githubusercontent.com/4608155/127063657-7790b53d-7cb5-4e36-8f2f-a04896d3785a.gif)


Closes https://github.com/primer/components/issues/1073
