### PR TITLE
Revert "Change path prefix to `/react`"

### DIFF
--- a/docs/gatsby-config.js
+++ b/docs/gatsby-config.js
@@ -26,5 +26,5 @@ module.exports = {
       }
     }
   ],
-  pathPrefix: '/react'
+  pathPrefix: '/components'
 }

--- a/now.json
+++ b/now.json
@@ -1,10 +1,13 @@
 {
+  "name": "primer-components",
+  "version": 2,
+  "alias": "primer-components.now.sh",
   "routes": [
-    {"src": "/react(/.*)?", "dest": "/docs$1"},
+    {"src": "/components(/.*)?", "dest": "/docs$1"},
     {
       "src": "/",
       "status": 301,
-      "headers": {"Location": "/react"}
+      "headers": {"Location": "/components"}
     }
   ],
   "builds": [


### PR DESCRIPTION
Reverts primer/components#1361

Ran into issues with Vercel deployments. Reverting this for now. Will investigate next week.