### PR TITLE
Change path prefix to `/react`

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -26,5 +26,5 @@ module.exports = {
       }
     }
   ],
-  pathPrefix: '/components'
+  pathPrefix: '/react'
 }

--- a/now.json
+++ b/now.json
@@ -3,11 +3,11 @@
   "version": 2,
   "alias": "primer-components.now.sh",
   "routes": [
-    {"src": "/components(/.*)?", "dest": "/docs$1"},
+    {"src": "/react(/.*)?", "dest": "/docs$1"},
     {
       "src": "/",
       "status": 301,
-      "headers": {"Location": "/components"}
+      "headers": {"Location": "/react"}
     }
   ],
   "builds": [

--- a/now.json
+++ b/now.json
@@ -1,7 +1,4 @@
 {
-  "name": "primer-components",
-  "version": 2,
-  "alias": "primer-components.now.sh",
   "routes": [
     {"src": "/react(/.*)?", "dest": "/docs$1"},
     {


### PR DESCRIPTION
This PR will enable us to redirect `primer.style/components` URLs to `primer.style/react`.

Part of https://github.com/github/primer/issues/241