### PR TITLE
Deploy with GitHub actions instead of Vercel integration

### DIFF
--- a/.github/workflows/deploy_preview.yml
+++ b/.github/workflows/deploy_preview.yml
@@ -1,0 +1,46 @@
+name: Deploy
+on:
+  push:
+    branches-ignore:
+      - 'main'
+      - 'dependabot/**'
+jobs:
+  deploy-preview:
+    if: ${{ github.repository == 'primer/components' }}
+    name: Preview
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: chrnorm/deployment-action@v1.2.0
+        name: Create GitHub deployment
+        id: deployment
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment: Preview
+
+      - name: Vercel Action
+        uses: amondnet/vercel-action@v20
+        id: vercel-action
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          vercel-token: ${{ secrets.VERCEL_TOKEN_SHARED }}
+          github-comment: false
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID_SHARED }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Update deployment status (success)
+        if: success()
+        uses: chrnorm/deployment-status@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          environment_url: ${{ steps.vercel-action.outputs.preview-url }}
+          state: 'success'
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
+
+      - name: Update deployment status (failure)
+        if: failure()
+        uses: chrnorm/deployment-status@v1.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          state: 'failure'
+          deployment_id: ${{ steps.deployment.outputs.deployment_id }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -1,13 +1,25 @@
 name: Deploy
 on:
   push:
-    branches-ignore:
+    branches:
       - 'main'
-      - 'dependabot/**'
 jobs:
-  deploy-preview:
-    if: ${{ github.repository == 'primer/components' }}
-    name: Preview
+  guard:
+    name: Guard
+    outputs:
+      # To avoid deploying documentation for unrelease changes, we check the number of changeset files.
+      # If it's 0, we deploy.
+      should_deploy: ${{ steps.changeset-count.outputs.change_count == 0 }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - id: changeset-count
+        run: echo "::set-output name=change_count::$(ls .changeset/*.md | grep -v README | wc -l | xargs)
+
+  deploy:
+    name: Production
+    needs: [guard]
+    if: ${{ needs.guard.should_deploy }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -17,14 +29,16 @@ jobs:
         id: deployment
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          environment: Preview
+          environment: Production
 
       - name: Deploy with Vercel
+        if: ${{ steps.changeset-count.outputs.CHANGE_COUNT == 0 }}
         uses: amondnet/vercel-action@v20
         id: vercel-action
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           vercel-token: ${{ secrets.VERCEL_TOKEN_SHARED }}
+          vercel-args: '--prod'
           github-comment: false
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID_SHARED }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -1,7 +1,8 @@
-name: size
+name: Size
 on: [pull_request]
 jobs:
   size:
+    name: Size
     runs-on: ubuntu-latest
     env:
       CI_JOB_NUMBER: 1


### PR DESCRIPTION
Copied from https://github.com/primer/css/pull/1303:

> This PR disables the `vercel-bot` auto deployment and uses this Vercel action instead https://github.com/marketplace/actions/vercel-action
>
> The reasoning behind this is more control on when we deploy. Here's the new logic:
>
> * **Preview deploys** Preview deploys deploy to preview Vercel URLs whenever a push happens on any branch except `main`.
> * **Production deploys** Production deploys deploy to primer.style/components whenever a push happens only on the `main` branch. The workflow also checks the changesets to see if this is a new version release or if there's a release being worked on. When there's currently a release being worked on and hasn't been published yet, the script doesn't deploy.