### PR TITLE
Replace octoface icon with spinner in SelectMenu component

### DIFF
--- a/.changeset/few-flowers-play.md
+++ b/.changeset/few-flowers-play.md
@@ -1,0 +1,5 @@
+---
+"@primer/components": patch
+---
+
+Replace octoface icon with spinner in SelectMenu component

--- a/src/SelectMenu/SelectMenuLoadingAnimation.tsx
+++ b/src/SelectMenu/SelectMenuLoadingAnimation.tsx
@@ -1,30 +1,13 @@
 import React from 'react'
-import styled, {keyframes} from 'styled-components'
-import StyledOcticon from '../StyledOcticon'
-import {OctofaceIcon} from '@primer/octicons-react'
-import {get, COMMON, SystemCommonProps} from '../constants'
+import styled from 'styled-components'
+import {COMMON, get, SystemCommonProps} from '../constants'
+import Spinner from '../Spinner'
 import {ComponentProps} from '../utils/types'
-
-const pulseKeyframes = keyframes`
-  0% {
-    opacity: 0.3;
-  }
-  10% {
-    opacity: 1;
-  }
-  100% {
-    opacity: 0.3;
-  }
-`
 
 const Animation = styled.div<SystemCommonProps>`
   padding: ${get('space.6')} ${get('space.4')};
   text-align: center;
   background-color: ${get('colors.bg.overlay')};
-  animation-name: ${pulseKeyframes};
-  animation-duration: 2s;
-  animation-timing-function: linear;
-  animation-iteration-count: infinite;
   ${COMMON}
 `
 
@@ -33,7 +16,7 @@ export type SelectMenuLoadingAnimationProps = ComponentProps<typeof Animation>
 const SelectMenuLoadingAnimation = (props: SelectMenuLoadingAnimationProps) => {
   return (
     <Animation {...props}>
-      <StyledOcticon size={32} icon={OctofaceIcon} />
+      <Spinner />
     </Animation>
   )
 }


### PR DESCRIPTION
We've deprecated the use of the `octoface` icon in favor of the [Spinner](https://primer.style/components/spinner) component.

| Before | After |
| --- | --- |
| <img width="317" alt="image" src="https://user-images.githubusercontent.com/4608155/127234642-6befddc8-a72f-4104-9cc2-4660bd5df3da.png"> | <img width="320" alt="image" src="https://user-images.githubusercontent.com/4608155/127234600-5f987456-0477-45a9-8000-98df84feb54d.png"> |